### PR TITLE
Respect slack display channel names

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -236,7 +236,7 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 		newChannel := &IntermediateChannel{
 			OriginalName: getOriginalName(channel),
 			Name:         name,
-			DisplayName:  name,
+			DisplayName:  channel.Name,
 			Members:      validMembers,
 			Purpose:      channel.Purpose.Value,
 			Header:       channel.Topic.Value,


### PR DESCRIPTION
#### Summary

Weird channel names were silently changed to c01xyz2345 since the very initial commit.
Such names are common in non-English languages, where accented or otherwise modified letters appear in 30% of words.

I believe the patch is pretty self-explanatory.