### PR TITLE
Add download functionality to mmetl

### DIFF
--- a/commands/check.go
+++ b/commands/check.go
@@ -75,7 +75,7 @@ func checkSlackCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = slackTransformer.Transform(slackExport, "", true, true)
+	err = slackTransformer.Transform(slackExport, "", true, true, false)
 	if err != nil {
 		return err
 	}

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -41,6 +41,7 @@ func init() {
 	TransformSlackCmd.Flags().StringP("attachments-dir", "d", "data", "the path for the attachments directory")
 	TransformSlackCmd.Flags().BoolP("skip-convert-posts", "c", false, "Skips converting mentions and post markup. Only for testing purposes")
 	TransformSlackCmd.Flags().BoolP("skip-attachments", "a", false, "Skips copying the attachments from the import file")
+	TransformSlackCmd.Flags().BoolP("allow-download", "l", false, "Allows downloading the attachments for the import file")
 	TransformSlackCmd.Flags().BoolP("discard-invalid-props", "p", false, "Skips converting posts with invalid props instead discarding the props themselves")
 	TransformSlackCmd.Flags().Bool("debug", true, "Whether to show debug logs or not")
 
@@ -60,6 +61,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	attachmentsDir, _ := cmd.Flags().GetString("attachments-dir")
 	skipConvertPosts, _ := cmd.Flags().GetBool("skip-convert-posts")
 	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
+	allowDownload, _ := cmd.Flags().GetBool("allow-download")
 	discardInvalidProps, _ := cmd.Flags().GetBool("discard-invalid-props")
 	debug, _ := cmd.Flags().GetBool("debug")
 
@@ -113,7 +115,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = slackTransformer.Transform(slackExport, attachmentsDir, skipAttachments, discardInvalidProps)
+	err = slackTransformer.Transform(slackExport, attachmentsDir, skipAttachments, discardInvalidProps, allowDownload)
 	if err != nil {
 		return err
 	}

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -41,8 +41,10 @@ type SlackUser struct {
 }
 
 type SlackFile struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	DownloadURL string `json:"url_private_download"`
 }
 
 type SlackPost struct {


### PR DESCRIPTION
#### Summary
Happy open source Friday. This PR adds functionality for `mmetl` to download slack attachments while converting. It also restricts the file names a bit more strictly to prevent generating invalid paths.

* The downloader will check if an existing file matches the expected size and only download it when it's missing or the wrong size.
* The file name normaizer now checks for common substitutions (`ß` to `ss`), tries to convert accented characters to their "ASCII form", and will remove or replace all remaining characters.

The download functionality is disabled by default but can be enabled with the `-l` flag.
```
mmetl import slack -l -f file.zip -t team
```