### PR TITLE
fix: show correct version in `mmetl version` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO_PACKAGES=$(shell go list ./...)
 GO ?= $(shell command -v go 2> /dev/null)
 BUILD_HASH ?= $(shell git rev-parse HEAD)
-BUILD_VERSION ?= $(shell git ls-remote --tags --refs https://github.com/mattermost/mmetl.git | tail -n1 | sed 's/.*\///')
+BUILD_VERSION ?= $(shell git ls-remote --tags --refs https://github.com/mattermost/mmetl.git | sed 's/.*\///' | sort -V | tail -n1)
 
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.BuildHash=$(BUILD_HASH)"
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.Version=$(BUILD_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO_PACKAGES=$(shell go list ./...)
 GO ?= $(shell command -v go 2> /dev/null)
 BUILD_HASH ?= $(shell git rev-parse HEAD)
-BUILD_VERSION ?= $(shell git ls-remote --tags --refs https://github.com/mattermost/mmetl.git | sed 's/.*\///' | sort -V | tail -n1)
+BUILD_VERSION ?= $(shell git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='version:refname' https://github.com/mattermost/mmetl.git | tail -n1 | sed 's/.*\///')
 
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.BuildHash=$(BUILD_HASH)"
 LDFLAGS += -X "github.com/mattermost/mmetl/commands.Version=$(BUILD_VERSION)"

--- a/commands/version.go
+++ b/commands/version.go
@@ -49,7 +49,7 @@ func getBuildHash() string {
 		return BuildHash
 	}
 
-	if info, ok := debug.ReadBuildInfo(); ok {
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
 				return setting.Value

--- a/commands/version.go
+++ b/commands/version.go
@@ -26,6 +26,9 @@ func init() {
 	RootCmd.AddCommand(VersionCmd)
 }
 
+// getVersion returns the version string, preferring the value set via ldflags,
+// falling back to the module version from Go's build info (e.g. when installed
+// via `go install`), and defaulting to "dev" for local development builds.
 func getVersion() string {
 	if Version != "" {
 		return Version
@@ -38,6 +41,9 @@ func getVersion() string {
 	return "dev"
 }
 
+// getBuildHash returns the build hash, preferring the value set via ldflags,
+// falling back to the VCS revision from Go's build info, and defaulting to
+// "dev mode" for local development builds.
 func getBuildHash() string {
 	if BuildHash != "" {
 		return BuildHash

--- a/commands/version.go
+++ b/commands/version.go
@@ -13,6 +13,10 @@ import (
 var (
 	BuildHash = ""
 	Version   = ""
+
+	// readBuildInfo is an indirection for runtime/debug.ReadBuildInfo so
+	// tests can inject controlled stubs.
+	readBuildInfo = debug.ReadBuildInfo
 )
 
 var VersionCmd = &cobra.Command{
@@ -34,7 +38,7 @@ func getVersion() string {
 		return Version
 	}
 
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+	if info, ok := readBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
 		return info.Main.Version
 	}
 
@@ -49,7 +53,7 @@ func getBuildHash() string {
 		return BuildHash
 	}
 
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+	if info, ok := readBuildInfo(); ok && info.Main.Version != "(devel)" {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
 				return setting.Value

--- a/commands/version.go
+++ b/commands/version.go
@@ -5,13 +5,14 @@ package commands
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	BuildHash = "dev mode"
-	Version   = "0.1.0"
+	BuildHash = ""
+	Version   = ""
 )
 
 var VersionCmd = &cobra.Command{
@@ -25,6 +26,34 @@ func init() {
 	RootCmd.AddCommand(VersionCmd)
 }
 
+func getVersion() string {
+	if Version != "" {
+		return Version
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+
+	return "dev"
+}
+
+func getBuildHash() string {
+	if BuildHash != "" {
+		return BuildHash
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
+	}
+
+	return "dev mode"
+}
+
 func versionCmdF(cmd *cobra.Command, args []string) {
-	fmt.Println("mmetl " + Version + " -- " + BuildHash)
+	fmt.Println("mmetl " + getVersion() + " -- " + getBuildHash())
 }

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersion(t *testing.T) {
+	t.Run("returns ldflags value when set", func(t *testing.T) {
+		original := Version
+		t.Cleanup(func() { Version = original })
+
+		Version = "v1.2.3"
+		assert.Equal(t, "v1.2.3", getVersion())
+	})
+
+	t.Run("returns dev when ldflags not set", func(t *testing.T) {
+		original := Version
+		t.Cleanup(func() { Version = original })
+
+		// In test binaries, info.Main.Version is "(devel)",
+		// so getVersion should fall through to "dev".
+		Version = ""
+		assert.Equal(t, "dev", getVersion())
+	})
+}
+
+func TestGetBuildHash(t *testing.T) {
+	t.Run("returns ldflags value when set", func(t *testing.T) {
+		original := BuildHash
+		t.Cleanup(func() { BuildHash = original })
+
+		BuildHash = "abc123"
+		assert.Equal(t, "abc123", getBuildHash())
+	})
+
+	t.Run("returns dev mode when ldflags not set", func(t *testing.T) {
+		original := BuildHash
+		t.Cleanup(func() { BuildHash = original })
+
+		// In test binaries, info.Main.Version is "(devel)",
+		// so getBuildHash should skip vcs.revision and return "dev mode".
+		BuildHash = ""
+		assert.Equal(t, "dev mode", getBuildHash())
+	})
+}

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,40 @@ func TestGetVersion(t *testing.T) {
 		Version = ""
 		assert.Equal(t, "dev", getVersion())
 	})
+
+	t.Run("returns module version from build info", func(t *testing.T) {
+		origVersion := Version
+		origReader := readBuildInfo
+		t.Cleanup(func() {
+			Version = origVersion
+			readBuildInfo = origReader
+		})
+
+		Version = ""
+		readBuildInfo = func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.9.0"},
+			}, true
+		}
+		assert.Equal(t, "v0.9.0", getVersion())
+	})
+
+	t.Run("returns dev when build info version is (devel)", func(t *testing.T) {
+		origVersion := Version
+		origReader := readBuildInfo
+		t.Cleanup(func() {
+			Version = origVersion
+			readBuildInfo = origReader
+		})
+
+		Version = ""
+		readBuildInfo = func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+			}, true
+		}
+		assert.Equal(t, "dev", getVersion())
+	})
 }
 
 func TestGetBuildHash(t *testing.T) {
@@ -45,6 +80,46 @@ func TestGetBuildHash(t *testing.T) {
 		// In test binaries, info.Main.Version is "(devel)",
 		// so getBuildHash should skip vcs.revision and return "dev mode".
 		BuildHash = ""
+		assert.Equal(t, "dev mode", getBuildHash())
+	})
+
+	t.Run("returns vcs.revision from build info", func(t *testing.T) {
+		origHash := BuildHash
+		origReader := readBuildInfo
+		t.Cleanup(func() {
+			BuildHash = origHash
+			readBuildInfo = origReader
+		})
+
+		BuildHash = ""
+		readBuildInfo = func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.9.0"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "deadbeef1234"},
+				},
+			}, true
+		}
+		assert.Equal(t, "deadbeef1234", getBuildHash())
+	})
+
+	t.Run("returns dev mode when version is (devel)", func(t *testing.T) {
+		origHash := BuildHash
+		origReader := readBuildInfo
+		t.Cleanup(func() {
+			BuildHash = origHash
+			readBuildInfo = origReader
+		})
+
+		BuildHash = ""
+		readBuildInfo = func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "deadbeef1234"},
+				},
+			}, true
+		}
 		assert.Equal(t, "dev mode", getBuildHash())
 	})
 }


### PR DESCRIPTION
## Summary
- Use `runtime/debug.BuildInfo` to resolve version and build hash when ldflags are not set (e.g. when installed via `go install`). Previously the command always showed hardcoded `0.1.0 – dev mode` unless built with `make`.
- Fix `BUILD_VERSION` in Makefile to use `sort -V` for proper semantic version ordering of remote tags.

Fixes: https://mattermost.atlassian.net/browse/MM-66780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Version selection now picks the latest semantic tag for more predictable release values.
  * Runtime resolution added for version and build identifiers, with sensible fallbacks when build metadata is absent.
  * CLI version output now consistently displays the resolved version and build information.

* **Tests**
  * Added unit tests covering runtime resolution and fallback behavior for version and build identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->