### PR TITLE
Support deactivating users - Map slack `deleted:bool` to MM `delete_at:int64`

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -81,6 +81,7 @@ type IntermediateUser struct {
 	Email       string   `json:"email"`
 	Password    string   `json:"password"`
 	Memberships []string `json:"memberships"`
+	DeleteAt    int64    `json:"delete_at"`
 }
 
 func (u *IntermediateUser) Sanitise(logger log.FieldLogger) {
@@ -117,6 +118,11 @@ func (t *Transformer) TransformUsers(users []SlackUser) {
 
 	resultUsers := map[string]*IntermediateUser{}
 	for _, user := range users {
+		var deleteAt int64 = 0
+		if user.Deleted {
+			deleteAt = model.GetMillis()
+		}
+
 		newUser := &IntermediateUser{
 			Id:        user.Id,
 			Username:  user.Username,
@@ -125,6 +131,7 @@ func (t *Transformer) TransformUsers(users []SlackUser) {
 			Position:  user.Profile.Title,
 			Email:     user.Profile.Email,
 			Password:  model.NewId(),
+			DeleteAt:  deleteAt,
 		}
 
 		if user.IsBot {

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -500,7 +500,73 @@ func TestTransformUsers(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("lastname%d", i+1), slackTransformer.Intermediate.UsersById[id].LastName)
 		assert.Equal(t, fmt.Sprintf("position%d", i+1), slackTransformer.Intermediate.UsersById[id].Position)
 		assert.Equal(t, fmt.Sprintf("email%d@example.com", i+1), slackTransformer.Intermediate.UsersById[id].Email)
+		assert.Zero(t, slackTransformer.Intermediate.UsersById[id].DeleteAt)
 	}
+}
+
+func TestDeleteAt(t *testing.T) {
+	id1 := "id1"
+	id2 := "id2"
+	id3 := "id3"
+	id4 := "id4"
+
+	slackTransformer := NewTransformer("test", log.New())
+	activeUsers := []SlackUser{
+		{
+			Id:       id1,
+			Username: "username1",
+			Profile: SlackProfile{
+				FirstName: "firstname1",
+				LastName:  "lastname1",
+				Title:     "position1",
+				Email:     "email1@example.com",
+			},
+		},
+		{
+			Id:       id2,
+			Username: "username2",
+			Deleted:  false,
+			Profile: SlackProfile{
+				FirstName: "firstname2",
+				LastName:  "lastname2",
+				Title:     "position2",
+				Email:     "email2@example.com",
+			},
+		},
+	}
+
+	inactiveUsers := []SlackUser{
+		{
+			Id:       id3,
+			Username: "username3",
+			Deleted:  true,
+			Profile: SlackProfile{
+				FirstName: "firstname3",
+				LastName:  "lastname3",
+				Title:     "position3",
+				Email:     "email3@example.com",
+			},
+		},
+		{
+			Id:       id4,
+			Username: "username4",
+			Deleted:  true,
+			Profile: SlackProfile{
+				FirstName: "firstname4",
+				LastName:  "lastname4",
+				Title:     "position4",
+				Email:     "email4@example.com",
+			},
+		},
+	}
+
+	users := append(activeUsers, inactiveUsers...)
+
+	slackTransformer.TransformUsers(users)
+	require.Zero(t, slackTransformer.Intermediate.UsersById[activeUsers[0].Id].DeleteAt)
+	require.Zero(t, slackTransformer.Intermediate.UsersById[activeUsers[1].Id].DeleteAt)
+	require.NotZero(t, slackTransformer.Intermediate.UsersById[inactiveUsers[0].Id].DeleteAt)
+	require.NotZero(t, slackTransformer.Intermediate.UsersById[inactiveUsers[1].Id].DeleteAt)
 }
 
 func TestPopulateUserMemberships(t *testing.T) {

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -40,6 +40,7 @@ type SlackUser struct {
 	Username string       `json:"name"`
 	IsBot    bool         `json:"is_bot"`
 	Profile  SlackProfile `json:"profile"`
+	Deleted  bool         `json:"deleted"`
 }
 
 type SlackFile struct {


### PR DESCRIPTION
#### Summary

This PR makes it so we parse the Slack export's `deleted` field, and use its value to set the bulk import's `delete_at` field. If `deleted: true`, then we use `delete_at=model.GetMillis()` as the import user's `delete_at` value.

Note that the import file format for Mattermost bulk import format includes this `delete_at` field https://docs.mattermost.com/onboard/bulk-loading-data.html#fields-of-the-user-object

From Slack's [export docs](https://slack.com/help/articles/220556107-How-to-read-Slack-data-exports), the `users.json` file contains Slack [user objects](https://api.slack.com/types/user#fields), which contains a `deleted: boolean` field.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

