### PR TITLE
Add simple precheck to ensure import files exist before trying to parse them

### DIFF
--- a/commands/check.go
+++ b/commands/check.go
@@ -65,6 +65,11 @@ func checkSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 	slackTransformer := slack.NewTransformer("test", logger)
 
+	valid := slackTransformer.Precheck(zipReader)
+	if !valid {
+		return nil
+	}
+
 	slackExport, err := slackTransformer.ParseSlackExportFile(zipReader, true)
 	if err != nil {
 		return err

--- a/services/slack/precheck.go
+++ b/services/slack/precheck.go
@@ -1,0 +1,48 @@
+package slack
+
+import (
+	"archive/zip"
+	"strings"
+)
+
+func (t *Transformer) checkForRequiredFile(zipReader *zip.Reader, fileName string) bool {
+	found := false
+	foundInSubdirectory := false
+
+	for _, file := range zipReader.File {
+		if file.Name == fileName {
+			found = true
+		} else if strings.HasSuffix(file.Name, "/"+fileName) {
+			foundInSubdirectory = true
+		}
+	}
+
+	if !found {
+		if foundInSubdirectory {
+			t.Logger.Errorf("Failed to find required file %s in the correct location, but might have found it in a subdirectory.", fileName)
+		} else {
+			t.Logger.Errorf("Failed to find required file %s in the correct location.", fileName)
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func (t *Transformer) Precheck(zipReader *zip.Reader) bool {
+	requiredFiles := []string{
+		"channels.json",
+		"integration_logs.json",
+	}
+
+	valid := true
+
+	for _, fileName := range requiredFiles {
+		fileExists := t.checkForRequiredFile(zipReader, fileName)
+
+		valid = valid && fileExists
+	}
+
+	return valid
+}


### PR DESCRIPTION
The current version of this likes to fail silently if the Slack export is malformed (like if files like `channels.json` are instead located in `my_slack_export/channels.json`).

We could check for more here, but I'm just going with the basic files listed [here](https://slack.com/help/articles/220556107-How-to-read-Slack-data-exports#export-file-contents) that are in every Slack export.
