### PR TITLE
Support for huddle threads

### DIFF
--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -211,6 +211,7 @@ func GetImportLineFromPost(post *IntermediatePost, team string) *imports.LineImp
 				CreateAt:       &post.CreateAt,
 				Replies:        &replies,
 				Attachments:    &postAttachments,
+				Type:           &post.Type,
 			},
 		}
 	} else {
@@ -225,6 +226,7 @@ func GetImportLineFromPost(post *IntermediatePost, team string) *imports.LineImp
 				CreateAt:    &post.CreateAt,
 				Replies:     &replies,
 				Attachments: &postAttachments,
+				Type:        &post.Type,
 			},
 		}
 	}

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -519,7 +519,7 @@ func buildMessagePropsFromHuddle(post *SlackPost) model.StringInterface {
 		FromPlugin  bool         `json:"from_plugin"`
 	}
 
-	Props := MessageProps{
+	props := MessageProps{
 		Title: "",
 		Attachments: []Attachment{{
 			ID:       0,

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -532,12 +532,12 @@ func buildMessagePropsFromHuddle(post *SlackPost) model.StringInterface {
 	}
 
 	if post.Room != nil {
-		Props.EndAt = int64(post.Room.DateEnd) * 1000
-		Props.StartAt = int64(post.Room.DateStart) * 1000
+		props.EndAt = int64(post.Room.DateEnd) * 1000
+		props.StartAt = int64(post.Room.DateStart) * 1000
 	}
 
 	propsMap := make(map[string]interface{})
-	bytes, _ := json.Marshal(Props)
+	bytes, _ := json.Marshal(props)
 	_ = json.Unmarshal(bytes, &propsMap)
 
 	return propsMap

--- a/services/slack/parse.go
+++ b/services/slack/parse.go
@@ -49,6 +49,23 @@ type SlackFile struct {
 	DownloadURL string `json:"url_private_download"`
 }
 
+type SlackRoom struct {
+	Id                 string   `json:"id"`
+	Name               string   `json:"name"`
+	CreatedBy          string   `json:"created_by"`
+	DateStart          int64    `json:"date_start"`
+	DateEnd            int64    `json:"date_end"`
+	Participants       []string `json:"participants"`
+	ParticipantHistory []string `json:"participant_history"`
+	ThreadTS           string   `json:"thread_root_ts"`
+	Channels           []string `json:"channels"`
+	IsDMCall           bool     `json:"is_dm_call"`
+	WasRejected        bool     `json:"was_rejected"`
+	WasMissed          bool     `json:"was_missed"`
+	WasAccepted        bool     `json:"was_accepted"`
+	HasEnded           bool     `json:"has_ended"`
+}
+
 type SlackPost struct {
 	User        string                   `json:"user"`
 	BotId       string                   `json:"bot_id"`
@@ -63,6 +80,7 @@ type SlackPost struct {
 	File        *SlackFile               `json:"file"`
 	Files       []*SlackFile             `json:"files"`
 	Attachments []*model.SlackAttachment `json:"attachments"`
+	Room        *SlackRoom               `json:"room"`
 }
 
 func (p *SlackPost) IsPlainMessage() bool {
@@ -95,6 +113,10 @@ func (p *SlackPost) IsChannelPurposeMessage() bool {
 
 func (p *SlackPost) IsChannelNameMessage() bool {
 	return p.Type == "message" && p.SubType == "channel_name"
+}
+
+func (p *SlackPost) isHuddleThread() bool {
+	return p.Type == "message" && p.SubType == "huddle_thread"
 }
 
 type SlackComment struct {


### PR DESCRIPTION
#### Summary
This PR introduces support for slack huddles, which is a new message type. These will be imported to look like a Mattermost call with the thread attachment. I did also find the subtype `sh_room_created` which appears to be huddles without a threaded reply. Currently those are disregarded, but support could be added.

![Screenshot 2024-01-11 at 11 48 14 AM](https://github.com/mattermost/mmetl/assets/46071821/239517a3-8f0e-4032-81a2-430c346ef361)

Huddle thread syntax in the slack export is below. All huddles seem to belong to `USLACKBOT` but have a creator in the room. 

```json
 {
    "type": "message",
    "text": "",
    "user": "USLACKBOT",
    "channel": "REDACTED",
    "room": {
        "id": "REDACTED",
        "name": "",
        "media_server": "",
        "created_by": "REDACTED",
        "date_start": 1687381097,
        "date_end": 1687387089,
        "participants": [],
        "participant_history": [
            "REDACTED",
            "REDACTED"
        ],
        "participants_camera_on": [],
        "participants_camera_off": [],
        "participants_screenshare_on": [],
        "participants_screenshare_off": [],
        "canvas_thread_ts": "1687381097.297369",
        "thread_root_ts": "1687381097.297369",
        "channels": [
            "REDACTED"
        ],
        "is_dm_call": false,
        "was_rejected": false,
        "was_missed": false,
        "was_accepted": false,
        "has_ended": true,
        "is_prewarmed": false,
        "is_scheduled": false,
        "attached_file_ids": [],
        "media_backend_type": "free_willy",
        "display_id": "",
        "external_unique_id": "REDACTED",
        "app_id": "A00",
        "call_family": "huddle",
        "pending_invitees": {}
    },
    "no_notifications": true,
    "permalink": "REDACTED",
    "subtype": "huddle_thread",
    "ts": "1687381097.297369",
    "blocks": [],
    "team": "REDACTED",
    "user_team": "REDACTED",
    "source_team": "REDACTED",
    "user_profile": {
        "avatar_hash": "sv41d8cd98f0",
        "image_72": "https:\/\/a.slack-edge.com\/80588\/img\/slackbot_72.png",
        "first_name": "slackbot",
        "real_name": "Slackbot",
        "display_name": "Slackbot",
        "team": "REDACTED",
        "name": "slackbot",
        "is_restricted": false,
        "is_ultra_restricted": false
    }
}
```

I also uncommented the `Type` information, so these can be imported as `custom_calls` and render the nice Calls UI.
