### PR TITLE
Deprecation of 'go get' for installing executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ set of providers into a Mattermost compatible export file.
 To install the project in your `$GOPATH`, just run:
 
 ```sh
-go get -u github.com/mattermost/mmetl
+go install github.com/mattermost/mmetl@latest
 ```
 
 ## Usage


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://go.dev/doc/go-get-install-deprecation


