### PR TITLE
feat: import archived Slack channels as archived Mattermost channels

### DIFF
--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -685,8 +685,10 @@ func TestTransformSlackE2EBotImport(t *testing.T) {
 	// unresolvable owner. This test documents that behaviour so we notice if
 	// the server-side semantics ever change.
 	t.Run("import succeeds with non-existent bot owner username", func(t *testing.T) {
-		th := testhelper.SetupHelper(t)
-		defer th.TearDown()
+		// This subtest needs its own isolated Mattermost instance because the
+		// bot owner validation test must run on a clean server state.
+		subTH := testhelper.SetupHelper(t)
+		defer subTH.TearDown()
 
 		ctx := context.Background()
 		tempDir := t.TempDir()
@@ -699,7 +701,7 @@ func TestTransformSlackE2EBotImport(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create team
-		team := th.CreateTeam(ctx, teamName, "Bad Owner E2E Team")
+		team := subTH.CreateTeam(ctx, teamName, "Bad Owner E2E Team")
 		require.NotNil(t, team)
 
 		// Run transform with a --bot-owner that does not exist in Mattermost
@@ -721,14 +723,14 @@ func TestTransformSlackE2EBotImport(t *testing.T) {
 		defer os.Remove(transformLogFile)
 
 		// Import succeeds even though the owner username doesn't exist
-		err = th.ImportBulkData(ctx, mmExportPath)
+		err = subTH.ImportBulkData(ctx, mmExportPath)
 		require.NoError(t, err, "import should succeed even with non-existent bot owner")
 
 		// Bots should still be created with correct properties
-		deployBot := th.AssertBotExists(ctx, "deploybot")
+		deployBot := subTH.AssertBotExists(ctx, "deploybot")
 		assert.Equal(t, "Deploy Bot", deployBot.DisplayName)
 
-		alertBot := th.AssertBotExists(ctx, "alertbot")
+		alertBot := subTH.AssertBotExists(ctx, "alertbot")
 		assert.Equal(t, "Alert Bot", alertBot.DisplayName)
 
 		// OwnerId is the raw username string (plugin-owner fallback),
@@ -737,5 +739,83 @@ func TestTransformSlackE2EBotImport(t *testing.T) {
 			"bot owner should be the raw username string when the user doesn't exist")
 		assert.Equal(t, fakeOwner, alertBot.OwnerId,
 			"bot owner should be the raw username string when the user doesn't exist")
+	})
+
+	t.Run("archived channels are imported as archived in Mattermost", func(t *testing.T) {
+		// Reuses the outer th; isolation is provided by the unique team name.
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		slackExportPath := filepath.Join(tempDir, "slack_export.zip")
+		mmExportPath := filepath.Join(tempDir, "mattermost_import.jsonl")
+		teamName := uniqueTeamName("archived")
+
+		// 1. Create Slack export with an archived channel
+		err := testhelper.ExportWithArchivedChannels().Build(slackExportPath)
+		require.NoError(t, err, "failed to create Slack export fixture with archived channels")
+
+		// 2. Create team
+		team := th.CreateTeam(ctx, teamName, "Archived Channels E2E Team")
+		require.NotNil(t, team)
+
+		// 3. Run transform
+		args := []string{
+			"transform", "slack",
+			"--team", teamName,
+			"--file", slackExportPath,
+			"--output", mmExportPath,
+			"--skip-attachments",
+		}
+
+		c := commands.RootCmd
+		resetCobraFlags(c)
+		c.SetArgs(args)
+		err = c.Execute()
+		require.NoError(t, err, "transform command should succeed")
+
+		// 4. Verify the JSONL contains deleted_at for the archived channel
+		t.Log("Checking JSONL output for archived channel...")
+		outputBytes, err := os.ReadFile(mmExportPath)
+		require.NoError(t, err)
+
+		var foundArchivedChannel bool
+		for _, line := range strings.Split(string(outputBytes), "\n") {
+			if line == "" {
+				continue
+			}
+			var importLine map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(line), &importLine))
+			if string(importLine["type"]) != `"channel"` {
+				continue
+			}
+			var channel struct {
+				Name      string `json:"name"`
+				DeletedAt *int64 `json:"deleted_at"`
+			}
+			require.NoError(t, json.Unmarshal(importLine["channel"], &channel))
+			if channel.Name == "old-project" {
+				require.NotNil(t, channel.DeletedAt, "archived channel should have deleted_at set")
+				assert.Greater(t, *channel.DeletedAt, int64(0), "deleted_at should be positive")
+				foundArchivedChannel = true
+			}
+		}
+		require.True(t, foundArchivedChannel, "should find archived channel 'old-project' in JSONL output")
+
+		// 5. Validate and import
+		t.Log("Validating import file...")
+		th.ValidateImportFileOrFail(ctx, mmExportPath)
+
+		t.Log("Importing data into Mattermost...")
+		err = th.ImportBulkData(ctx, mmExportPath)
+		require.NoError(t, err, "import should succeed")
+
+		// 6. Verify active channel exists normally
+		t.Log("Verifying active channel is not archived...")
+		generalChannel := th.AssertChannelExists(ctx, teamName, "general")
+		assert.Equal(t, int64(0), generalChannel.DeleteAt, "general channel should not be archived")
+
+		// 7. Verify the archived channel is archived in Mattermost
+		t.Log("Verifying archived channel is archived in Mattermost...")
+		archivedChannel := th.AssertChannelIsArchived(ctx, teamName, "old-project")
+		assert.Greater(t, archivedChannel.DeleteAt, int64(0), "old-project channel should be archived (DeleteAt > 0)")
 	})
 }

