### PR TITLE
Cap field lengths on User model

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -105,6 +105,21 @@ func (u *IntermediateUser) Sanitise(logger log.FieldLogger, defaultEmailDomain s
 			exitFunc(1)
 		}
 	}
+
+	if utf8.RuneCountInString(u.FirstName) > model.UserFirstNameMaxRunes {
+		logger.Warnf("User %s first name exceeds the maximum length. It will be truncated when imported.", u.Username)
+		u.FirstName = truncateRunes(u.FirstName, model.UserFirstNameMaxRunes)
+	}
+
+	if utf8.RuneCountInString(u.LastName) > model.UserLastNameMaxRunes {
+		logger.Warnf("User %s last name exceeds the maximum length. It will be truncated when imported.", u.Username)
+		u.LastName = truncateRunes(u.LastName, model.UserLastNameMaxRunes)
+	}
+
+	if utf8.RuneCountInString(u.Position) > model.UserPositionMaxRunes {
+		logger.Warnf("User %s position exceeds the maximum length. It will be truncated when imported.", u.Username)
+		u.Position = truncateRunes(u.Position, model.UserPositionMaxRunes)
+	}
 }
 
 type IntermediatePost struct {

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -545,20 +545,11 @@ func TestIntermediateUserSanitise(t *testing.T) {
 		expectedLastName := strings.Repeat("b", 64)
 		expectedPosition := strings.Repeat("c", 128)
 
-		exitCode := -1
-		exitFunc = func(code int) {
-			exitCode = code
-		}
-		defer func() {
-			exitFunc = os.Exit
-		}()
-
 		user.Sanitise(log.New(), "", false)
 
 		assert.Equal(t, expectedFirstName, user.FirstName)
 		assert.Equal(t, expectedLastName, user.LastName)
 		assert.Equal(t, expectedPosition, user.Position)
-		require.Equal(t, -1, exitCode)
 	})
 }
 

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -531,6 +531,35 @@ func TestIntermediateUserSanitise(t *testing.T) {
 		require.Equal(t, expectedEmail, user.Email)
 		require.Equal(t, -1, exitCode)
 	})
+
+	t.Run("Properties should respect the max length", func(t *testing.T) {
+		user := &IntermediateUser{
+			Username:  "test-username",
+			Email:     "test-email@otherdomain.com",
+			FirstName: strings.Repeat("a", 70),
+			LastName:  strings.Repeat("b", 70),
+			Position:  strings.Repeat("c", 400),
+		}
+
+		expectedFirstName := strings.Repeat("a", 64)
+		expectedLastName := strings.Repeat("b", 64)
+		expectedPosition := strings.Repeat("c", 128)
+
+		exitCode := -1
+		exitFunc = func(code int) {
+			exitCode = code
+		}
+		defer func() {
+			exitFunc = os.Exit
+		}()
+
+		user.Sanitise(log.New(), "", false)
+
+		assert.Equal(t, expectedFirstName, user.FirstName)
+		assert.Equal(t, expectedLastName, user.LastName)
+		assert.Equal(t, expectedPosition, user.Position)
+		require.Equal(t, -1, exitCode)
+	})
 }
 
 func TestTransformUsers(t *testing.T) {

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -536,14 +536,14 @@ func TestIntermediateUserSanitise(t *testing.T) {
 		user := &IntermediateUser{
 			Username:  "test-username",
 			Email:     "test-email@otherdomain.com",
-			FirstName: strings.Repeat("a", 70),
-			LastName:  strings.Repeat("b", 70),
-			Position:  strings.Repeat("c", 400),
+			FirstName: strings.Repeat("a", model.UserFirstNameMaxRunes+4),
+			LastName:  strings.Repeat("b", model.UserLastNameMaxRunes+4),
+			Position:  strings.Repeat("c", model.UserPositionMaxRunes+4),
 		}
 
-		expectedFirstName := strings.Repeat("a", 64)
-		expectedLastName := strings.Repeat("b", 64)
-		expectedPosition := strings.Repeat("c", 128)
+		expectedFirstName := strings.Repeat("a", model.UserFirstNameMaxRunes)
+		expectedLastName := strings.Repeat("b", model.UserLastNameMaxRunes)
+		expectedPosition := strings.Repeat("c", model.UserPositionMaxRunes)
 
 		user.Sanitise(log.New(), "", false)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Adds truncation for FirstName, LastName and Position fields of the User model.

#### Ticket Link

Closes #51
