### PR TITLE
Migrate slack user Position to mattermost Title

### DIFF
--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -115,7 +115,7 @@ func GetImportLineFromUser(user *IntermediateUser, team string) *app.LineImportD
 			Nickname:  model.NewString(""),
 			FirstName: model.NewString(user.FirstName),
 			LastName:  model.NewString(user.LastName),
-			Position:  model.NewString(""),
+			Position:  model.NewString(user.Position),
 			Roles:     model.NewString(model.SystemUserRoleId),
 			Teams: &[]app.UserTeamImportData{
 				{

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -75,6 +75,7 @@ type IntermediateUser struct {
 	Username    string   `json:"username"`
 	FirstName   string   `json:"first_name"`
 	LastName    string   `json:"last_name"`
+	Position    string   `json:"position"`
 	Email       string   `json:"email"`
 	Password    string   `json:"password"`
 	Memberships []string `json:"memberships"`
@@ -119,6 +120,7 @@ func (t *Transformer) TransformUsers(users []SlackUser) {
 			Username:  user.Username,
 			FirstName: user.Profile.FirstName,
 			LastName:  user.Profile.LastName,
+			Position:  user.Profile.Title,
 			Email:     user.Profile.Email,
 			Password:  model.NewId(),
 		}

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -464,6 +464,7 @@ func TestTransformUsers(t *testing.T) {
 			Profile: SlackProfile{
 				FirstName: "firstname1",
 				LastName:  "lastname1",
+				Title:     "position1",
 				Email:     "email1@example.com",
 			},
 		},
@@ -473,6 +474,7 @@ func TestTransformUsers(t *testing.T) {
 			Profile: SlackProfile{
 				FirstName: "firstname2",
 				LastName:  "lastname2",
+				Title:     "position2",
 				Email:     "email2@example.com",
 			},
 		},
@@ -482,6 +484,7 @@ func TestTransformUsers(t *testing.T) {
 			Profile: SlackProfile{
 				FirstName: "firstname3",
 				LastName:  "lastname3",
+				Title:     "position3",
 				Email:     "email3@example.com",
 			},
 		},
@@ -495,6 +498,7 @@ func TestTransformUsers(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("username%d", i+1), slackTransformer.Intermediate.UsersById[id].Username)
 		assert.Equal(t, fmt.Sprintf("firstname%d", i+1), slackTransformer.Intermediate.UsersById[id].FirstName)
 		assert.Equal(t, fmt.Sprintf("lastname%d", i+1), slackTransformer.Intermediate.UsersById[id].LastName)
+		assert.Equal(t, fmt.Sprintf("position%d", i+1), slackTransformer.Intermediate.UsersById[id].Position)
 		assert.Equal(t, fmt.Sprintf("email%d@example.com", i+1), slackTransformer.Intermediate.UsersById[id].Email)
 	}
 }

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -31,6 +31,7 @@ type SlackProfile struct {
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
 	Email     string `json:"email"`
+	Title     string `json:"title"`
 }
 
 type SlackUser struct {


### PR DESCRIPTION
#### Summary

Restore user's `Position` from slack profile to mattermost `Title`
