### PR TITLE
post.Upload isn't always true when files exist on a post

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/text/unicode/norm"
 	"io"
 	"log"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 )
@@ -384,7 +385,7 @@ func TransformPosts(slackExport *SlackExport, intermediate *Intermediate, attach
 					Message:  post.Text,
 					CreateAt: SlackConvertTimeStamp(post.TimeStamp),
 				}
-				if post.Upload && !skipAttachments {
+				if (post.File != nil || post.Files != nil) && !skipAttachments {
 					if post.File != nil {
 						addFileToPost(post.File, slackExport.Uploads, newPost, attachmentsDir)
 					} else if post.Files != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I was doing some testing with this routine and found that in my Slack backup, `post.Upload` was `false` even when files were attached. I'm not sure why that was the case, but I loosened the conditional as shown in this diff and everything started to work, so I think this is a small bug which this PR resolves.

This change was needed to get this PR to work properly: https://github.com/mattermost/awat/pull/1

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

No ticket