### PR TITLE
Minor check for nil value.

### DIFF
--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -771,7 +771,7 @@ func (t *Transformer) TransformPosts(slackExport *SlackExport, attachmentsDir st
 				// all huddles are owned by USLACKBOT, but the room has a CreatedBy prop.
 				// this lets us get the actual user who created the huddle and fit with how Mattermost works.
 				poster := post.User
-				if len(post.Room.CreatedBy) > 0 {
+				if post.Room != nil && len(post.Room.CreatedBy) > 0 {
 					poster = post.Room.CreatedBy
 				}
 


### PR DESCRIPTION
I ran into issue migrating my 10 years old slack backup into mattermost, adding this check seemed to have fixed the issue.