--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -772,6 +772,7 @@ func TestTransformSlackE2EBotImport(t *testing.T) {
 		c.SetArgs(args)
 		err = c.Execute()
 		require.NoError(t, err, "transform command should succeed")
+		defer os.Remove(transformLogFile)
 
 		// 4. Verify the JSONL contains deleted_at for the archived channel
 		t.Log("Checking JSONL output for archived channel...")

--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -148,6 +148,10 @@ func GetImportLineFromChannel(team string, channel *IntermediateChannel) *import
 		Purpose:     &channel.Purpose,
 	}
 
+	if channel.DeleteAt > 0 {
+		newChannel.DeletedAt = model.NewPointer(channel.DeleteAt)
+	}
+
 	return &imports.LineImportData{
 		Type:    "channel",
 		Channel: newChannel,

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -535,3 +535,57 @@ func TestExportUsersWithBots(t *testing.T) {
 		assert.Equal(t, "user", line0.Type)
 	})
 }
+
+func TestGetImportLineFromChannel(t *testing.T) {
+	t.Run("Active channel has no deleted_at in output", func(t *testing.T) {
+		channel := &IntermediateChannel{
+			Name:        "general",
+			DisplayName: "General",
+			Type:        model.ChannelTypeOpen,
+			Header:      "Welcome",
+			Purpose:     "General discussion",
+			DeleteAt:    0,
+		}
+
+		line := GetImportLineFromChannel("myteam", channel)
+
+		assert.Equal(t, "channel", line.Type)
+		require.NotNil(t, line.Channel)
+		assert.Equal(t, "myteam", *line.Channel.Team)
+		assert.Equal(t, "general", *line.Channel.Name)
+		assert.Equal(t, "General", *line.Channel.DisplayName)
+		assert.Nil(t, line.Channel.DeletedAt)
+	})
+
+	t.Run("Archived channel has deleted_at set in output", func(t *testing.T) {
+		channel := &IntermediateChannel{
+			Name:        "old-project",
+			DisplayName: "Old Project",
+			Type:        model.ChannelTypeOpen,
+			Header:      "",
+			Purpose:     "",
+			DeleteAt:    1620000000000,
+		}
+
+		line := GetImportLineFromChannel("myteam", channel)
+
+		assert.Equal(t, "channel", line.Type)
+		require.NotNil(t, line.Channel)
+		require.NotNil(t, line.Channel.DeletedAt)
+		assert.Equal(t, int64(1620000000000), *line.Channel.DeletedAt)
+	})
+
+	t.Run("Archived channel with sentinel value has deleted_at set", func(t *testing.T) {
+		channel := &IntermediateChannel{
+			Name:        "another-old",
+			DisplayName: "Another Old",
+			Type:        model.ChannelTypePrivate,
+			DeleteAt:    1,
+		}
+
+		line := GetImportLineFromChannel("myteam", channel)
+
+		require.NotNil(t, line.Channel.DeletedAt)
+		assert.Equal(t, int64(1), *line.Channel.DeletedAt)
+	})
+}

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -323,6 +323,7 @@ func getOriginalName(channel SlackChannel) string {
 func (t *Transformer) TransformChannels(channels []SlackChannel) []*IntermediateChannel {
 	resultChannels := []*IntermediateChannel{}
 	for _, channel := range channels {
+		originalType := channel.Type
 		validMembers := t.filterValidMembers(channel.Members, t.Intermediate.UsersById)
 		if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && len(validMembers) <= 1 {
 			t.Logger.Warnf("Bulk export for direct channels containing a single member is not supported. Not importing channel %s", channel.Name)
@@ -349,7 +350,7 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 		// Only public and private channels support DeletedAt in the Mattermost import
 		// format. Direct and group channels use a separate import type (direct_channel)
 		// that has no DeletedAt field, so archiving those is not supported.
-		if channel.IsArchived && channel.Type != model.ChannelTypeDirect && channel.Type != model.ChannelTypeGroup {
+		if channel.IsArchived && originalType != model.ChannelTypeDirect && originalType != model.ChannelTypeGroup {
 			if channel.Updated > 0 {
 				// Use the Slack "updated" timestamp as a best-effort approximation of
 				// the archive time. Slack exports do not include a dedicated archive timestamp.

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -32,6 +32,7 @@ type IntermediateChannel struct {
 	Header           string            `json:"header"`
 	Topic            string            `json:"topic"`
 	Type             model.ChannelType `json:"type"`
+	DeleteAt         int64             `json:"delete_at"`
 }
 
 func (c *IntermediateChannel) Sanitise(logger log.FieldLogger) {
@@ -251,6 +252,19 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 			Purpose:      channel.Purpose.Value,
 			Header:       channel.Topic.Value,
 			Type:         channel.Type,
+		}
+
+		// Only public and private channels support DeletedAt in the Mattermost import
+		// format. Direct and group channels use a separate import type (direct_channel)
+		// that has no DeletedAt field, so archiving those is not supported.
+		if channel.IsArchived && channel.Type != model.ChannelTypeDirect && channel.Type != model.ChannelTypeGroup {
+			if channel.Updated > 0 {
+				// Use the Slack "updated" timestamp as a best-effort approximation of
+				// the archive time. Slack exports do not include a dedicated archive timestamp.
+				newChannel.DeleteAt = channel.Updated
+			} else {
+				newChannel.DeleteAt = model.GetMillis()
+			}
 		}
 
 		newChannel.Sanitise(t.Logger)

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -323,6 +323,8 @@ func getOriginalName(channel SlackChannel) string {
 func (t *Transformer) TransformChannels(channels []SlackChannel) []*IntermediateChannel {
 	resultChannels := []*IntermediateChannel{}
 	for _, channel := range channels {
+		// Capture the original type before the oversized-MPIM rewrite below,
+		// so the archive gate checks against the real Slack channel type.
 		originalType := channel.Type
 		validMembers := t.filterValidMembers(channel.Members, t.Intermediate.UsersById)
 		if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && len(validMembers) <= 1 {
@@ -352,12 +354,16 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 		// that has no DeletedAt field, so archiving those is not supported.
 		if channel.IsArchived && originalType != model.ChannelTypeDirect && originalType != model.ChannelTypeGroup {
 			if channel.Updated > 0 {
-				// Use the Slack "updated" timestamp as a best-effort approximation of
-				// the archive time. Slack exports do not include a dedicated archive timestamp.
+				// Use the Slack "updated" timestamp (already in milliseconds) as a
+				// best-effort approximation of the archive time. Slack exports do not
+				// include a dedicated archive timestamp.
 				newChannel.DeleteAt = channel.Updated
 			} else {
+				t.Logger.Warnf("Archived channel %s has no updated timestamp; using current time as DeleteAt", channel.Name)
 				newChannel.DeleteAt = model.GetMillis()
 			}
+		} else if channel.IsArchived {
+			t.Logger.Warnf("Channel %s is archived in Slack but is a %s channel; Mattermost import does not support archiving this channel type", channel.Name, originalType)
 		}
 
 		newChannel.Sanitise(t.Logger)

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -323,9 +323,6 @@ func getOriginalName(channel SlackChannel) string {
 func (t *Transformer) TransformChannels(channels []SlackChannel) []*IntermediateChannel {
 	resultChannels := []*IntermediateChannel{}
 	for _, channel := range channels {
-		// Capture the original type before the oversized-MPIM rewrite below,
-		// so the archive gate checks against the real Slack channel type.
-		originalType := channel.Type
 		validMembers := t.filterValidMembers(channel.Members, t.Intermediate.UsersById)
 		if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && len(validMembers) <= 1 {
 			t.Logger.Warnf("Bulk export for direct channels containing a single member is not supported. Not importing channel %s", channel.Name)
@@ -349,10 +346,11 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 			Created:      channel.Created,
 		}
 
-		// Only public and private channels support DeletedAt in the Mattermost import
+		// Public and private channels support DeletedAt in the Mattermost import
 		// format. Direct and group channels use a separate import type (direct_channel)
-		// that has no DeletedAt field, so archiving those is not supported.
-		if channel.IsArchived && originalType != model.ChannelTypeDirect && originalType != model.ChannelTypeGroup {
+		// that has no DeletedAt field, so archiving those is not supported. Oversized
+		// MPIMs are rewritten to ChannelTypePrivate above, so they're eligible here.
+		if channel.IsArchived && channel.Type != model.ChannelTypeDirect && channel.Type != model.ChannelTypeGroup {
 			if channel.Updated > 0 {
 				// Use the Slack "updated" timestamp (already in milliseconds) as a
 				// best-effort approximation of the archive time. Slack exports do not
@@ -362,8 +360,6 @@ func (t *Transformer) TransformChannels(channels []SlackChannel) []*Intermediate
 				t.Logger.Warnf("Archived channel %s has no updated timestamp; using current time as DeleteAt", channel.Name)
 				newChannel.DeleteAt = model.GetMillis()
 			}
-		} else if channel.IsArchived {
-			t.Logger.Warnf("Channel %s is archived in Slack but is a %s channel; Mattermost import does not support archiving this channel type", channel.Name, originalType)
 		}
 
 		newChannel.Sanitise(t.Logger)

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -2099,6 +2099,37 @@ func TestTransformArchivedChannels(t *testing.T) {
 		assert.Equal(t, model.ChannelTypePrivate, result[0].Type)
 	})
 
+	t.Run("Oversized archived MPIM rewritten to private does not get DeleteAt set", func(t *testing.T) {
+		// An MPIM with more members than ChannelGroupMaxUsers (8) gets rewritten
+		// to ChannelTypePrivate. The archive gate must use the original type so
+		// this channel does NOT receive a DeleteAt value.
+		bigTransformer := NewTransformer("test", log.New())
+		bigTransformer.Intermediate.UsersById = make(map[string]*IntermediateUser)
+		members := make([]string, model.ChannelGroupMaxUsers+1)
+		for i := range members {
+			id := fmt.Sprintf("u%d", i)
+			members[i] = id
+			bigTransformer.Intermediate.UsersById[id] = &IntermediateUser{}
+		}
+
+		channels := []SlackChannel{
+			{
+				Id:         "G999",
+				Name:       "",
+				Members:    members,
+				Purpose:    SlackChannelSub{Value: "big-group-purpose"},
+				IsArchived: true,
+				Updated:    1620000000000,
+				Type:       model.ChannelTypeGroup,
+			},
+		}
+
+		result := bigTransformer.TransformChannels(channels)
+		require.Len(t, result, 1)
+		assert.Equal(t, model.ChannelTypePrivate, result[0].Type, "oversized MPIM should be rewritten to private")
+		assert.Equal(t, int64(0), result[0].DeleteAt, "rewritten MPIM should not have DeleteAt set")
+	})
+
 	t.Run("Archived direct or group channels do not get DeleteAt set", func(t *testing.T) {
 		directChannel := SlackChannel{
 			Id:         "D001",

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -1735,3 +1735,118 @@ func TestTransformPosts(t *testing.T) {
 		// This test ensures that sorting works correctly even with split chunks
 	})
 }
+
+func TestTransformArchivedChannels(t *testing.T) {
+	slackTransformer := NewTransformer("test", log.New())
+	slackTransformer.Intermediate.UsersById = map[string]*IntermediateUser{"m1": {}, "m2": {}, "m3": {}}
+
+	t.Run("Active channel has DeleteAt of zero", func(t *testing.T) {
+		channels := []SlackChannel{
+			{
+				Id:         "id1",
+				Name:       "active-channel",
+				Members:    []string{"m1", "m2", "m3"},
+				Purpose:    SlackChannelSub{Value: "purpose"},
+				Topic:      SlackChannelSub{Value: "topic"},
+				IsArchived: false,
+				Type:       model.ChannelTypeOpen,
+			},
+		}
+
+		result := slackTransformer.TransformChannels(channels)
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(0), result[0].DeleteAt)
+	})
+
+	t.Run("Archived channel with updated timestamp uses that timestamp", func(t *testing.T) {
+		channels := []SlackChannel{
+			{
+				Id:         "id2",
+				Name:       "archived-channel",
+				Members:    []string{"m1", "m2", "m3"},
+				Purpose:    SlackChannelSub{Value: "purpose"},
+				Topic:      SlackChannelSub{Value: "topic"},
+				IsArchived: true,
+				Updated:    1620000000000,
+				Type:       model.ChannelTypeOpen,
+			},
+		}
+
+		result := slackTransformer.TransformChannels(channels)
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(1620000000000), result[0].DeleteAt)
+	})
+
+	t.Run("Archived channel without updated timestamp uses current time", func(t *testing.T) {
+		before := model.GetMillis()
+		channels := []SlackChannel{
+			{
+				Id:         "id3",
+				Name:       "archived-no-ts",
+				Members:    []string{"m1", "m2", "m3"},
+				Purpose:    SlackChannelSub{Value: "purpose"},
+				Topic:      SlackChannelSub{Value: "topic"},
+				IsArchived: true,
+				Updated:    0,
+				Type:       model.ChannelTypeOpen,
+			},
+		}
+
+		result := slackTransformer.TransformChannels(channels)
+		after := model.GetMillis()
+
+		require.Len(t, result, 1)
+		assert.GreaterOrEqual(t, result[0].DeleteAt, before)
+		assert.LessOrEqual(t, result[0].DeleteAt, after)
+	})
+
+	t.Run("Archived private channel preserves archived state", func(t *testing.T) {
+		channels := []SlackChannel{
+			{
+				Id:         "id4",
+				Name:       "archived-private",
+				Members:    []string{"m1", "m2", "m3"},
+				Purpose:    SlackChannelSub{Value: "purpose"},
+				Topic:      SlackChannelSub{Value: "topic"},
+				IsArchived: true,
+				Updated:    1630000000000,
+				Type:       model.ChannelTypePrivate,
+			},
+		}
+
+		result := slackTransformer.TransformChannels(channels)
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(1630000000000), result[0].DeleteAt)
+		assert.Equal(t, model.ChannelTypePrivate, result[0].Type)
+	})
+
+	t.Run("Archived direct or group channels do not get DeleteAt set", func(t *testing.T) {
+		directChannel := SlackChannel{
+			Id:         "D001",
+			Name:       "archived-dm",
+			Members:    []string{"m1", "m2"},
+			IsArchived: true,
+			Updated:    1620000000000,
+			Type:       model.ChannelTypeDirect,
+		}
+		groupChannel := SlackChannel{
+			Id:         "G001",
+			Name:       "archived-group",
+			Members:    []string{"m1", "m2", "m3"},
+			IsArchived: true,
+			Updated:    1620000000000,
+			Type:       model.ChannelTypeGroup,
+		}
+
+		dmResult := slackTransformer.TransformChannels([]SlackChannel{directChannel})
+		// Direct channels with <= 1 valid member are dropped; with 2 they pass through
+		if len(dmResult) > 0 {
+			assert.Equal(t, int64(0), dmResult[0].DeleteAt, "direct channels should not have DeleteAt set")
+		}
+
+		groupResult := slackTransformer.TransformChannels([]SlackChannel{groupChannel})
+		if len(groupResult) > 0 {
+			assert.Equal(t, int64(0), groupResult[0].DeleteAt, "group channels should not have DeleteAt set")
+		}
+	})
+}

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -2099,10 +2099,10 @@ func TestTransformArchivedChannels(t *testing.T) {
 		assert.Equal(t, model.ChannelTypePrivate, result[0].Type)
 	})
 
-	t.Run("Oversized archived MPIM rewritten to private does not get DeleteAt set", func(t *testing.T) {
+	t.Run("Oversized archived MPIM rewritten to private retains DeleteAt", func(t *testing.T) {
 		// An MPIM with more members than ChannelGroupMaxUsers (8) gets rewritten
-		// to ChannelTypePrivate. The archive gate must use the original type so
-		// this channel does NOT receive a DeleteAt value.
+		// to ChannelTypePrivate and is exported as a regular private channel,
+		// which supports DeletedAt — so the archived state must be preserved.
 		bigTransformer := NewTransformer("test", log.New())
 		bigTransformer.Intermediate.UsersById = make(map[string]*IntermediateUser)
 		members := make([]string, model.ChannelGroupMaxUsers+1)
@@ -2127,7 +2127,7 @@ func TestTransformArchivedChannels(t *testing.T) {
 		result := bigTransformer.TransformChannels(channels)
 		require.Len(t, result, 1)
 		assert.Equal(t, model.ChannelTypePrivate, result[0].Type, "oversized MPIM should be rewritten to private")
-		assert.Equal(t, int64(0), result[0].DeleteAt, "rewritten MPIM should not have DeleteAt set")
+		assert.Equal(t, int64(1620000000000), result[0].DeleteAt, "rewritten MPIM should retain DeleteAt")
 	})
 
 	t.Run("Archived direct or group channels do not get DeleteAt set", func(t *testing.T) {

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -2118,14 +2118,11 @@ func TestTransformArchivedChannels(t *testing.T) {
 		}
 
 		dmResult := slackTransformer.TransformChannels([]SlackChannel{directChannel})
-		// Direct channels with <= 1 valid member are dropped; with 2 they pass through
-		if len(dmResult) > 0 {
-			assert.Equal(t, int64(0), dmResult[0].DeleteAt, "direct channels should not have DeleteAt set")
-		}
+		require.Len(t, dmResult, 1, "direct channel with 2 valid members should be transformed")
+		assert.Equal(t, int64(0), dmResult[0].DeleteAt, "direct channels should not have DeleteAt set")
 
 		groupResult := slackTransformer.TransformChannels([]SlackChannel{groupChannel})
-		if len(groupResult) > 0 {
-			assert.Equal(t, int64(0), groupResult[0].DeleteAt, "group channels should not have DeleteAt set")
-		}
+		require.Len(t, groupResult, 1, "group channel with 3 valid members should be transformed")
+		assert.Equal(t, int64(0), groupResult[0].DeleteAt, "group channels should not have DeleteAt set")
 	})
 }

--- a/services/slack/models.go
+++ b/services/slack/models.go
@@ -8,13 +8,15 @@ import (
 
 // SlackChannel represents a Slack channel in the export
 type SlackChannel struct {
-	Id      string            `json:"id"`
-	Name    string            `json:"name"`
-	Creator string            `json:"creator"`
-	Members []string          `json:"members"`
-	Purpose SlackChannelSub   `json:"purpose"`
-	Topic   SlackChannelSub   `json:"topic"`
-	Type    model.ChannelType `json:"-"` // Computed, not from JSON
+	Id         string            `json:"id"`
+	Name       string            `json:"name"`
+	Creator    string            `json:"creator"`
+	Members    []string          `json:"members"`
+	Purpose    SlackChannelSub   `json:"purpose"`
+	Topic      SlackChannelSub   `json:"topic"`
+	IsArchived bool              `json:"is_archived"`
+	Updated    int64             `json:"updated"` // millisecond timestamp of last settings update; used as a best-effort approximation of archive time
+	Type       model.ChannelType `json:"-"`       // Computed, not from JSON
 }
 
 // SlackChannelSub represents a sub-field in Slack channel data (purpose/topic)

--- a/services/slack/models.go
+++ b/services/slack/models.go
@@ -8,16 +8,19 @@ import (
 
 // SlackChannel represents a Slack channel in the export
 type SlackChannel struct {
-	Id         string            `json:"id"`
-	Name       string            `json:"name"`
-	Creator    string            `json:"creator"`
-	Created    int64             `json:"created"`
-	Members    []string          `json:"members"`
-	Purpose    SlackChannelSub   `json:"purpose"`
-	Topic      SlackChannelSub   `json:"topic"`
-	IsArchived bool              `json:"is_archived"`
-	Updated    int64             `json:"updated"` // Millisecond timestamp of last settings update (note: unlike Created which is seconds, Slack's "updated" field is already in milliseconds per https://docs.slack.dev/reference/objects/conversation-object)
-	Type       model.ChannelType `json:"-"`       // Computed, not from JSON
+	Id         string          `json:"id"`
+	Name       string          `json:"name"`
+	Creator    string          `json:"creator"`
+	Created    int64           `json:"created"`
+	Members    []string        `json:"members"`
+	Purpose    SlackChannelSub `json:"purpose"`
+	Topic      SlackChannelSub `json:"topic"`
+	IsArchived bool            `json:"is_archived"`
+	// Updated is the millisecond timestamp of the last channel settings update.
+	// Unlike Created (seconds), Slack's "updated" field is already in milliseconds.
+	// See https://docs.slack.dev/reference/objects/conversation-object
+	Updated int64             `json:"updated"`
+	Type    model.ChannelType `json:"-"` // Computed, not from JSON
 }
 
 // SlackChannelSub represents a sub-field in Slack channel data (purpose/topic)

--- a/services/slack/models.go
+++ b/services/slack/models.go
@@ -16,7 +16,7 @@ type SlackChannel struct {
 	Purpose    SlackChannelSub   `json:"purpose"`
 	Topic      SlackChannelSub   `json:"topic"`
 	IsArchived bool              `json:"is_archived"`
-	Updated    int64             `json:"updated"` // millisecond timestamp of last settings update; used as a best-effort approximation of archive time
+	Updated    int64             `json:"updated"` // Millisecond timestamp of last settings update (note: unlike Created which is seconds, Slack's "updated" field is already in milliseconds per https://docs.slack.dev/reference/objects/conversation-object)
 	Type       model.ChannelType `json:"-"`       // Computed, not from JSON
 }
 

--- a/testhelper/slack_fixtures.go
+++ b/testhelper/slack_fixtures.go
@@ -537,3 +537,37 @@ func ExportWithDeletedBot() *SlackExportBuilder {
 			Members: []string{"U001"},
 		})
 }
+
+// ExportWithArchivedChannels creates an export containing both active and archived channels.
+// The archived channel has is_archived=true with an updated timestamp.
+func ExportWithArchivedChannels() *SlackExportBuilder {
+	return NewSlackExportBuilder().
+		AddUser(slack.SlackUser{
+			Id:       "U001",
+			Username: "john.doe",
+			Profile: slack.SlackProfile{
+				RealName: "John Doe",
+				Email:    "john.doe@example.com",
+				Title:    "Software Engineer",
+			},
+		}).
+		AddChannel(slack.SlackChannel{
+			Id:         "C001",
+			Name:       "general",
+			Creator:    "U001",
+			Members:    []string{"U001"},
+			Purpose:    slack.SlackChannelSub{Value: "General discussion"},
+			Topic:      slack.SlackChannelSub{Value: "Welcome!"},
+			IsArchived: false,
+		}).
+		AddChannel(slack.SlackChannel{
+			Id:         "C002",
+			Name:       "old-project",
+			Creator:    "U001",
+			Members:    []string{"U001"},
+			Purpose:    slack.SlackChannelSub{Value: "Old project channel"},
+			Topic:      slack.SlackChannelSub{Value: ""},
+			IsArchived: true,
+			Updated:    1620000000000, // ms timestamp used as archive time
+		})
+}

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -409,6 +409,28 @@ func (th *TestHelper) AssertChannelExists(ctx context.Context, teamName, channel
 	return channel
 }
 
+// AssertChannelIsArchived verifies that a channel exists in a team and is archived (DeleteAt > 0).
+// It uses GetDeletedChannelsForTeam to locate soft-deleted channels since the standard
+// GetChannelByName endpoint excludes archived channels.
+func (th *TestHelper) AssertChannelIsArchived(ctx context.Context, teamName, channelName string) *model.Channel {
+	team, err := th.GetTeam(ctx, teamName)
+	require.NoError(th.t, err, "team %s should exist", teamName)
+	require.NotNil(th.t, team, "team %s should not be nil", teamName)
+
+	deletedChannels, _, err := th.Client.GetDeletedChannelsForTeam(ctx, team.Id, 0, defaultPaginationLimit, "")
+	require.NoError(th.t, err, "failed to get deleted channels for team %s", teamName)
+
+	for _, ch := range deletedChannels {
+		if ch.Name == channelName {
+			require.Greater(th.t, ch.DeleteAt, int64(0), "channel %s should have a non-zero DeleteAt", channelName)
+			return ch
+		}
+	}
+
+	require.Fail(th.t, "archived channel not found", "channel %s in team %s should be archived", channelName, teamName)
+	return nil
+}
+
 // AssertUserInTeam verifies that a user is a member of a team
 func (th *TestHelper) AssertUserInTeam(ctx context.Context, teamID, userID string) {
 	members, err := th.GetTeamMembers(ctx, teamID)


### PR DESCRIPTION
## Summary
- Adds support for importing archived Slack channels (`is_archived: true`) as soft-deleted Mattermost channels by setting `DeleteAt` on the intermediate channel representation.
- Uses Slack's `updated` millisecond timestamp as a best-effort approximation of the archive time; falls back to `model.GetMillis()` when unavailable.
- Only applies to public and private channels — direct and group channels are excluded since the Mattermost `direct_channel` import type has no `DeletedAt` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archived Slack channels now carry an archived timestamp through export/import so archived state is preserved and reflected after migration; direct/group conversations are not treated as archived for migration and missing timestamps use a fallback.

* **Tests**
  * Added end-to-end and unit tests, fixtures, and test helpers to validate archived-channel export, transformation, import, and server-state assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->