### PR TITLE
Use `user.profile.real_name` for user's first & last name, and log to external log file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,6 @@ jobs:
       - name: Build and package
         run: make package
 
-      - name: Save cache
-        uses: actions/cache@v2
-        with:
-          path: build
-          key: go-mod-v1-${{ hashFiles('**/go.sum') }}
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/commands/check.go
+++ b/commands/check.go
@@ -27,6 +27,7 @@ func init() {
 	CheckSlackCmd.Flags().Bool("debug", true, "Whether to show debug logs or not")
 	CheckSlackCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
 	CheckSlackCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+	CheckSlackCmd.Flags().Bool("strict-user-errors", false, "Surface any user parsing errors, and exit the program.")
 
 	if err := CheckSlackCmd.MarkFlagRequired("file"); err != nil {
 		panic(err)
@@ -46,6 +47,7 @@ func checkSlackCmdF(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
 	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+	strictUserErrors, _ := cmd.Flags().GetBool("strict-user-errors")
 
 	// input file
 	fileReader, err := os.Open(inputFilePath)
@@ -75,7 +77,7 @@ func checkSlackCmdF(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	slackExport, err := slackTransformer.ParseSlackExportFile(zipReader, true)
+	slackExport, err := slackTransformer.ParseSlackExportFile(zipReader, true, strictUserErrors)
 	if err != nil {
 		return err
 	}

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -43,6 +43,7 @@ func init() {
 	TransformSlackCmd.Flags().BoolP("skip-attachments", "a", false, "Skips copying the attachments from the import file")
 	TransformSlackCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
 	TransformSlackCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+	TransformSlackCmd.Flags().Bool("strict-user-errors", false, "Surface any user parsing errors, and exit the program.")
 	TransformSlackCmd.Flags().BoolP("allow-download", "l", false, "Allows downloading the attachments for the import file")
 	TransformSlackCmd.Flags().BoolP("discard-invalid-props", "p", false, "Skips converting posts with invalid props instead discarding the props themselves")
 	TransformSlackCmd.Flags().Bool("debug", true, "Whether to show debug logs or not")
@@ -65,6 +66,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
 	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
 	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+	strictUserErrors, _ := cmd.Flags().GetBool("strict-user-errors")
 	allowDownload, _ := cmd.Flags().GetBool("allow-download")
 	discardInvalidProps, _ := cmd.Flags().GetBool("discard-invalid-props")
 	debug, _ := cmd.Flags().GetBool("debug")
@@ -114,7 +116,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 	slackTransformer := slack.NewTransformer(team, logger)
 
-	slackExport, err := slackTransformer.ParseSlackExportFile(zipReader, skipConvertPosts)
+	slackExport, err := slackTransformer.ParseSlackExportFile(zipReader, skipConvertPosts, strictUserErrors)
 	if err != nil {
 		return err
 	}

--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -1,0 +1,244 @@
+package commands_test
+
+import (
+	"archive/zip"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	// "strconv"
+	"testing"
+
+	"github.com/mattermost/mmetl/commands"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYourCommandFunction(t *testing.T) {
+	defaultChannelsData := `[
+		{
+			"id": "channel1",
+			"name": "general",
+			"creator": "user1",
+			"members": ["user1", "user2", "user3"],
+			"purpose": {"value": "Company wide announcements and work-based matters"},
+			"topic": {"value": "Work matters"},
+			"type": "O"
+		},
+		{
+			"id": "channel2",
+			"name": "random",
+			"creator": "user2",
+			"members": ["user1", "user2", "user3", "user4"],
+			"purpose": {"value": "Non-work related chit-chat"},
+			"topic": {"value": "Anything goes!"},
+			"type": "O"
+		}
+	]`
+
+	defaultUsersData := `[
+		{
+			"id": "user1",
+			"name": "JohnDoe",
+			"is_bot": false,
+			"profile": {
+				"real_name": "John Doe",
+				"email": "john.doe@example.com",
+				"title": "Software Engineer"
+			},
+			"deleted": false
+		},
+		{
+			"id": "user2",
+			"name": "JaneSmith",
+			"id_bot": false,
+			"profile": {
+				"real_name": "Jane Smith",
+				"email":  "jane.smith@example.com",
+				"title": "Product Manager"
+			},
+			"deleted": false
+		}
+	]`
+
+	defaultPostsData := `[
+		{
+			"user": "user1",
+			"text": "Hello, World!",
+			"ts": "1577836800.000000",
+			"type":      "message",
+			"attachments": [
+				{
+				}
+			}
+		},
+		{
+			"user": "user2",
+			"text": "Hello, user1!",
+			"ts": "1577836801.000000",
+			"type": "message",
+			"attachments": [
+				{
+				}
+			}
+		}
+	]`
+
+	for name, tc := range map[string]struct {
+		channelsData   string
+		usersData      string
+		postsData      string
+		expectedOutput string
+		expectedError  string
+	}{
+		"valid": {
+			channelsData: defaultChannelsData,
+			usersData:    defaultUsersData,
+			postsData:    defaultPostsData,
+			expectedOutput: `{"type":"version","version":1}
+{"type":"channel","channel":{"team":"myteam","name":"general","display_name":"general","type":"O","header":"Work matters","purpose":"Company wide announcements and work-based matters"}}
+{"type":"channel","channel":{"team":"myteam","name":"random","display_name":"random","type":"O","header":"Anything goes!","purpose":"Non-work related chit-chat"}}
+{"type":"user","user":{"username":"JohnDoe","email":"john.doe@example.com","auth_service":null,"nickname":"","first_name":"John","last_name":"Doe","position":"Software Engineer","roles":"system_user","locale":null,"teams":[{"name":"myteam","roles":"team_user","channels":[{"name":"general","roles":"channel_user"},{"name":"random","roles":"channel_user"}]}]}}
+{"type":"user","user":{"username":"JaneSmith","email":"jane.smith@example.com","auth_service":null,"nickname":"","first_name":"Jane","last_name":"Smith","position":"Product Manager","roles":"system_user","locale":null,"teams":[{"name":"myteam","roles":"team_user","channels":[{"name":"general","roles":"channel_user"},{"name":"random","roles":"channel_user"}]}]}}
+`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			team := "myteam"
+			inputFilePath := "test_input.zip"
+			outputFilePath := "test_output.txt"
+
+			var err error
+			err = createTestZipFile(inputFilePath, tc.channelsData, tc.usersData, tc.postsData)
+			require.NoError(t, err)
+
+			args := []string{
+				"transform",
+				"slack",
+				"--team", team,
+				"--file", inputFilePath,
+				"--output", outputFilePath,
+				"--strict-user-errors",
+			}
+
+			c := commands.RootCmd
+			c.SetArgs(args)
+			err = c.Execute()
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, err = os.Stat(outputFilePath)
+			if os.IsNotExist(err) {
+				t.Fatalf("output file was not created")
+			}
+
+			require.NoError(t, err)
+
+			output, err := ioutil.ReadFile(outputFilePath)
+			require.NoError(t, err, "failed to read output file")
+
+			require.Equal(t, tc.expectedOutput, string(output))
+		})
+	}
+}
+
+func createTestZipFile(inputFilePath, channelsData, usersData, postsData string) error {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = writeFile(filepath.Join(tempDir, "channels.json"), channelsData)
+	if err != nil {
+		return err
+	}
+	err = writeFile(filepath.Join(tempDir, "users.json"), usersData)
+	if err != nil {
+		return err
+	}
+	err = writeFile(filepath.Join(tempDir, "posts.json"), postsData)
+	if err != nil {
+		return err
+	}
+
+	err = zipFiles(inputFilePath, tempDir, []string{"channels.json", "users.json", "posts.json"})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeFile(filePath, data string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func zipFiles(zipFilePath, dir string, files []string) error {
+	zipFile, err := os.Create(zipFilePath)
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	archive := zip.NewWriter(zipFile)
+	defer archive.Close()
+
+	for _, file := range files {
+		err = addFileToZip(archive, filepath.Join(dir, file), file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addFileToZip(archive *zip.Writer, filePath, fileName string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	header.Name = fileName
+	header.Method = zip.Deflate
+
+	writer, err := archive.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(writer, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -3,11 +3,9 @@ package commands_test
 import (
 	"archive/zip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	// "strconv"
 	"testing"
 
 	"github.com/mattermost/mmetl/commands"
@@ -140,7 +138,7 @@ func TestYourCommandFunction(t *testing.T) {
 
 			require.NoError(t, err)
 
-			output, err := ioutil.ReadFile(outputFilePath)
+			output, err := os.ReadFile(outputFilePath)
 			require.NoError(t, err, "failed to read output file")
 
 			require.Equal(t, tc.expectedOutput, string(output))
@@ -149,11 +147,11 @@ func TestYourCommandFunction(t *testing.T) {
 }
 
 func createTestZipFile(inputFilePath, channelsData, usersData, postsData string) error {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "")
+	defer os.RemoveAll(tempDir)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tempDir)
 
 	err = writeFile(filepath.Join(tempDir, "channels.json"), channelsData)
 	if err != nil {

--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -105,6 +105,11 @@ func TestYourCommandFunction(t *testing.T) {
 			team := "myteam"
 			inputFilePath := "test_input.zip"
 			outputFilePath := "test_output.txt"
+			defer func() {
+				os.Remove(inputFilePath)
+				os.Remove(outputFilePath)
+				os.Remove("transform-slack.log")
+			}()
 
 			var err error
 			err = createTestZipFile(inputFilePath, tc.channelsData, tc.usersData, tc.postsData)
@@ -116,7 +121,6 @@ func TestYourCommandFunction(t *testing.T) {
 				"--team", team,
 				"--file", inputFilePath,
 				"--output", outputFilePath,
-				"--strict-user-errors",
 			}
 
 			c := commands.RootCmd

--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -280,8 +281,18 @@ func (t *Transformer) ExportDirectChannels(channels []*IntermediateChannel, writ
 }
 
 func (t *Transformer) ExportUsers(writer io.Writer) error {
-	for _, user := range t.Intermediate.UsersById {
-		line := GetImportLineFromUser(user, t.TeamName)
+	users := t.Intermediate.UsersById
+	userIds := make([]string, len(users))
+	i := 0
+	for k := range users {
+		userIds[i] = k
+		i++
+	}
+
+	sort.Strings(userIds)
+
+	for _, userId := range userIds {
+		line := GetImportLineFromUser(users[userId], t.TeamName)
 		if err := ExportWriteLine(writer, line); err != nil {
 			return err
 		}

--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -281,18 +280,8 @@ func (t *Transformer) ExportDirectChannels(channels []*IntermediateChannel, writ
 }
 
 func (t *Transformer) ExportUsers(writer io.Writer) error {
-	users := t.Intermediate.UsersById
-	userIds := make([]string, len(users))
-	i := 0
-	for k := range users {
-		userIds[i] = k
-		i++
-	}
-
-	sort.Strings(userIds)
-
-	for _, userId := range userIds {
-		line := GetImportLineFromUser(users[userId], t.TeamName)
+	for _, user := range t.Intermediate.UsersById {
+		line := GetImportLineFromUser(user, t.TeamName)
 		if err := ExportWriteLine(writer, line); err != nil {
 			return err
 		}

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -135,11 +135,19 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			deleteAt = model.GetMillis()
 		}
 
+		firstName := ""
+		lastName := ""
+		if user.Profile.RealName != "" {
+			names := strings.Split(user.Profile.RealName, " ")
+			firstName = names[0]
+			lastName = strings.Join(names[1:], " ")
+		}
+
 		newUser := &IntermediateUser{
 			Id:        user.Id,
 			Username:  user.Username,
-			FirstName: user.Profile.FirstName,
-			LastName:  user.Profile.LastName,
+			FirstName: firstName,
+			LastName:  lastName,
 			Position:  user.Profile.Title,
 			Email:     user.Profile.Email,
 			Password:  model.NewId(),

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -97,7 +97,9 @@ func (u *IntermediateUser) Sanitise(logger log.FieldLogger, defaultEmailDomain s
 			u.Email = u.Username + "@" + defaultEmailDomain
 			logger.Warnf("User %s does not have an email address in the Slack export. Used %s as a placeholder. The user should update their email address once logged in to the system.", u.Username, u.Email)
 		} else {
-			logger.Errorf("User %s does not have an email address in the Slack export. Please provide an email domain through the --default-email-domain flag, to assign this user's email address. Alternatively, use the --skip-empty-emails flag to set the user's email to an empty string.", u.Username)
+			msg := fmt.Sprintf("User %s does not have an email address in the Slack export. Please provide an email domain through the --default-email-domain flag, to assign this user's email address. Alternatively, use the --skip-empty-emails flag to set the user's email to an empty string.", u.Username)
+			logger.Error(msg)
+			fmt.Println(msg)
 			exitFunc(1)
 		}
 	}

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -544,30 +544,27 @@ func TestTransformUsers(t *testing.T) {
 			Id:       id1,
 			Username: "username1",
 			Profile: SlackProfile{
-				FirstName: "firstname1",
-				LastName:  "lastname1",
-				Title:     "position1",
-				Email:     "email1@example.com",
+				RealName: "firstname1 lastname1",
+				Title:    "position1",
+				Email:    "email1@example.com",
 			},
 		},
 		{
 			Id:       id2,
 			Username: "username2",
 			Profile: SlackProfile{
-				FirstName: "firstname2",
-				LastName:  "lastname2",
-				Title:     "position2",
-				Email:     "email2@example.com",
+				RealName: "firstname2 lastname2",
+				Title:    "position2",
+				Email:    "email2@example.com",
 			},
 		},
 		{
 			Id:       id3,
 			Username: "username3",
 			Profile: SlackProfile{
-				FirstName: "firstname3",
-				LastName:  "lastname3",
-				Title:     "position3",
-				Email:     "email3@example.com",
+				RealName: "firstname3 lastname3",
+				Title:    "position3",
+				Email:    "email3@example.com",
 			},
 		},
 	}
@@ -600,10 +597,9 @@ func TestDeleteAt(t *testing.T) {
 			Id:       id1,
 			Username: "username1",
 			Profile: SlackProfile{
-				FirstName: "firstname1",
-				LastName:  "lastname1",
-				Title:     "position1",
-				Email:     "email1@example.com",
+				RealName: "firstname1 lastname1",
+				Title:    "position1",
+				Email:    "email1@example.com",
 			},
 		},
 		{
@@ -611,10 +607,9 @@ func TestDeleteAt(t *testing.T) {
 			Username: "username2",
 			Deleted:  false,
 			Profile: SlackProfile{
-				FirstName: "firstname2",
-				LastName:  "lastname2",
-				Title:     "position2",
-				Email:     "email2@example.com",
+				RealName: "firstname2 lastname2",
+				Title:    "position2",
+				Email:    "email2@example.com",
 			},
 		},
 	}
@@ -625,10 +620,9 @@ func TestDeleteAt(t *testing.T) {
 			Username: "username3",
 			Deleted:  true,
 			Profile: SlackProfile{
-				FirstName: "firstname3",
-				LastName:  "lastname3",
-				Title:     "position3",
-				Email:     "email3@example.com",
+				RealName: "firstname3 lastname3",
+				Title:    "position3",
+				Email:    "email3@example.com",
 			},
 		},
 		{
@@ -636,10 +630,9 @@ func TestDeleteAt(t *testing.T) {
 			Username: "username4",
 			Deleted:  true,
 			Profile: SlackProfile{
-				FirstName: "firstname4",
-				LastName:  "lastname4",
-				Title:     "position4",
-				Email:     "email4@example.com",
+				RealName: "firstname4 lastname4",
+				Title:    "position4",
+				Email:    "email4@example.com",
 			},
 		},
 	}

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -8,9 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -115,23 +112,26 @@ type SlackExport struct {
 	Uploads         map[string]*zip.File
 }
 
-func SlackParseUsers(data io.Reader) ([]SlackUser, error) {
+func (t *Transformer) SlackParseUsers(data io.Reader) ([]SlackUser, error) {
 	decoder := json.NewDecoder(data)
 
 	var users []SlackUser
-	err := decoder.Decode(&users)
+	if err := decoder.Decode(&users); err != nil {
+		t.Logger.Warnf("Slack Import: Error occurred when parsing some Slack users. Import may work anyway. err=%v", err)
 
-	// This returns errors that are ignored, unless --strict-user-errors flag is provided.
-	return users, err
+		// This returns errors that are ignored
+		return users, err
+	}
+
+	return users, nil
 }
 
-func SlackParseChannels(data io.Reader, channelType model.ChannelType) ([]SlackChannel, error) {
+func (t *Transformer) SlackParseChannels(data io.Reader, channelType model.ChannelType) ([]SlackChannel, error) {
 	decoder := json.NewDecoder(data)
 
 	var channels []SlackChannel
 	if err := decoder.Decode(&channels); err != nil {
-		log.Println("Slack Import: Error occurred when parsing some Slack channels. Import may work anyway.")
-		log.Println(err.Error())
+		t.Logger.Warnf("Slack Import: Error occurred when parsing some Slack channels. Import may work anyway. err=%v", err)
 		return channels, err
 	}
 
@@ -142,24 +142,23 @@ func SlackParseChannels(data io.Reader, channelType model.ChannelType) ([]SlackC
 	return channels, nil
 }
 
-func SlackParsePosts(data io.Reader) ([]SlackPost, error) {
+func (t *Transformer) SlackParsePosts(data io.Reader) ([]SlackPost, error) {
 	decoder := json.NewDecoder(data)
 
 	var posts []SlackPost
 	if err := decoder.Decode(&posts); err != nil {
-		log.Println("Slack Import: Error occurred when parsing some Slack posts. Import may work anyway.")
-		log.Println(err.Error())
+		t.Logger.Warnf("Slack Import: Error occurred when parsing some Slack posts. Import may work anyway. err=%v", err)
 		return posts, err
 	}
 	return posts, nil
 }
 
-func SlackConvertUserMentions(users []SlackUser, posts map[string][]SlackPost) map[string][]SlackPost {
+func (t *Transformer) SlackConvertUserMentions(users []SlackUser, posts map[string][]SlackPost) map[string][]SlackPost {
 	var regexes = make(map[string]*regexp.Regexp, len(users))
 	for _, user := range users {
 		r, err := regexp.Compile("<@" + user.Id + `(\|` + user.Username + ")?>")
 		if err != nil {
-			log.Println("Slack Import: Unable to compile the @mention, matching regular expression for the Slack user. user_name=" + user.Username + " user_id" + user.Id)
+			t.Logger.Infof("Slack Import: Unable to compile the @mention, matching regular expression for the Slack user. username=%s user_id=%s", user.Username, user.Id)
 			continue
 		}
 		regexes["@"+user.Username] = r
@@ -182,12 +181,12 @@ func SlackConvertUserMentions(users []SlackUser, posts map[string][]SlackPost) m
 	return posts
 }
 
-func SlackConvertChannelMentions(channels []SlackChannel, posts map[string][]SlackPost) map[string][]SlackPost {
+func (t *Transformer) SlackConvertChannelMentions(channels []SlackChannel, posts map[string][]SlackPost) map[string][]SlackPost {
 	var regexes = make(map[string]*regexp.Regexp, len(channels))
 	for _, channel := range channels {
 		r, err := regexp.Compile("<#" + channel.Id + `(\|` + channel.Name + ")?>")
 		if err != nil {
-			log.Println("Slack Import: Unable to compile the !channel, matching regular expression for the Slack channel. channel_id=" + channel.Id + " channel_name" + channel.Name)
+			t.Logger.Infof("Slack Import: Unable to compile the !channel, matching regular expression for the Slack channel. channel_id=%s channel_name=%s", channel.Id, channel.Name)
 			continue
 		}
 		regexes["~"+channel.Name] = r
@@ -205,7 +204,7 @@ func SlackConvertChannelMentions(channels []SlackChannel, posts map[string][]Sla
 	return posts
 }
 
-func SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPost {
+func (t *Transformer) SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPost {
 	regexReplaceAllString := []struct {
 		regex *regexp.Regexp
 		rpl   string
@@ -269,39 +268,40 @@ func SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPos
 	return posts
 }
 
-func (t *Transformer) ParseSlackExportFile(zipReader *zip.Reader, skipConvertPosts, strictUserErrors bool) (*SlackExport, error) {
+func (t *Transformer) ParseSlackExportFile(zipReader *zip.Reader, skipConvertPosts bool) (*SlackExport, error) {
 	slackExport := SlackExport{TeamName: t.TeamName}
 	slackExport.Posts = make(map[string][]SlackPost)
 	slackExport.Uploads = make(map[string]*zip.File)
+	numFiles := len(zipReader.File)
 
-	for _, file := range zipReader.File {
+	for i, file := range zipReader.File {
+		t.Logger.Infof("Processing file %d of %d: %s", i+1, numFiles, file.Name)
+
 		reader, err := file.Open()
 		if err != nil {
 			return nil, err
 		}
+		defer reader.Close()
 
 		if file.Name == "channels.json" {
-			slackExport.PublicChannels, _ = SlackParseChannels(reader, model.ChannelTypeOpen)
+			slackExport.PublicChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeOpen)
 			slackExport.Channels = append(slackExport.Channels, slackExport.PublicChannels...)
 		} else if file.Name == "dms.json" {
-			slackExport.DirectChannels, _ = SlackParseChannels(reader, model.ChannelTypeDirect)
+			slackExport.DirectChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeDirect)
 			slackExport.Channels = append(slackExport.Channels, slackExport.DirectChannels...)
 		} else if file.Name == "groups.json" {
-			slackExport.PrivateChannels, _ = SlackParseChannels(reader, model.ChannelTypePrivate)
+			slackExport.PrivateChannels, _ = t.SlackParseChannels(reader, model.ChannelTypePrivate)
 			slackExport.Channels = append(slackExport.Channels, slackExport.PrivateChannels...)
 		} else if file.Name == "mpims.json" {
-			slackExport.GroupChannels, _ = SlackParseChannels(reader, model.ChannelTypeGroup)
+			slackExport.GroupChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeGroup)
 			slackExport.Channels = append(slackExport.Channels, slackExport.GroupChannels...)
 		} else if file.Name == "users.json" {
-			users, userErr := SlackParseUsers(reader)
-			if userErr != nil && strictUserErrors {
-				return nil, errors.Wrap(userErr, "failed to parse users")
-			}
+			users, _ := t.SlackParseUsers(reader)
 			slackExport.Users = users
 		} else {
 			spl := strings.Split(file.Name, "/")
 			if len(spl) == 2 && strings.HasSuffix(spl[1], ".json") {
-				newposts, _ := SlackParsePosts(reader)
+				newposts, _ := t.SlackParsePosts(reader)
 				channel := spl[0]
 				if _, ok := slackExport.Posts[channel]; !ok {
 					slackExport.Posts[channel] = newposts
@@ -317,9 +317,9 @@ func (t *Transformer) ParseSlackExportFile(zipReader *zip.Reader, skipConvertPos
 	if !skipConvertPosts {
 		t.Logger.Info("Converting post mentions and markup")
 		start := time.Now()
-		slackExport.Posts = SlackConvertUserMentions(slackExport.Users, slackExport.Posts)
-		slackExport.Posts = SlackConvertChannelMentions(slackExport.Channels, slackExport.Posts)
-		slackExport.Posts = SlackConvertPostsMarkup(slackExport.Posts)
+		slackExport.Posts = t.SlackConvertUserMentions(slackExport.Users, slackExport.Posts)
+		slackExport.Posts = t.SlackConvertChannelMentions(slackExport.Channels, slackExport.Posts)
+		slackExport.Posts = t.SlackConvertPostsMarkup(slackExport.Posts)
 		elapsed := time.Since(start)
 		t.Logger.Debug("Converting mentions finished (%s)", elapsed)
 	}

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -28,11 +28,10 @@ type SlackChannelSub struct {
 }
 
 type SlackProfile struct {
-	BotID     string `json:"bot_id"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
-	Email     string `json:"email"`
-	Title     string `json:"title"`
+	BotID    string `json:"bot_id"`
+	RealName string `json:"real_name"`
+	Email    string `json:"email"`
+	Title    string `json:"title"`
 }
 
 type SlackUser struct {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Slack's data model has stopped using `first_name` and `last_name` for user objects, and is instead using `real_name` for the full name. This PR makes it so we parse the `real_name` into first and last name.

The tool now sends all log output to an external file `transform-slack.log` for easier debugging

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

