### PR TITLE
[MM-48092] WIP: enable importing slack bots as mattermost bots

### DIFF
--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -107,24 +107,35 @@ func GetImportLineFromUser(user *IntermediateUser, team string) *imports.LineImp
 		})
 	}
 
-	return &imports.LineImportData{
-		Type: "user",
-		User: &imports.UserImportData{
-			Username:  model.NewString(user.Username),
-			Email:     model.NewString(user.Email),
-			Nickname:  model.NewString(""),
-			FirstName: model.NewString(user.FirstName),
-			LastName:  model.NewString(user.LastName),
-			Position:  model.NewString(user.Position),
-			Roles:     model.NewString(model.SystemUserRoleId),
-			Teams: &[]imports.UserTeamImportData{
-				{
-					Name:     model.NewString(team),
-					Channels: &channelMemberships,
-					Roles:    model.NewString(model.TeamUserRoleId),
+	switch {
+	case user.IsBot:
+		return &imports.LineImportData{
+			Type: "bot",
+			Bot: &imports.BotImportData{
+				Username:    model.NewString(user.Username),
+				DisplayName: model.NewString(user.FirstName),
+			},
+		}
+	default:
+		return &imports.LineImportData{
+			Type: "user",
+			User: &imports.UserImportData{
+				Username:  model.NewString(user.Username),
+				Email:     model.NewString(user.Email),
+				Nickname:  model.NewString(""),
+				FirstName: model.NewString(user.FirstName),
+				LastName:  model.NewString(user.LastName),
+				Position:  model.NewString(user.Position),
+				Roles:     model.NewString(model.SystemUserRoleId),
+				Teams: &[]imports.UserTeamImportData{
+					{
+						Name:     model.NewString(team),
+						Channels: &channelMemberships,
+						Roles:    model.NewString(model.TeamUserRoleId),
+					},
 				},
 			},
-		},
+		}
 	}
 }
 

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -84,6 +84,7 @@ type IntermediateUser struct {
 	Password    string   `json:"password"`
 	Memberships []string `json:"memberships"`
 	DeleteAt    int64    `json:"delete_at"`
+	IsBot       bool     `json:"is_bot"`
 }
 
 func (u *IntermediateUser) Sanitise(logger log.FieldLogger, defaultEmailDomain string, skipEmptyEmails bool) {
@@ -161,6 +162,7 @@ func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, de
 			Email:     user.Profile.Email,
 			Password:  model.NewId(),
 			DeleteAt:  deleteAt,
+			IsBot:     user.IsBot,
 		}
 
 		t.Logger.Debugf("TransformUsers: newUser IntermediateUser struct: %+v", newUser)


### PR DESCRIPTION

#### Summary
Enable transform bot users as bots. The build is expected to fail, it's waiting https://github.com/mattermost/mattermost/pull/28214 to be merged. Then, we should update the `mattermost/imports` module.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48092

