### PR TITLE
Default the attachments dir to data to save one step in the migration

### DIFF
--- a/commands/transform.go
+++ b/commands/transform.go
@@ -71,11 +71,11 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// attachments dir
-	attachmentsRealDir := path.Join(attachmentsDir, attachmentsInternal)
+	attachmentsFullDir := path.Join(attachmentsDir, attachmentsInternal)
 
 	if !skipAttachments {
-		if fileInfo, err := os.Stat(attachmentsRealDir); os.IsNotExist(err) {
-			if createErr := os.MkdirAll(attachmentsRealDir, 0755); createErr != nil {
+		if fileInfo, err := os.Stat(attachmentsFullDir); os.IsNotExist(err) {
+			if createErr := os.MkdirAll(attachmentsFullDir, 0755); createErr != nil {
 				return createErr
 			}
 		} else if err != nil {

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -4,12 +4,15 @@ import (
 	"archive/zip"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mmetl/services/slack"
 )
+
+const attachmentsInternal = "bulk-export-attachments"
 
 var TransformCmd = &cobra.Command{
 	Use:   "transform",
@@ -35,7 +38,7 @@ func init() {
 		panic(err)
 	}
 	TransformSlackCmd.Flags().StringP("output", "o", "bulk-export.jsonl", "the output path")
-	TransformSlackCmd.Flags().StringP("attachments-dir", "d", "bulk-export-attachments", "the path for the attachments directory")
+	TransformSlackCmd.Flags().StringP("attachments-dir", "d", "data", "the path for the attachments directory")
 	TransformSlackCmd.Flags().BoolP("skip-convert-posts", "c", false, "Skips converting mentions and post markup. Only for testing purposes")
 	TransformSlackCmd.Flags().BoolP("skip-attachments", "a", false, "Skips copying the attachments from the import file")
 	TransformSlackCmd.Flags().BoolP("discard-invalid-props", "p", false, "Skips converting posts with invalid props instead discarding the props themselves")
@@ -68,9 +71,11 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// attachments dir
+	attachmentsRealDir := filepath.Join(attachmentsDir, attachmentsInternal)
+
 	if !skipAttachments {
-		if fileInfo, err := os.Stat(attachmentsDir); os.IsNotExist(err) {
-			if createErr := os.Mkdir(attachmentsDir, 0755); createErr != nil {
+		if fileInfo, err := os.Stat(attachmentsRealDir); os.IsNotExist(err) {
+			if createErr := os.MkdirAll(attachmentsRealDir, 0755); createErr != nil {
 				return createErr
 			}
 		} else if err != nil {

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -71,7 +71,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// attachments dir
-	attachmentsRealDir := filepath.Join(attachmentsDir, attachmentsInternal)
+	attachmentsRealDir := path.Join(attachmentsDir, attachmentsInternal)
 
 	if !skipAttachments {
 		if fileInfo, err := os.Stat(attachmentsRealDir); os.IsNotExist(err) {

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -322,7 +322,7 @@ func buildChannelsByOriginalNameMap(intermediate *Intermediate) map[string]*Inte
 }
 
 func getNormalisedFilePath(file *SlackFile, attachmentsDir string) string {
-	filePath := filepath.Join(attachmentsDir, fmt.Sprintf("%s_%s", file.Id, file.Name))
+	filePath := path.Join(attachmentsDir, fmt.Sprintf("%s_%s", file.Id, file.Name))
 	return string(norm.NFC.Bytes([]byte(filePath)))
 }
 
@@ -339,7 +339,7 @@ func addFileToPost(file *SlackFile, uploads map[string]*zip.File, post *Intermed
 	defer zipFileReader.Close()
 
 	destFilePath := getNormalisedFilePath(file, attachmentsInternal)
-	destFile, err := os.Create(filepath.Join(attachmentsDir, destFilePath))
+	destFile, err := os.Create(path.Join(attachmentsDir, destFilePath))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create file %s in the attachments directory", file.Id)
 	}

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -16,6 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/text/unicode/norm"
 )
+
+const attachmentsInternal = "bulk-export-attachments"
 
 type IntermediateChannel struct {
 	Id               string            `json:"id"`
@@ -320,7 +322,7 @@ func buildChannelsByOriginalNameMap(intermediate *Intermediate) map[string]*Inte
 }
 
 func getNormalisedFilePath(file *SlackFile, attachmentsDir string) string {
-	filePath := path.Join(attachmentsDir, fmt.Sprintf("%s_%s", file.Id, file.Name))
+	filePath := filepath.Join(attachmentsDir, fmt.Sprintf("%s_%s", file.Id, file.Name))
 	return string(norm.NFC.Bytes([]byte(filePath)))
 }
 
@@ -336,8 +338,8 @@ func addFileToPost(file *SlackFile, uploads map[string]*zip.File, post *Intermed
 	}
 	defer zipFileReader.Close()
 
-	destFilePath := getNormalisedFilePath(file, attachmentsDir)
-	destFile, err := os.Create(destFilePath)
+	destFilePath := getNormalisedFilePath(file, attachmentsInternal)
+	destFile, err := os.Create(filepath.Join(attachmentsDir, destFilePath))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create file %s in the attachments directory", file.Id)
 	}


### PR DESCRIPTION
#### Summary
This PR changes the default output directory for attachments to `data/` and changes the behavior to generate import paths that match the files _in_ the `data/` folder (excluding the `data/` prefix). With this change `mmetl` matches the expected format of the Mattermost import archive and simplifies the creation of a suitable zip file.
