### PR TITLE
Adjusted user mention parsing, added tests, and parsing for attachment fallback.

### DIFF
--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -189,7 +189,7 @@ func (t *Transformer) SlackConvertUserMentions(users []SlackUser, posts map[stri
 	}
 
 	// Special cases.
-	regexes["@here"], _ = regexp.Compile(`<!here\|@here>`)
+	regexes["@here"], _ = regexp.Compile("<(!|@)here>")
 	regexes["@channel"], _ = regexp.Compile("<!channel>")
 	regexes["@all"], _ = regexp.Compile("<!everyone>")
 

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -198,6 +198,12 @@ func (t *Transformer) SlackConvertUserMentions(users []SlackUser, posts map[stri
 			for mention, r := range regexes {
 				post.Text = r.ReplaceAllString(post.Text, mention)
 				posts[channelName][postIdx] = post
+
+				if post.Attachments != nil {
+					for _, attachment := range post.Attachments {
+						attachment.Fallback = r.ReplaceAllString(attachment.Fallback, mention)
+					}
+				}
 			}
 		}
 	}
@@ -221,6 +227,12 @@ func (t *Transformer) SlackConvertChannelMentions(channels []SlackChannel, posts
 			for channelReplace, r := range regexes {
 				post.Text = r.ReplaceAllString(post.Text, channelReplace)
 				posts[channelName][postIdx] = post
+
+				if post.Attachments != nil {
+					for _, attachment := range post.Attachments {
+						attachment.Fallback = r.ReplaceAllString(attachment.Fallback, channelReplace)
+					}
+				}
 			}
 		}
 	}

--- a/services/slack/parse_test.go
+++ b/services/slack/parse_test.go
@@ -1,0 +1,59 @@
+package slack
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var posts = map[string][]SlackPost{
+	"mentions": {
+		{
+			Text: "test <!here> test",
+		},
+		{
+			Text: "test <!channel> test",
+		},
+		{
+			Text: "test <!everyone> test",
+		},
+		{
+			Text: "test <@U100> test",
+		},
+		{
+			Text: "test <@user1> test",
+		},
+	},
+}
+
+var users = []SlackUser{
+	{
+		Id:       "U100",
+		Username: "user1",
+	},
+}
+
+func TestSlackConvertUserMentions(t *testing.T) {
+	transformer := NewTransformer("test", logrus.New())
+	parsedPosts := transformer.SlackConvertUserMentions(users, posts)
+	for _, post := range parsedPosts["mentions"] {
+		fmt.Println(post.Text)
+		if strings.Contains(post.Text, "!here") {
+			t.Errorf("Expected !here to be converted to @here. Post: %s", post.Text)
+		}
+
+		if strings.Contains(post.Text, "!channel") {
+			t.Errorf("Expected !channel to be converted to @channel. Post: %s", post.Text)
+		}
+
+		if strings.Contains(post.Text, "!all") {
+			t.Errorf("Expected !all to be converted to @all. Post: %s", post.Text)
+		}
+
+		if strings.Contains(post.Text, "@U100") {
+			t.Errorf("Expected !U100 to be converted to @user1. Post: %s", post.Text)
+		}
+	}
+}

--- a/services/slack/parse_test.go
+++ b/services/slack/parse_test.go
@@ -1,59 +1,53 @@
 package slack
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/sirupsen/logrus"
 )
 
-var posts = map[string][]SlackPost{
-	"mentions": {
-		{
-			Text: "test <!here> test",
-		},
-		{
-			Text: "test <!channel> test",
-		},
-		{
-			Text: "test <!everyone> test",
-		},
-		{
-			Text: "test <@U100> test",
-		},
-		{
-			Text: "test <@user1> test",
-		},
-	},
-}
-
-var users = []SlackUser{
-	{
-		Id:       "U100",
-		Username: "user1",
-	},
-}
-
 func TestSlackConvertUserMentions(t *testing.T) {
+	type TestCases struct {
+		mention  string
+		expected string
+	}
+
+	var testCases = []TestCases{
+		{mention: "<!here>", expected: "@here"},
+		{mention: "<!channel>", expected: "@channel"},
+		{mention: "<!everyone>", expected: "@all"},
+		{mention: "<@U100>", expected: "@user1"},
+		{mention: "<@user1>", expected: "<@user1>"},
+	}
+
+	var users = []SlackUser{
+		{
+			Id:       "U100",
+			Username: "user1",
+		},
+	}
 	transformer := NewTransformer("test", logrus.New())
-	parsedPosts := transformer.SlackConvertUserMentions(users, posts)
-	for _, post := range parsedPosts["mentions"] {
-		fmt.Println(post.Text)
-		if strings.Contains(post.Text, "!here") {
-			t.Errorf("Expected !here to be converted to @here. Post: %s", post.Text)
+
+	for _, testCase := range testCases {
+		posts := map[string][]SlackPost{
+			"channelName": {
+				{
+					Text: testCase.mention,
+					Attachments: []*model.SlackAttachment{
+						{Fallback: testCase.mention},
+					},
+				},
+			},
+		}
+		parsedPosts := transformer.SlackConvertUserMentions(users, posts)
+		post := parsedPosts["channelName"][0]
+		if post.Text != testCase.expected {
+			t.Errorf("In post expected %s to be converted to %s. Post: %s", testCase.mention, testCase.expected, post.Text)
 		}
 
-		if strings.Contains(post.Text, "!channel") {
-			t.Errorf("Expected !channel to be converted to @channel. Post: %s", post.Text)
-		}
-
-		if strings.Contains(post.Text, "!all") {
-			t.Errorf("Expected !all to be converted to @all. Post: %s", post.Text)
-		}
-
-		if strings.Contains(post.Text, "@U100") {
-			t.Errorf("Expected !U100 to be converted to @user1. Post: %s", post.Text)
+		if post.Attachments[0].Fallback != testCase.expected {
+			t.Errorf("In fallback expected %s to be converted to %s. Post: %s", testCase.mention, testCase.expected, post.Text)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
When importing from slack I noticed `<!here>` was not properly converted at all. This adjusted the regex to find both `<@here>` and `<!here`>

Additionally, added parsing for attachment fallbacks because they use the mention syntax. 

Before the change:

```
test <!here> test
test @channel test
test @all test
test @user1 test
test <@user1> test
```

Before the change:

```
test @here test
test @channel test
test @all test
test @user1 test
test <@user1> test
```
