### PR TITLE
Added support for thread_broadcast subtype

### DIFF
--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -60,7 +60,7 @@ type SlackPost struct {
 }
 
 func (p *SlackPost) IsPlainMessage() bool {
-	return p.Type == "message" && (p.SubType == "" || p.SubType == "file_share")
+	return p.Type == "message" && (p.SubType == "" || p.SubType == "file_share" || p.SubType == "thread_broadcast")
 }
 
 func (p *SlackPost) IsFileComment() bool {


### PR DESCRIPTION
#### Summary

Adds support for Slacks `thread_broadcast` subtype. These are included as threaded messages.

#### Ticket Link

Fixes issue #14 

Signed-off-by: Paul Rothrock <paul@movetoiceland.com>