### PR TITLE
Use HTTPS to retrieve tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO_PACKAGES=$(shell go list ./...)
 GO ?= $(shell command -v go 2> /dev/null)
 BUILD_HASH ?= $(shell git rev-parse HEAD)
-BUILD_VERSION ?= $(shell git ls-remote --tags --refs git://github.com/mattermost/mmetl | tail -n1 | sed 's/.*\///')
+BUILD_VERSION ?= $(shell git ls-remote --tags --refs https://github.com/mattermost/mmetl.git | tail -n1 | sed 's/.*\///')
 
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.BuildHash=$(BUILD_HASH)"
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.Version=$(BUILD_VERSION)"


### PR DESCRIPTION
#### Summary
The `git://` protocol is no longer supported by Github, so the request for tags failed. This PR replaces it with a request using HTTPS.
Thanks to @vmakarenko for the suggestion.

#### Ticket Link
Fixes https://github.com/mattermost/mmetl/issues/24