### PR TITLE
Support syncing usernames and emails with database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mmetl
 build/
+.DS_STORE

--- a/commands/check.go
+++ b/commands/check.go
@@ -65,7 +65,7 @@ func checkSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	logger := log.New()
-	logFile, err := os.OpenFile("check-slack.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	logFile, err := os.OpenFile("check-slack.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}

--- a/commands/sync_import_users.go
+++ b/commands/sync_import_users.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mmetl/services/data_integrity"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var SyncImportUsersCmd = &cobra.Command{
+	Use:   "sync-import-users",
+	Short: "Checks if any users in the export file already exist in the Mattermost instance, and makes sure both username and email are the same in both cases.",
+	Long:  "Checks if any users in the export file already exist in the Mattermost instance, and makes sure both username and email are the same in both cases. This requires credentials or to have local mode enabled/available.",
+	RunE:  syncImportUsersCmdF,
+}
+
+func init() {
+	SyncImportUsersCmd.Flags().StringP("file", "f", "", "the mmetl file to check")
+	SyncImportUsersCmd.Flags().StringP("output", "o", "", "the output file name")
+	SyncImportUsersCmd.Flags().Bool("debug", true, "Whether to show debug logs or not")
+	SyncImportUsersCmd.Flags().Bool("local", false, "Whether to use local mode to check for existing users")
+
+	if err := SyncImportUsersCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
+
+	if err := SyncImportUsersCmd.MarkFlagRequired("output"); err != nil {
+		panic(err)
+	}
+
+	RootCmd.AddCommand(
+		SyncImportUsersCmd,
+	)
+}
+
+func syncImportUsersCmdF(cmd *cobra.Command, args []string) error {
+	importFilePath, _ := cmd.Flags().GetString("file")
+	outputFilePath, _ := cmd.Flags().GetString("output")
+	debug, _ := cmd.Flags().GetBool("debug")
+	localMode, _ := cmd.Flags().GetBool("local")
+
+	fileReader, err := os.Open(importFilePath)
+	if err != nil {
+		return err
+	}
+	defer fileReader.Close()
+
+	logger := log.New()
+	logFile, err := os.OpenFile("sync-import-users.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	logger.SetOutput(logFile)
+	logger.SetFormatter(customLogFormatter)
+	logger.SetReportCaller(true)
+
+	if debug {
+		logger.Level = log.DebugLevel
+		logger.Info("Debug mode enabled")
+	}
+
+	var client *model.Client4
+	if localMode {
+		client = model.NewAPIv4SocketClient("/var/tmp/mattermost_local.socket")
+		// } else {
+		// 	// TODO: handle site url client
+	}
+
+	flags := data_integrity.SyncImportUsersFlags{
+		UpdateUsernames: false,
+		UpdateEmails:    false,
+		OutputFile:      outputFilePath,
+	}
+
+	err = data_integrity.SyncImportUsers(fileReader, flags, client, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commands/sync_import_users.go
+++ b/commands/sync_import_users.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"os"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -68,8 +69,15 @@ func syncImportUsersCmdF(cmd *cobra.Command, args []string) error {
 	var client *model.Client4
 	if localMode {
 		client = model.NewAPIv4SocketClient("/var/tmp/mattermost_local.socket")
-		// } else {
-		// 	// TODO: handle site url client
+	} else {
+		siteURL := os.Getenv("MM_SITE_URL")
+		adminToken := os.Getenv("MM_ADMIN_TOKEN")
+		if siteURL == "" || adminToken == "" {
+			return errors.New("Please use the --local flag, or provide the Mattermost site URL and admin token via environment variables MM_SITE_URL and MM_ADMIN_TOKEN")
+		}
+
+		client = model.NewAPIv4Client(siteURL)
+		client.SetToken(adminToken)
 	}
 
 	flags := data_integrity.SyncImportUsersFlags{

--- a/commands/sync_import_users.go
+++ b/commands/sync_import_users.go
@@ -19,7 +19,9 @@ var SyncImportUsersCmd = &cobra.Command{
 func init() {
 	SyncImportUsersCmd.Flags().StringP("file", "f", "", "the mmetl file to check")
 	SyncImportUsersCmd.Flags().StringP("output", "o", "", "the output file name")
-	SyncImportUsersCmd.Flags().Bool("debug", true, "Whether to show debug logs or not")
+	SyncImportUsersCmd.Flags().Bool("update-users", false, "Whether to update user records in the import file")
+
+	SyncImportUsersCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
 	SyncImportUsersCmd.Flags().Bool("local", false, "Whether to use local mode to check for existing users")
 
 	if err := SyncImportUsersCmd.MarkFlagRequired("file"); err != nil {
@@ -38,6 +40,7 @@ func init() {
 func syncImportUsersCmdF(cmd *cobra.Command, args []string) error {
 	importFilePath, _ := cmd.Flags().GetString("file")
 	outputFilePath, _ := cmd.Flags().GetString("output")
+	updateUsers, _ := cmd.Flags().GetBool("update-users")
 	debug, _ := cmd.Flags().GetBool("debug")
 	localMode, _ := cmd.Flags().GetBool("local")
 
@@ -48,7 +51,7 @@ func syncImportUsersCmdF(cmd *cobra.Command, args []string) error {
 	defer fileReader.Close()
 
 	logger := log.New()
-	logFile, err := os.OpenFile("sync-import-users.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	logFile, err := os.OpenFile("sync-import-users.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}
@@ -70,9 +73,8 @@ func syncImportUsersCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	flags := data_integrity.SyncImportUsersFlags{
-		UpdateUsernames: false,
-		UpdateEmails:    false,
-		OutputFile:      outputFilePath,
+		UpdateUsers: updateUsers,
+		OutputFile:  outputFilePath,
 	}
 
 	err = data_integrity.SyncImportUsers(fileReader, flags, client, logger)

--- a/services/data_integrity/sync_import_users.go
+++ b/services/data_integrity/sync_import_users.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -14,20 +15,37 @@ import (
 )
 
 type SyncImportUsersFlags struct {
-	UpdateUsernames bool
-	UpdateEmails    bool
-	OutputFile      string
+	UpdateUsers bool
+	OutputFile  string
 }
 
 func SyncImportUsers(reader io.Reader, flags SyncImportUsersFlags, client *model.Client4, logger *logrus.Logger) error {
 	scanner := bufio.NewScanner(reader)
 
-	out, err := os.Open(flags.OutputFile)
-	if err != nil {
-		return errors.Wrap(err, "Error opening output file")
-	}
-	defer out.Close()
+	var out *os.File
+	var err error
 
+	var write = func(line string) error {
+		if out != nil {
+			if _, writeErr := out.WriteString(line + "\n"); writeErr != nil {
+				return errors.Wrap(writeErr, "Failed to write to output file")
+			}
+		}
+
+		return nil
+	}
+
+	if flags.UpdateUsers {
+		out, err = os.OpenFile(flags.OutputFile, os.O_CREATE|os.O_WRONLY, 0666)
+		if err != nil {
+			return errors.Wrap(err, "Error opening output file")
+		}
+		defer out.Close()
+	}
+
+	foundUser := false
+
+	logger.Info("Starting sync process")
 	for scanner.Scan() {
 		var lineData imports.LineImportData
 
@@ -35,19 +53,27 @@ func SyncImportUsers(reader io.Reader, flags SyncImportUsersFlags, client *model
 		err := json.Unmarshal([]byte(line), &lineData)
 		if err != nil {
 			logger.Warnf("Error unmarshalling line, continuing process anyway: %v", err)
-			if _, writeErr := out.WriteString(line + "\n"); writeErr != nil {
-				return errors.Wrap(writeErr, "Failed to write to output file")
+			if writeErr := write(line + "\n"); writeErr != nil {
+				return writeErr
 			}
 		}
 
 		if lineData.Type != "user" {
-			if _, writeErr := out.WriteString(line + "\n"); writeErr != nil {
-				return errors.Wrap(writeErr, "Failed to write to output file")
+			if foundUser && !flags.UpdateUsers {
+				break
+			}
+
+			if writeErr := write(line + "\n"); writeErr != nil {
+				return writeErr
 			}
 			continue
 		}
 
+		foundUser = true
+
 		user := lineData.User
+		logger.Debugf("Processing user %s", *user.Username)
+
 		err = mergeImportFileUser(user, flags, client, logger)
 		if err != nil {
 			logger.Errorf("Error checking user %s, keeping import record as-is. %v", *user.Username, err)
@@ -59,14 +85,20 @@ func SyncImportUsers(reader io.Reader, flags SyncImportUsersFlags, client *model
 			return errors.Wrap(err, "Error marshaling user")
 		}
 
-		if _, writeErr := out.Write(append(userOut, '\n')); writeErr != nil {
-			return errors.Wrap(writeErr, "Failed to write to output file")
+		if writeErr := write(string(userOut) + "\n"); writeErr != nil {
+			return writeErr
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
 		return err
 	}
+
+	if !flags.UpdateUsers {
+		logger.Info("Exited after reading users from import file, due to not providing --update-users flag")
+	}
+
+	logger.Info("Finished sync process")
 
 	return nil
 }
@@ -75,50 +107,64 @@ func mergeImportFileUser(user *imports.UserImportData, flags SyncImportUsersFlag
 	usernameExists := false
 	emailExists := false
 
-	existingUserByUsername, resp, err := client.GetUserByUsername(*user.Username, "")
+	emailFromImport := strings.ToLower(*user.Email)
+	usernameFromImport := strings.ToLower(*user.Username)
+
+	existingUserByUsername, resp, err := client.GetUserByUsername(usernameFromImport, "")
 	if err != nil {
 		if resp.StatusCode != 404 {
 			return err
 		}
 
-		logger.Debugf("Username %s does not exist in database", *user.Username)
+		logger.Debugf("Username %s does not exist in database", usernameFromImport)
 	} else {
 		usernameExists = true
-		logger.Debugf("Username %s exists in database", *user.Username)
+		logger.Debugf("Username %s exists in database", usernameFromImport)
 	}
 
-	existingUserByEmail, resp, err := client.GetUserByEmail(*user.Email, "")
+	existingUserByEmail, resp, err := client.GetUserByEmail(emailFromImport, "")
 	if err != nil {
 		if resp.StatusCode != 404 {
 			return err
 		}
 
-		logger.Debugf("Email %s does not exist in database", *user.Email)
+		logger.Debugf("Email %s does not exist in database", emailFromImport)
 	} else {
 		emailExists = true
-		logger.Debugf("Email %s exists in database", *user.Email)
+		logger.Debugf("Email %s exists in database", emailFromImport)
 	}
 
-	if usernameExists && existingUserByUsername.Email != *user.Email {
-		logger.Warnf("Username %s already exists, but has a different email. DB email: (%s) Import file email (%s)", *user.Username, existingUserByUsername.Email, *user.Email)
+	if usernameExists && existingUserByUsername.Email != emailFromImport {
+		logger.Warnf("Username %s already exists, but has a different email. DB email: (%s) Import file email (%s)", usernameFromImport, existingUserByUsername.Email, emailFromImport)
 	}
 
-	if emailExists && existingUserByEmail.Username != *user.Username {
-		logger.Warnf("Email %s already exists, but has a different username. DB username: (%s) Import file username (%s)", *user.Email, existingUserByEmail.Username, *user.Username)
+	if emailExists && existingUserByEmail.Username != usernameFromImport {
+		logger.Warnf("Email %s already exists, but has a different username. DB username: (%s) Import file username (%s)", emailFromImport, existingUserByEmail.Username, usernameFromImport)
 	}
 
-	if usernameExists && existingUserByUsername.Email != *user.Email {
-		if flags.UpdateEmails {
-			logger.Infof("Updating email for user %s from %s to %s", *user.Username, *user.Email, existingUserByUsername.Email)
+	recordChanged := false
+	if usernameExists && existingUserByUsername.Email != emailFromImport {
+		if flags.UpdateUsers {
+			logger.Infof("Updating email for user %s from %s to %s", usernameFromImport, emailFromImport, existingUserByUsername.Email)
 			user.Email = &existingUserByUsername.Email
+			recordChanged = true
+		} else {
+			logger.Infof("Use the `--update-users` flag to update the import file's user record for user %s", usernameFromImport)
 		}
 	}
 
-	if emailExists && existingUserByEmail.Username != *user.Username {
-		if flags.UpdateUsernames {
-			logger.Infof("Updating username for user %s from %s to %s", *user.Email, *user.Username, existingUserByEmail.Username)
+	if emailExists && existingUserByEmail.Username != usernameFromImport {
+		if flags.UpdateUsers {
+			logger.Infof("Updating username for user %s from %s to %s", emailFromImport, usernameFromImport, existingUserByEmail.Username)
 			user.Username = &existingUserByEmail.Username
+			recordChanged = true
+		} else {
+			logger.Infof("Use the `--update-users` flag to update the import file's user record for user %s", usernameFromImport)
 		}
+	}
+
+	if !recordChanged {
+		logger.Debugf("Record not changed for user %s", usernameFromImport)
 	}
 
 	return nil

--- a/services/data_integrity/sync_import_users.go
+++ b/services/data_integrity/sync_import_users.go
@@ -1,0 +1,126 @@
+package data_integrity
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/mattermost/mattermost-server/v6/app/imports"
+	"github.com/mattermost/mattermost-server/v6/model"
+)
+
+type SyncImportUsersFlags struct {
+	UpdateUsernames bool
+	UpdateEmails    bool
+	OutputFile      string
+}
+
+func SyncImportUsers(reader io.Reader, flags SyncImportUsersFlags, client *model.Client4, logger *logrus.Logger) error {
+	scanner := bufio.NewScanner(reader)
+
+	out, err := os.Open(flags.OutputFile)
+	if err != nil {
+		return errors.Wrap(err, "Error opening output file")
+	}
+	defer out.Close()
+
+	for scanner.Scan() {
+		var lineData imports.LineImportData
+
+		line := scanner.Text()
+		err := json.Unmarshal([]byte(line), &lineData)
+		if err != nil {
+			logger.Warnf("Error unmarshalling line, continuing process anyway: %v", err)
+			if _, writeErr := out.WriteString(line + "\n"); writeErr != nil {
+				return errors.Wrap(writeErr, "Failed to write to output file")
+			}
+		}
+
+		if lineData.Type != "user" {
+			if _, writeErr := out.WriteString(line + "\n"); writeErr != nil {
+				return errors.Wrap(writeErr, "Failed to write to output file")
+			}
+			continue
+		}
+
+		user := lineData.User
+		err = mergeImportFileUser(user, flags, client, logger)
+		if err != nil {
+			logger.Errorf("Error checking user %s, keeping import record as-is. %v", *user.Username, err)
+			continue
+		}
+
+		userOut, err := json.Marshal(user)
+		if err != nil {
+			return errors.Wrap(err, "Error marshaling user")
+		}
+
+		if _, writeErr := out.Write(append(userOut, '\n')); writeErr != nil {
+			return errors.Wrap(writeErr, "Failed to write to output file")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func mergeImportFileUser(user *imports.UserImportData, flags SyncImportUsersFlags, client *model.Client4, logger *logrus.Logger) error {
+	usernameExists := false
+	emailExists := false
+
+	existingUserByUsername, resp, err := client.GetUserByUsername(*user.Username, "")
+	if err != nil {
+		if resp.StatusCode != 404 {
+			return err
+		}
+
+		logger.Debugf("Username %s does not exist in database", *user.Username)
+	} else {
+		usernameExists = true
+		logger.Debugf("Username %s exists in database", *user.Username)
+	}
+
+	existingUserByEmail, resp, err := client.GetUserByEmail(*user.Email, "")
+	if err != nil {
+		if resp.StatusCode != 404 {
+			return err
+		}
+
+		logger.Debugf("Email %s does not exist in database", *user.Email)
+	} else {
+		emailExists = true
+		logger.Debugf("Email %s exists in database", *user.Email)
+	}
+
+	if usernameExists && existingUserByUsername.Email != *user.Email {
+		logger.Warnf("Username %s already exists, but has a different email. DB email: (%s) Import file email (%s)", *user.Username, existingUserByUsername.Email, *user.Email)
+	}
+
+	if emailExists && existingUserByEmail.Username != *user.Username {
+		logger.Warnf("Email %s already exists, but has a different username. DB username: (%s) Import file username (%s)", *user.Email, existingUserByEmail.Username, *user.Username)
+	}
+
+	if usernameExists && existingUserByUsername.Email != *user.Email {
+		if flags.UpdateEmails {
+			logger.Infof("Updating email for user %s from %s to %s", *user.Username, *user.Email, existingUserByUsername.Email)
+			user.Email = &existingUserByUsername.Email
+		}
+	}
+
+	if emailExists && existingUserByEmail.Username != *user.Username {
+		if flags.UpdateUsernames {
+			logger.Infof("Updating username for user %s from %s to %s", *user.Email, *user.Username, existingUserByEmail.Username)
+			user.Username = &existingUserByEmail.Username
+		}
+	}
+
+	return nil
+
+}

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -87,6 +87,8 @@ type IntermediateUser struct {
 }
 
 func (u *IntermediateUser) Sanitise(logger log.FieldLogger, defaultEmailDomain string, skipEmptyEmails bool) {
+	logger.Debugf("TransformUsers: Sanitise: IntermediateUser receiver: %+v", u)
+
 	if u.Email == "" {
 		if skipEmptyEmails {
 			logger.Warnf("User %s does not have an email address in the Slack export. Using blank email address due to --skip-empty-emails flag.", u.Username)
@@ -130,6 +132,8 @@ type Intermediate struct {
 func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, defaultEmailDomain string) {
 	t.Logger.Info("Transforming users")
 
+	t.Logger.Debugf("TransformUsers: Input user structs: %+v", users)
+
 	resultUsers := map[string]*IntermediateUser{}
 	for _, user := range users {
 		var deleteAt int64 = 0
@@ -145,6 +149,9 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			lastName = strings.Join(names[1:], " ")
 		}
 
+		t.Logger.Debugf("TransformUsers: User struct: %+v", user)
+		t.Logger.Debugf("TransformUsers: User.Profile struct: %+v", user.Profile)
+
 		newUser := &IntermediateUser{
 			Id:        user.Id,
 			Username:  user.Username,
@@ -155,6 +162,8 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			Password:  model.NewId(),
 			DeleteAt:  deleteAt,
 		}
+
+		t.Logger.Debugf("TransformUsers: newUser struct: %+v", newUser)
 
 		if user.IsBot {
 			newUser.Id = user.Profile.BotID

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -132,7 +132,7 @@ type Intermediate struct {
 func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, defaultEmailDomain string) {
 	t.Logger.Info("Transforming users")
 
-	t.Logger.Debugf("TransformUsers: Input user structs: %+v", users)
+	t.Logger.Debugf("TransformUsers: Input SlackUser structs: %+v", users)
 
 	resultUsers := map[string]*IntermediateUser{}
 	for _, user := range users {
@@ -149,8 +149,8 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			lastName = strings.Join(names[1:], " ")
 		}
 
-		t.Logger.Debugf("TransformUsers: User struct: %+v", user)
-		t.Logger.Debugf("TransformUsers: User.Profile struct: %+v", user.Profile)
+		t.Logger.Debugf("TransformUsers: SlackUser struct: %+v", user)
+		t.Logger.Debugf("TransformUsers: SlackUser.Profile struct: %+v", user.Profile)
 
 		newUser := &IntermediateUser{
 			Id:        user.Id,
@@ -163,7 +163,7 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			DeleteAt:  deleteAt,
 		}
 
-		t.Logger.Debugf("TransformUsers: newUser struct: %+v", newUser)
+		t.Logger.Debugf("TransformUsers: newUser IntermediateUser struct: %+v", newUser)
 
 		if user.IsBot {
 			newUser.Id = user.Profile.BotID

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -113,15 +114,40 @@ type SlackExport struct {
 }
 
 func (t *Transformer) SlackParseUsers(data io.Reader) ([]SlackUser, error) {
-	decoder := json.NewDecoder(data)
-
 	var users []SlackUser
-	if err := decoder.Decode(&users); err != nil {
+
+	b, err := io.ReadAll(data)
+	if err != nil {
+		return users, err
+	}
+
+	t.Logger.Debugf("SlackParseUsers: Raw json input data: %s", string(b))
+
+	err = json.Unmarshal(b, &users)
+	if err != nil {
 		t.Logger.Warnf("Slack Import: Error occurred when parsing some Slack users. Import may work anyway. err=%v", err)
 
 		// This returns errors that are ignored
 		return users, err
 	}
+
+	t.Logger.Debugf("SlackParseUsers: Parsed users struct data: %+v", users)
+
+	testUser := os.Getenv("DEBUG_TEST_USER")
+	if testUser != "" {
+		for _, u := range users {
+			if u.Username == testUser {
+				t.Logger.Debugf("SlackParseUsers: Test user %+v", u)
+			}
+		}
+	}
+
+	b, err = json.Marshal(users)
+	if err != nil {
+		return users, err
+	}
+
+	t.Logger.Debugf("SlackParseUsers: Marshalled users struct data: %s", string(b))
 
 	return users, nil
 }
@@ -275,42 +301,50 @@ func (t *Transformer) ParseSlackExportFile(zipReader *zip.Reader, skipConvertPos
 	numFiles := len(zipReader.File)
 
 	for i, file := range zipReader.File {
-		t.Logger.Infof("Processing file %d of %d: %s", i+1, numFiles, file.Name)
+		err := func(i int, file *zip.File) error {
+			t.Logger.Infof("Processing file %d of %d: %s", i+1, numFiles, file.Name)
 
-		reader, err := file.Open()
+			reader, err := file.Open()
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
+
+			if file.Name == "channels.json" {
+				slackExport.PublicChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeOpen)
+				slackExport.Channels = append(slackExport.Channels, slackExport.PublicChannels...)
+			} else if file.Name == "dms.json" {
+				slackExport.DirectChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeDirect)
+				slackExport.Channels = append(slackExport.Channels, slackExport.DirectChannels...)
+			} else if file.Name == "groups.json" {
+				slackExport.PrivateChannels, _ = t.SlackParseChannels(reader, model.ChannelTypePrivate)
+				slackExport.Channels = append(slackExport.Channels, slackExport.PrivateChannels...)
+			} else if file.Name == "mpims.json" {
+				slackExport.GroupChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeGroup)
+				slackExport.Channels = append(slackExport.Channels, slackExport.GroupChannels...)
+			} else if file.Name == "users.json" {
+				users, _ := t.SlackParseUsers(reader)
+				slackExport.Users = users
+			} else {
+				spl := strings.Split(file.Name, "/")
+				if len(spl) == 2 && strings.HasSuffix(spl[1], ".json") {
+					newposts, _ := t.SlackParsePosts(reader)
+					channel := spl[0]
+					if _, ok := slackExport.Posts[channel]; !ok {
+						slackExport.Posts[channel] = newposts
+					} else {
+						slackExport.Posts[channel] = append(slackExport.Posts[channel], newposts...)
+					}
+				} else if len(spl) == 3 && spl[0] == "__uploads" {
+					slackExport.Uploads[spl[1]] = file
+				}
+			}
+
+			return nil
+		}(i, file)
+
 		if err != nil {
 			return nil, err
-		}
-		defer reader.Close()
-
-		if file.Name == "channels.json" {
-			slackExport.PublicChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeOpen)
-			slackExport.Channels = append(slackExport.Channels, slackExport.PublicChannels...)
-		} else if file.Name == "dms.json" {
-			slackExport.DirectChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeDirect)
-			slackExport.Channels = append(slackExport.Channels, slackExport.DirectChannels...)
-		} else if file.Name == "groups.json" {
-			slackExport.PrivateChannels, _ = t.SlackParseChannels(reader, model.ChannelTypePrivate)
-			slackExport.Channels = append(slackExport.Channels, slackExport.PrivateChannels...)
-		} else if file.Name == "mpims.json" {
-			slackExport.GroupChannels, _ = t.SlackParseChannels(reader, model.ChannelTypeGroup)
-			slackExport.Channels = append(slackExport.Channels, slackExport.GroupChannels...)
-		} else if file.Name == "users.json" {
-			users, _ := t.SlackParseUsers(reader)
-			slackExport.Users = users
-		} else {
-			spl := strings.Split(file.Name, "/")
-			if len(spl) == 2 && strings.HasSuffix(spl[1], ".json") {
-				newposts, _ := t.SlackParsePosts(reader)
-				channel := spl[0]
-				if _, ok := slackExport.Posts[channel]; !ok {
-					slackExport.Posts[channel] = newposts
-				} else {
-					slackExport.Posts[channel] = append(slackExport.Posts[channel], newposts...)
-				}
-			} else if len(spl) == 3 && spl[0] == "__uploads" {
-				slackExport.Uploads[spl[1]] = file
-			}
 		}
 	}
 
@@ -321,7 +355,7 @@ func (t *Transformer) ParseSlackExportFile(zipReader *zip.Reader, skipConvertPos
 		slackExport.Posts = t.SlackConvertChannelMentions(slackExport.Channels, slackExport.Posts)
 		slackExport.Posts = t.SlackConvertPostsMarkup(slackExport.Posts)
 		elapsed := time.Since(start)
-		t.Logger.Debug("Converting mentions finished (%s)", elapsed)
+		t.Logger.Debugf("Converting mentions finished (%s)", elapsed)
 	}
 
 	return &slackExport, nil

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -130,10 +130,12 @@ func (t *Transformer) SlackParseUsers(data io.Reader) ([]SlackUser, error) {
 		return users, err
 	}
 
-	t.Logger.Debugf("SlackParseUsers: Parsed users struct data: %+v", users)
+	usersAsMaps := []map[string]interface{}{}
+	_ = json.Unmarshal(b, &usersAsMaps)
 
-	for _, u := range users {
+	for i, u := range users {
 		t.Logger.Debugf("SlackParseUsers: Parsed user struct data %+v", u)
+		t.Logger.Debugf("SlackParseUsers: Parsed user data as map %+v", usersAsMaps[i])
 	}
 
 	b, err = json.Marshal(users)

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -133,13 +132,8 @@ func (t *Transformer) SlackParseUsers(data io.Reader) ([]SlackUser, error) {
 
 	t.Logger.Debugf("SlackParseUsers: Parsed users struct data: %+v", users)
 
-	testUser := os.Getenv("DEBUG_TEST_USER")
-	if testUser != "" {
-		for _, u := range users {
-			if u.Username == testUser {
-				t.Logger.Debugf("SlackParseUsers: Test user %+v", u)
-			}
-		}
+	for _, u := range users {
+		t.Logger.Debugf("SlackParseUsers: Parsed user struct data %+v", u)
 	}
 
 	b, err = json.Marshal(users)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR adds a new command `sync-import-users` to synchronize existing users in the import file. We check in the database for any matches of username or email, and then update the import file with the values present in the database.

When `--update-users` is not provided, the tool runs a dry run to note which users would be updated.

```
Usage:
  mmetl sync-import-users [flags]

Flags:
      --debug           Whether to show debug logs or not
  -f, --file string     the mmetl file to check
  -h, --help            help for sync-import-users
      --local           Whether to use local mode to check for existing users
  -o, --output string   the output file name
      --update-users    Whether to update user records in the import file. When this flag is not provided, the tool runs a dry run to note which users would be updated.
```

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-54030
