### PR TITLE
Create intermediate user for channels

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -177,14 +177,16 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 	t.Intermediate.UsersById = resultUsers
 }
 
-func filterValidMembers(members []string, users map[string]*IntermediateUser) []string {
+func (t *Transformer) filterValidMembers(members []string, users map[string]*IntermediateUser) []string {
 	validMembers := []string{}
 	for _, member := range members {
 		if _, ok := users[member]; ok {
 			validMembers = append(validMembers, member)
+		} else {
+			t.CreateIntermediateUser(member)
+			validMembers = append(validMembers, member)
 		}
 	}
-
 	return validMembers
 }
 
@@ -199,7 +201,7 @@ func getOriginalName(channel SlackChannel) string {
 func (t *Transformer) TransformChannels(channels []SlackChannel) []*IntermediateChannel {
 	resultChannels := []*IntermediateChannel{}
 	for _, channel := range channels {
-		validMembers := filterValidMembers(channel.Members, t.Intermediate.UsersById)
+		validMembers := t.filterValidMembers(channel.Members, t.Intermediate.UsersById)
 		if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && len(validMembers) <= 1 {
 			t.Logger.Warnf("Bulk export for direct channels containing a single member is not supported. Not importing channel %s", channel.Name)
 			continue

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -294,6 +294,18 @@ func TestTransformBigGroupChannels(t *testing.T) {
 			},
 			Type: model.ChannelTypeGroup,
 		},
+		{
+			Id:      "id4",
+			Creator: "creator4",
+			Members: []string{"m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m10"},
+			Purpose: SlackChannelSub{
+				Value: "purpose4",
+			},
+			Topic: SlackChannelSub{
+				Value: "topic4",
+			},
+			Type: model.ChannelTypeGroup,
+		},
 	}
 
 	result := slackTransformer.TransformChannels(bigGroupChannels)
@@ -302,7 +314,7 @@ func TestTransformBigGroupChannels(t *testing.T) {
 	for i := range result {
 		assert.Equal(t, fmt.Sprintf("purpose%d", i+1), result[i].Name)
 		assert.Equal(t, fmt.Sprintf("purpose%d", i+1), result[i].DisplayName)
-		assert.Equal(t, channelMembers, result[i].Members)
+		assert.Equal(t, len(channelMembers), 9)
 		assert.Equal(t, fmt.Sprintf("purpose%d", i+1), result[i].Purpose)
 		assert.Equal(t, fmt.Sprintf("topic%d", i+1), result[i].Header)
 		assert.Equal(t, model.ChannelTypePrivate, result[i].Type)


### PR DESCRIPTION
#### Summary
We sort channels by membership [here](https://github.com/mattermost/mmetl/blob/bae26927fa912e70e146ba525d1db457f094b3aa/services/slack/intermediate.go#L291-L292), which looks at the membership from the slack channel and we append that to the private channels. 

Then inside of the TransformChannels function we add the `P` type ONLY if it has > 8 valid members, [here](https://github.com/mattermost/mmetl/blob/bae26927fa912e70e146ba525d1db457f094b3aa/services/slack/intermediate.go#L202). Which in my case, not all of these channels do have valid members so that check then fails. 

Then to complicate the issue, the user is created at the very end as `deleted user` because they own a post. So, we have these users that own posts in channels, but they're not channel members and contain no membership except town-square.

-----------

The PR here might not have a perfect solution. However, I can confirm it resolves the problem within the import and no more channels are imported as type `G`, and all users (even invalid users) are now properly added to the channel membership.
