### PR TITLE
fix: deduplicate Slack group channels with identical member sets (MM-68736)

### DIFF
--- a/commands/transform_slack_e2e_test.go
+++ b/commands/transform_slack_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -879,4 +880,295 @@ func TestTransformSlackE2ELastViewedAt(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestTransformSlackE2EMpimDedup verifies the mmetl-side fix for MM-68736:
+// when a Slack export contains two MPIMs that share the same member set, mmetl
+// should emit exactly one `direct_channel` JSONL line, preserve posts from
+// both Slack channels, and the resulting import should succeed against
+// Mattermost without crashing on `ChannelMember not found`.
+func TestTransformSlackE2EMpimDedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	defer th.TearDown()
+	t.Cleanup(func() { os.Remove(transformLogFile) })
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	slackExportPath := filepath.Join(tempDir, "slack_export.zip")
+	mmExportPath := filepath.Join(tempDir, "mattermost_import.jsonl")
+	teamName := uniqueTeamName("mpim")
+
+	require.NoError(t, testhelper.ExportWithDuplicateMpims().Build(slackExportPath),
+		"failed to build duplicate-MPIM Slack export fixture")
+
+	team := th.CreateTeam(ctx, teamName, "MPIM Dedup E2E Team")
+	require.NotNil(t, team)
+
+	c := commands.RootCmd
+	resetCobraFlags(c)
+	c.SetArgs([]string{
+		"transform", "slack",
+		"--team", teamName,
+		"--file", slackExportPath,
+		"--output", mmExportPath,
+		"--skip-attachments",
+	})
+	require.NoError(t, c.Execute(), "transform command should succeed")
+
+	content, err := os.ReadFile(mmExportPath)
+	require.NoError(t, err)
+
+	var directChannelLines []map[string]json.RawMessage
+	var directPostLines []map[string]json.RawMessage
+	for _, line := range strings.Split(strings.TrimSpace(string(content)), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		switch string(entry["type"]) {
+		case `"direct_channel"`:
+			directChannelLines = append(directChannelLines, entry)
+		case `"direct_post"`:
+			directPostLines = append(directPostLines, entry)
+		}
+	}
+
+	require.Len(t, directChannelLines, 1,
+		"two MPIMs with identical member sets should be deduplicated to one direct_channel line")
+
+	var dc struct {
+		Members []string `json:"members"`
+	}
+	require.NoError(t, json.Unmarshal(directChannelLines[0]["direct_channel"], &dc))
+	sortedMembers := append([]string{}, dc.Members...)
+	sort.Strings(sortedMembers)
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, sortedMembers,
+		"deduplicated channel should contain all three unique members")
+
+	require.Len(t, directPostLines, 4,
+		"posts from both Slack MPIMs should survive dedup (2 + 2 = 4)")
+	for _, post := range directPostLines {
+		var dp struct {
+			ChannelMembers []string `json:"channel_members"`
+		}
+		require.NoError(t, json.Unmarshal(post["direct_post"], &dp))
+		require.Len(t, dp.ChannelMembers, 3,
+			"every direct_post must carry the full 3-member set so the server routes it to the canonical channel")
+	}
+
+	validationResult := th.ValidateImportFileOrFail(ctx, mmExportPath)
+	assert.Equal(t, uint64(3), validationResult.UserCount, "all three users should validate")
+
+	// Import must succeed. Without dedup the server crashes with
+	// `ChannelMember not found` when the second direct_channel line hits a
+	// channel-hash collision with incomplete membership state.
+	require.NoError(t, th.ImportBulkData(ctx, mmExportPath),
+		"import of deduplicated MPIM should succeed without ChannelMember errors")
+
+	alice := th.AssertUserExists(ctx, "alice")
+	bobUser := th.AssertUserExists(ctx, "bob")
+	charlie := th.AssertUserExists(ctx, "charlie")
+
+	// Locate the imported group channel by enumerating alice's channels and
+	// picking the type-G one whose member set is exactly {alice, bob, charlie}.
+	// We avoid CreateGroupChannel here because that endpoint adds the calling
+	// user (the test admin) to the member set and would return a different
+	// 4-member channel rather than the imported 3-member one.
+	aliceChannels, _, err := th.Client.GetChannelsForUserWithLastDeleteAt(ctx, alice.Id, 0)
+	require.NoError(t, err)
+
+	expectedMembers := map[string]bool{alice.Id: true, bobUser.Id: true, charlie.Id: true}
+	var gmChannel *model.Channel
+	for _, ch := range aliceChannels {
+		if ch.Type != model.ChannelTypeGroup {
+			continue
+		}
+		members, mErr := th.GetChannelMembers(ctx, ch.Id)
+		require.NoError(t, mErr)
+		if len(members) != len(expectedMembers) {
+			continue
+		}
+		match := true
+		for _, m := range members {
+			if !expectedMembers[m.UserId] {
+				match = false
+				break
+			}
+		}
+		if match {
+			gmChannel = ch
+			break
+		}
+	}
+	require.NotNil(t, gmChannel,
+		"a group channel with exactly {alice, bob, charlie} should exist after import")
+
+	gmPosts, err := th.GetChannelPosts(ctx, gmChannel.Id, 0, 100)
+	require.NoError(t, err)
+
+	expectedMessages := []string{
+		"Message from the first MPIM",
+		"Reply in the first MPIM",
+		"Message from the second MPIM",
+		"Another message from the second MPIM",
+	}
+	found := map[string]bool{}
+	for _, postID := range gmPosts.Order {
+		for _, expected := range expectedMessages {
+			if strings.Contains(gmPosts.Posts[postID].Message, expected) {
+				found[expected] = true
+			}
+		}
+	}
+	for _, expected := range expectedMessages {
+		assert.True(t, found[expected],
+			"posts from both Slack MPIMs should be imported; missing: %q", expected)
+	}
+}
+
+// TestTransformSlackE2EMpimsNotMergedWhenMembersDiffer is the non-happy-path
+// counterpart to TestTransformSlackE2EMpimDedup: when two Slack MPIMs share
+// some — but not all — members, the dedup pass must NOT merge them. Mattermost
+// keys group channels by full member-set hash, so {alice,bob,charlie} and
+// {alice,bob,dave} are independent channels and both must survive into the
+// JSONL and into the imported Mattermost state.
+func TestTransformSlackE2EMpimsNotMergedWhenMembersDiffer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	defer th.TearDown()
+	t.Cleanup(func() { os.Remove(transformLogFile) })
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	slackExportPath := filepath.Join(tempDir, "slack_export.zip")
+	mmExportPath := filepath.Join(tempDir, "mattermost_import.jsonl")
+	teamName := uniqueTeamName("mpimno")
+
+	require.NoError(t, testhelper.ExportWithOverlappingMpims().Build(slackExportPath),
+		"failed to build overlapping-MPIM Slack export fixture")
+
+	team := th.CreateTeam(ctx, teamName, "MPIM No-Merge E2E Team")
+	require.NotNil(t, team)
+
+	c := commands.RootCmd
+	resetCobraFlags(c)
+	c.SetArgs([]string{
+		"transform", "slack",
+		"--team", teamName,
+		"--file", slackExportPath,
+		"--output", mmExportPath,
+		"--skip-attachments",
+	})
+	require.NoError(t, c.Execute(), "transform command should succeed")
+
+	content, err := os.ReadFile(mmExportPath)
+	require.NoError(t, err)
+
+	var directChannelMemberSets [][]string
+	var directPostCount int
+	for _, line := range strings.Split(strings.TrimSpace(string(content)), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		switch string(entry["type"]) {
+		case `"direct_channel"`:
+			var dc struct {
+				Members []string `json:"members"`
+			}
+			require.NoError(t, json.Unmarshal(entry["direct_channel"], &dc))
+			sorted := append([]string{}, dc.Members...)
+			sort.Strings(sorted)
+			directChannelMemberSets = append(directChannelMemberSets, sorted)
+		case `"direct_post"`:
+			directPostCount++
+		}
+	}
+
+	require.Len(t, directChannelMemberSets, 2,
+		"two distinct member sets must produce two direct_channel lines — dedup should not collapse non-identical sets")
+
+	// Order the two emitted sets deterministically before asserting content.
+	sort.Slice(directChannelMemberSets, func(i, j int) bool {
+		return strings.Join(directChannelMemberSets[i], ",") < strings.Join(directChannelMemberSets[j], ",")
+	})
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, directChannelMemberSets[0])
+	assert.Equal(t, []string{"alice", "bob", "dave"}, directChannelMemberSets[1])
+
+	assert.Equal(t, 2, directPostCount, "one post per MPIM should survive (no merging)")
+
+	require.NoError(t, th.ImportBulkData(ctx, mmExportPath), "import should succeed")
+
+	alice := th.AssertUserExists(ctx, "alice")
+	bobUser := th.AssertUserExists(ctx, "bob")
+	charlie := th.AssertUserExists(ctx, "charlie")
+	dave := th.AssertUserExists(ctx, "dave")
+
+	aliceChannels, _, err := th.Client.GetChannelsForUserWithLastDeleteAt(ctx, alice.Id, 0)
+	require.NoError(t, err)
+
+	// Build a {sorted-userIDs → channel} index over alice's group channels.
+	gmByMembers := map[string]*model.Channel{}
+	for _, ch := range aliceChannels {
+		if ch.Type != model.ChannelTypeGroup {
+			continue
+		}
+		members, mErr := th.GetChannelMembers(ctx, ch.Id)
+		require.NoError(t, mErr)
+		ids := make([]string, 0, len(members))
+		for _, m := range members {
+			ids = append(ids, m.UserId)
+		}
+		sort.Strings(ids)
+		gmByMembers[strings.Join(ids, ",")] = ch
+	}
+
+	charlieKey := joinSorted(alice.Id, bobUser.Id, charlie.Id)
+	daveKey := joinSorted(alice.Id, bobUser.Id, dave.Id)
+	require.NotNil(t, gmByMembers[charlieKey],
+		"GM for {alice,bob,charlie} should exist in Mattermost as a distinct channel")
+	require.NotNil(t, gmByMembers[daveKey],
+		"GM for {alice,bob,dave} should exist in Mattermost as a distinct channel")
+	assert.NotEqual(t, gmByMembers[charlieKey].Id, gmByMembers[daveKey].Id,
+		"the two GMs must be distinct Mattermost channels")
+
+	charlieGMPosts, err := th.GetChannelPosts(ctx, gmByMembers[charlieKey].Id, 0, 100)
+	require.NoError(t, err)
+	daveGMPosts, err := th.GetChannelPosts(ctx, gmByMembers[daveKey].Id, 0, 100)
+	require.NoError(t, err)
+
+	assert.True(t, anyPostContains(charlieGMPosts, "Hi charlie group"),
+		"the {alice,bob,charlie} GM should contain its own post")
+	assert.False(t, anyPostContains(charlieGMPosts, "Hi dave group"),
+		"the {alice,bob,charlie} GM must NOT contain posts from the {alice,bob,dave} GM")
+	assert.True(t, anyPostContains(daveGMPosts, "Hi dave group"),
+		"the {alice,bob,dave} GM should contain its own post")
+	assert.False(t, anyPostContains(daveGMPosts, "Hi charlie group"),
+		"the {alice,bob,dave} GM must NOT contain posts from the {alice,bob,charlie} GM")
+}
+
+// joinSorted returns a deterministic comma-joined key from the given strings.
+func joinSorted(s ...string) string {
+	cp := append([]string{}, s...)
+	sort.Strings(cp)
+	return strings.Join(cp, ",")
+}
+
+// anyPostContains reports whether any post in list contains substring.
+func anyPostContains(list *model.PostList, substring string) bool {
+	for _, id := range list.Order {
+		if strings.Contains(list.Posts[id].Message, substring) {
+			return true
+		}
+	}
+	return false
 }

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -800,7 +800,7 @@ func TestExportDirectChannels(t *testing.T) {
 			},
 		}
 
-		transformer.DeduplicateGroupChannelsByMembers()
+		transformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		var buf bytes.Buffer
 		err := transformer.ExportDirectChannels(transformer.Intermediate.GroupChannels, &buf)

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -726,4 +726,37 @@ func TestExportDirectChannels(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, buf.String())
 	})
+
+	t.Run("emits exactly one line per unique member set after dedup", func(t *testing.T) {
+		transformer := NewTransformer("myteam", log.New())
+		transformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{
+				{
+					Id:               "C002",
+					OriginalName:     "mpdm-2",
+					Type:             model.ChannelTypeGroup,
+					MembersUsernames: []string{"alice", "bob", "charlie"},
+				},
+				{
+					Id:               "C001",
+					OriginalName:     "mpdm-1",
+					Type:             model.ChannelTypeGroup,
+					MembersUsernames: []string{"charlie", "alice", "bob"},
+				},
+			},
+		}
+
+		transformer.DeduplicateGroupChannelsByMembers()
+
+		var buf bytes.Buffer
+		err := transformer.ExportDirectChannels(transformer.Intermediate.GroupChannels, &buf)
+		require.NoError(t, err)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1, "duplicate MPIMs should collapse to one direct_channel line")
+
+		var parsed map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &parsed))
+		assert.Equal(t, `"direct_channel"`, string(parsed["type"]))
+	})
 }

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -239,6 +239,17 @@ type Intermediate struct {
 	DirectChannels  []*IntermediateChannel       `json:"direct_channels"`
 	UsersById       map[string]*IntermediateUser `json:"users"`
 	Posts           []*IntermediatePost          `json:"posts"`
+
+	// GroupChannelAliases maps a duplicate group/direct channel's OriginalName
+	// to the OriginalName of the canonical channel it was merged into. Slack
+	// permits multiple MPIMs with identical member sets, but Mattermost keys
+	// group channels by member-set hash so two such MPIMs collapse server-side.
+	// We deduplicate here to avoid emitting two `direct_channel` lines for the
+	// same hash (which crashes the bulk importer when one MPIM's members aren't
+	// fully written yet — see MM-68736), and route posts from every aliased
+	// Slack channel name to the surviving IntermediateChannel via
+	// buildChannelsByOriginalNameMap.
+	GroupChannelAliases map[string]string `json:"-"`
 }
 
 func (t *Transformer) TransformUsers(users []SlackUser, skipEmptyEmails bool, defaultEmailDomain string) {
@@ -448,6 +459,95 @@ func (t *Transformer) PopulateChannelMemberships() {
 	}
 }
 
+// DeduplicateGroupChannelsByMembers collapses group/direct channels that share
+// the same member set (per directChannelKey) into a single canonical
+// IntermediateChannel. Slack allows multiple MPIMs with identical members but
+// Mattermost cannot represent that — emitting two `direct_channel` lines with
+// the same hash crashes the bulk importer (see MM-68736).
+//
+// The canonical channel is the one with the lexicographically smallest Slack
+// Id, so the choice is deterministic across runs. Topic/Header/Purpose fall
+// back to the first non-empty value in canonical order; Created is the minimum.
+// Post-derived stats are left zero and recomputed by ComputeChannelPostStats
+// after dedup.
+//
+// Each dropped duplicate's OriginalName is added to GroupChannelAliases so
+// buildChannelsByOriginalNameMap routes posts from every colliding Slack
+// channel name to the canonical IntermediateChannel.
+//
+// Must run after PopulateChannelMemberships (the key uses MembersUsernames)
+// and before TransformPosts (so post lookup sees the deduplicated slices).
+func (t *Transformer) DeduplicateGroupChannelsByMembers() {
+	t.Logger.Info("Deduplicating group and direct channels by member set")
+
+	if t.Intermediate.GroupChannelAliases == nil {
+		t.Intermediate.GroupChannelAliases = map[string]string{}
+	}
+
+	t.Intermediate.GroupChannels = t.dedupByMembers(t.Intermediate.GroupChannels)
+	t.Intermediate.DirectChannels = t.dedupByMembers(t.Intermediate.DirectChannels)
+}
+
+func (t *Transformer) dedupByMembers(channels []*IntermediateChannel) []*IntermediateChannel {
+	if len(channels) <= 1 {
+		return channels
+	}
+
+	groups := map[string][]*IntermediateChannel{}
+	keyOrder := []string{}
+	for _, ch := range channels {
+		if len(ch.MembersUsernames) == 0 {
+			// Defensive: a channel with no resolvable members can't be keyed and
+			// shouldn't be merged with anything. Keep it as its own bucket using
+			// the Slack Id so it survives untouched.
+			key := "__noMembers__" + ch.Id
+			groups[key] = append(groups[key], ch)
+			keyOrder = append(keyOrder, key)
+			continue
+		}
+		key := directChannelKey(ch.MembersUsernames)
+		if _, seen := groups[key]; !seen {
+			keyOrder = append(keyOrder, key)
+		}
+		groups[key] = append(groups[key], ch)
+	}
+
+	result := make([]*IntermediateChannel, 0, len(channels))
+	for _, key := range keyOrder {
+		bucket := groups[key]
+		if len(bucket) == 1 {
+			result = append(result, bucket[0])
+			continue
+		}
+
+		sort.SliceStable(bucket, func(i, j int) bool {
+			return bucket[i].Id < bucket[j].Id
+		})
+
+		canonical := bucket[0]
+		for _, dup := range bucket[1:] {
+			t.Logger.Warnf("Merging duplicate group channel: members=%s canonical_id=%s canonical_name=%s duplicate_id=%s duplicate_name=%s",
+				key, canonical.Id, canonical.OriginalName, dup.Id, dup.OriginalName)
+			if canonical.Topic == "" && dup.Topic != "" {
+				canonical.Topic = dup.Topic
+			}
+			if canonical.Header == "" && dup.Header != "" {
+				canonical.Header = dup.Header
+			}
+			if canonical.Purpose == "" && dup.Purpose != "" {
+				canonical.Purpose = dup.Purpose
+			}
+			if dup.Created > 0 && (canonical.Created == 0 || dup.Created < canonical.Created) {
+				canonical.Created = dup.Created
+			}
+			t.Intermediate.GroupChannelAliases[dup.OriginalName] = canonical.OriginalName
+		}
+		result = append(result, canonical)
+	}
+
+	return result
+}
+
 func (t *Transformer) TransformAllChannels(slackExport *SlackExport) error {
 	t.Logger.Info("Transforming channels")
 
@@ -529,6 +629,11 @@ func buildChannelsByOriginalNameMap(intermediate *Intermediate) map[string]*Inte
 	}
 	for _, channel := range intermediate.DirectChannels {
 		channelsByName[channel.OriginalName] = channel
+	}
+	for alias, canonical := range intermediate.GroupChannelAliases {
+		if ch, ok := channelsByName[canonical]; ok {
+			channelsByName[alias] = ch
+		}
 	}
 	return channelsByName
 }
@@ -1073,6 +1178,7 @@ func (t *Transformer) Transform(slackExport *SlackExport, attachmentsDir string,
 
 	t.PopulateUserMemberships()
 	t.PopulateChannelMemberships()
+	t.DeduplicateGroupChannelsByMembers()
 
 	if err := t.TransformPosts(slackExport, attachmentsDir, skipAttachments, discardInvalidProps, allowDownload); err != nil {
 		return err

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -476,7 +476,7 @@ func (t *Transformer) PopulateChannelMemberships() {
 	}
 }
 
-// DeduplicateGroupChannelsByMembers collapses group/direct channels that share
+// DeduplicateDirectAndGroupChannelsByMembers collapses group/direct channels that share
 // the same member set (per directChannelKey) into a single canonical
 // IntermediateChannel. Slack allows multiple MPIMs with identical members but
 // Mattermost cannot represent that — emitting two `direct_channel` lines with
@@ -494,7 +494,7 @@ func (t *Transformer) PopulateChannelMemberships() {
 //
 // Must run after PopulateChannelMemberships (the key uses MembersUsernames)
 // and before TransformPosts (so post lookup sees the deduplicated slices).
-func (t *Transformer) DeduplicateGroupChannelsByMembers() {
+func (t *Transformer) DeduplicateDirectAndGroupChannelsByMembers() {
 	t.Logger.Info("Deduplicating group and direct channels by member set")
 
 	if t.Intermediate.GroupChannelAliases == nil {
@@ -542,9 +542,9 @@ func (t *Transformer) dedupByMembers(channels []*IntermediateChannel) []*Interme
 		})
 
 		canonical := bucket[0]
+		dupSummaries := make([]string, 0, len(bucket)-1)
 		for _, dup := range bucket[1:] {
-			t.Logger.Warnf("Merging duplicate group channel: members=%s canonical_id=%s canonical_name=%s duplicate_id=%s duplicate_name=%s",
-				key, canonical.Id, canonical.OriginalName, dup.Id, dup.OriginalName)
+			dupSummaries = append(dupSummaries, fmt.Sprintf("%s (%s)", dup.Id, dup.OriginalName))
 			if canonical.Topic == "" && dup.Topic != "" {
 				canonical.Topic = dup.Topic
 			}
@@ -559,6 +559,8 @@ func (t *Transformer) dedupByMembers(channels []*IntermediateChannel) []*Interme
 			}
 			t.Intermediate.GroupChannelAliases[dup.OriginalName] = canonical.OriginalName
 		}
+		t.Logger.Infof("Merged %d duplicate channel(s) into canonical %s (%s) keyed by members=%s: [%s]",
+			len(dupSummaries), canonical.Id, canonical.OriginalName, key, strings.Join(dupSummaries, ", "))
 		result = append(result, canonical)
 	}
 
@@ -1198,7 +1200,7 @@ func (t *Transformer) Transform(slackExport *SlackExport, attachmentsDir string,
 
 	t.PopulateUserMemberships()
 	t.PopulateChannelMemberships()
-	t.DeduplicateGroupChannelsByMembers()
+	t.DeduplicateDirectAndGroupChannelsByMembers()
 
 	if err := t.TransformPosts(slackExport, attachmentsDir, skipAttachments, discardInvalidProps, allowDownload); err != nil {
 		return err

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -497,9 +497,10 @@ func (t *Transformer) PopulateChannelMemberships() {
 func (t *Transformer) DeduplicateDirectAndGroupChannelsByMembers() {
 	t.Logger.Info("Deduplicating group and direct channels by member set")
 
-	if t.Intermediate.GroupChannelAliases == nil {
-		t.Intermediate.GroupChannelAliases = map[string]string{}
-	}
+	// Reset on every run so a reused Transformer doesn't carry aliases from
+	// a previous Transform() over to the current one — buildChannelsByOriginalNameMap
+	// would otherwise overlay stale Slack channel names onto the new export.
+	t.Intermediate.GroupChannelAliases = map[string]string{}
 
 	t.Intermediate.GroupChannels = t.dedupByMembers(t.Intermediate.GroupChannels)
 	t.Intermediate.DirectChannels = t.dedupByMembers(t.Intermediate.DirectChannels)
@@ -554,7 +555,13 @@ func (t *Transformer) dedupByMembers(channels []*IntermediateChannel) []*Interme
 			if canonical.Purpose == "" && dup.Purpose != "" {
 				canonical.Purpose = dup.Purpose
 			}
-			if dup.Created > 0 && (canonical.Created == 0 || dup.Created < canonical.Created) {
+			// Slack uses placeholder Created values (e.g. 1 for DMs) that
+			// CreatedMillis() treats as invalid. Ignore them here so a real
+			// timestamp on the canonical isn't replaced by a placeholder from
+			// a duplicate.
+			canonicalCreatedValid := canonical.Created >= minValidSlackCreatedTimestamp
+			dupCreatedValid := dup.Created >= minValidSlackCreatedTimestamp
+			if dupCreatedValid && (!canonicalCreatedValid || dup.Created < canonical.Created) {
 				canonical.Created = dup.Created
 			}
 			t.Intermediate.GroupChannelAliases[dup.OriginalName] = canonical.OriginalName

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -1001,6 +1001,259 @@ func TestDirectChannelKey(t *testing.T) {
 	assert.Equal(t, "alice,bob,charlie", directChannelKey([]string{"charlie", "alice", "bob"}))
 }
 
+func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
+	t.Run("merges two group channels with identical member sets", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		ch1 := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-alice--bob--charlie-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Topic:            "second-topic",
+		}
+		ch2 := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-alice--bob--charlie-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"charlie", "alice", "bob"}, // different order
+			Topic:            "first-topic",
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{ch1, ch2},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		canonical := slackTransformer.Intermediate.GroupChannels[0]
+		assert.Equal(t, "C001", canonical.Id, "canonical should be the lexicographically smallest Id")
+		assert.Equal(t, "first-topic", canonical.Topic)
+		assert.Equal(t, "mpdm-alice--bob--charlie-1",
+			slackTransformer.Intermediate.GroupChannelAliases["mpdm-alice--bob--charlie-2"])
+	})
+
+	t.Run("preserves channels with different member sets", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		ch1 := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-a",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+		}
+		ch2 := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-b",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "dave"},
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{ch1, ch2},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 2)
+		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
+	})
+
+	t.Run("merges direct channels with identical pairs", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		ch1 := &IntermediateChannel{
+			Id:               "D002",
+			OriginalName:     "dm-2",
+			Type:             model.ChannelTypeDirect,
+			MembersUsernames: []string{"alice", "bob"},
+		}
+		ch2 := &IntermediateChannel{
+			Id:               "D001",
+			OriginalName:     "dm-1",
+			Type:             model.ChannelTypeDirect,
+			MembersUsernames: []string{"bob", "alice"},
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			DirectChannels: []*IntermediateChannel{ch1, ch2},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.DirectChannels, 1)
+		assert.Equal(t, "D001", slackTransformer.Intermediate.DirectChannels[0].Id)
+		assert.Equal(t, "dm-1", slackTransformer.Intermediate.GroupChannelAliases["dm-2"])
+	})
+
+	t.Run("canonical selection is deterministic regardless of input order", func(t *testing.T) {
+		members := []string{"alice", "bob", "charlie"}
+		for _, order := range [][]string{
+			{"C03", "C01", "C02"},
+			{"C02", "C03", "C01"},
+			{"C01", "C02", "C03"},
+		} {
+			channels := make([]*IntermediateChannel, len(order))
+			for i, id := range order {
+				channels[i] = &IntermediateChannel{
+					Id:               id,
+					OriginalName:     "mpdm-" + id,
+					Type:             model.ChannelTypeGroup,
+					MembersUsernames: members,
+				}
+			}
+			slackTransformer := NewTransformer("test", log.New())
+			slackTransformer.Intermediate = &Intermediate{GroupChannels: channels}
+			slackTransformer.DeduplicateGroupChannelsByMembers()
+
+			require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+			assert.Equal(t, "C01", slackTransformer.Intermediate.GroupChannels[0].Id,
+				"input order %v should still pick C01", order)
+		}
+	})
+
+	t.Run("metadata merge fills empty topic/header/purpose from duplicates", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          2000,
+			// Topic, Header, Purpose all empty
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1000, // earlier
+			Topic:            "filled-topic",
+			Header:           "filled-header",
+			Purpose:          "filled-purpose",
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		canonical := slackTransformer.Intermediate.GroupChannels[0]
+		assert.Equal(t, "C001", canonical.Id)
+		assert.Equal(t, "filled-topic", canonical.Topic)
+		assert.Equal(t, "filled-header", canonical.Header)
+		assert.Equal(t, "filled-purpose", canonical.Purpose)
+		assert.Equal(t, int64(1000), canonical.Created, "Created should be the minimum across duplicates")
+	})
+
+	t.Run("post stats aggregate onto canonical after dedup", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+			Posts: []*IntermediatePost{
+				{IsDirect: true, ChannelMembers: []string{"alice", "bob", "charlie"}, CreateAt: 1000},
+				{IsDirect: true, ChannelMembers: []string{"bob", "charlie", "alice"}, CreateAt: 2000},
+				{IsDirect: true, ChannelMembers: []string{"charlie", "alice", "bob"}, CreateAt: 3000,
+					Replies: []*IntermediatePost{{CreateAt: 3500}}},
+			},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.ComputeChannelPostStats()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		canonical := slackTransformer.Intermediate.GroupChannels[0]
+		assert.Equal(t, int64(4), canonical.MsgCount, "3 roots + 1 reply across both MPIMs")
+		assert.Equal(t, int64(3), canonical.MsgCountRoot)
+		assert.Equal(t, int64(3500), canonical.LastPostAt)
+	})
+
+	t.Run("is idempotent on already-deduplicated input", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		ch := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{ch},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
+	})
+
+	t.Run("channels with no resolvable members are not merged together", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		ch1 := &IntermediateChannel{
+			Id:           "C001",
+			OriginalName: "mpdm-1",
+			Type:         model.ChannelTypeGroup,
+			// MembersUsernames is empty (e.g. all members deleted/unknown)
+		}
+		ch2 := &IntermediateChannel{
+			Id:           "C002",
+			OriginalName: "mpdm-2",
+			Type:         model.ChannelTypeGroup,
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{ch1, ch2},
+		}
+
+		slackTransformer.DeduplicateGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 2,
+			"empty-member channels should never be merged with each other")
+		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
+	})
+}
+
+func TestBuildChannelsByOriginalNameMapHonoursAliases(t *testing.T) {
+	canonical := &IntermediateChannel{
+		Id:           "C001",
+		OriginalName: "mpdm-canonical",
+		Type:         model.ChannelTypeGroup,
+	}
+	intermediate := &Intermediate{
+		GroupChannels: []*IntermediateChannel{canonical},
+		GroupChannelAliases: map[string]string{
+			"mpdm-duplicate": "mpdm-canonical",
+		},
+	}
+
+	m := buildChannelsByOriginalNameMap(intermediate)
+
+	assert.Same(t, canonical, m["mpdm-canonical"])
+	assert.Same(t, canonical, m["mpdm-duplicate"],
+		"alias OriginalName should resolve to the canonical IntermediateChannel")
+}
+
+func TestBuildChannelsByOriginalNameMapIgnoresStaleAlias(t *testing.T) {
+	intermediate := &Intermediate{
+		GroupChannels: []*IntermediateChannel{},
+		GroupChannelAliases: map[string]string{
+			"mpdm-orphan": "mpdm-missing",
+		},
+	}
+
+	m := buildChannelsByOriginalNameMap(intermediate)
+
+	_, ok := m["mpdm-orphan"]
+	assert.False(t, ok, "alias pointing at a non-existent canonical must not create a nil entry")
+}
+
 func TestComputeChannelPostStats(t *testing.T) {
 	t.Run("regular channel counts root posts and replies", func(t *testing.T) {
 		slackTransformer := NewTransformer("test", log.New())

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -1122,7 +1122,7 @@ func TestDeduplicateDirectAndGroupChannelsByMembers(t *testing.T) {
 			OriginalName:     "mpdm-2",
 			Type:             model.ChannelTypeGroup,
 			MembersUsernames: []string{"alice", "bob", "charlie"},
-			Created:          1000, // earlier
+			Created:          1000,
 			Topic:            "filled-topic",
 			Header:           "filled-header",
 			Purpose:          "filled-purpose",
@@ -1139,7 +1139,6 @@ func TestDeduplicateDirectAndGroupChannelsByMembers(t *testing.T) {
 		assert.Equal(t, "filled-topic", canonical.Topic)
 		assert.Equal(t, "filled-header", canonical.Header)
 		assert.Equal(t, "filled-purpose", canonical.Purpose)
-		assert.Equal(t, int64(1000), canonical.Created, "Created should be the minimum across duplicates")
 	})
 
 	t.Run("post stats aggregate onto canonical after dedup", func(t *testing.T) {
@@ -1217,6 +1216,146 @@ func TestDeduplicateDirectAndGroupChannelsByMembers(t *testing.T) {
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 2,
 			"empty-member channels should never be merged with each other")
 		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
+	})
+
+	t.Run("aliases from a previous run do not leak into the next run", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{
+				{Id: "C001", OriginalName: "mpdm-1", Type: model.ChannelTypeGroup,
+					MembersUsernames: []string{"alice", "bob", "charlie"}},
+				{Id: "C002", OriginalName: "mpdm-2", Type: model.ChannelTypeGroup,
+					MembersUsernames: []string{"alice", "bob", "charlie"}},
+			},
+		}
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+		require.Equal(t, "mpdm-1",
+			slackTransformer.Intermediate.GroupChannelAliases["mpdm-2"],
+			"first run should record the mpdm-2 → mpdm-1 alias")
+
+		// Simulate a second Transform() pass on a reused Transformer where the
+		// new export has no duplicates. The stale alias from the previous run
+		// must not survive — otherwise buildChannelsByOriginalNameMap would
+		// overlay it onto the new channel set.
+		slackTransformer.Intermediate.GroupChannels = []*IntermediateChannel{
+			{Id: "C999", OriginalName: "mpdm-fresh", Type: model.ChannelTypeGroup,
+				MembersUsernames: []string{"alice", "bob", "dave"}},
+		}
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases,
+			"aliases from the first run must be cleared at the start of the second run")
+	})
+
+	t.Run("placeholder Slack Created on a duplicate does not overwrite a valid canonical Created", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1704067200, // valid, post-2013
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1, // Slack placeholder
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+		}
+
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		assert.Equal(t, int64(1704067200),
+			slackTransformer.Intermediate.GroupChannels[0].Created,
+			"placeholder Created=1 must not replace the canonical's real timestamp")
+	})
+
+	t.Run("valid Created on a duplicate replaces placeholder Created on the canonical", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1, // canonical (smallest Id) has a placeholder
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1704067200, // valid
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+		}
+
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		assert.Equal(t, int64(1704067200),
+			slackTransformer.Intermediate.GroupChannels[0].Created,
+			"a valid duplicate timestamp must replace the canonical's placeholder")
+	})
+
+	t.Run("Created across two valid duplicates picks the earliest", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1704070800, // valid, later
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1704067200, // valid, earlier
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+		}
+
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		assert.Equal(t, int64(1704067200),
+			slackTransformer.Intermediate.GroupChannels[0].Created,
+			"earliest valid timestamp should win when both duplicates have valid Created")
+	})
+
+	t.Run("Created stays untouched when both canonical and duplicate are placeholders", func(t *testing.T) {
+		slackTransformer := NewTransformer("test", log.New())
+		canonicalCh := &IntermediateChannel{
+			Id:               "C001",
+			OriginalName:     "mpdm-1",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          1, // placeholder
+		}
+		duplicateCh := &IntermediateChannel{
+			Id:               "C002",
+			OriginalName:     "mpdm-2",
+			Type:             model.ChannelTypeGroup,
+			MembersUsernames: []string{"alice", "bob", "charlie"},
+			Created:          minValidSlackCreatedTimestamp - 1, // also placeholder
+		}
+		slackTransformer.Intermediate = &Intermediate{
+			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
+		}
+
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+
+		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
+		assert.Equal(t, int64(1),
+			slackTransformer.Intermediate.GroupChannels[0].Created,
+			"two placeholders should leave canonical Created untouched")
 	})
 }
 

--- a/services/slack/intermediate_test.go
+++ b/services/slack/intermediate_test.go
@@ -1001,7 +1001,7 @@ func TestDirectChannelKey(t *testing.T) {
 	assert.Equal(t, "alice,bob,charlie", directChannelKey([]string{"charlie", "alice", "bob"}))
 }
 
-func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
+func TestDeduplicateDirectAndGroupChannelsByMembers(t *testing.T) {
 	t.Run("merges two group channels with identical member sets", func(t *testing.T) {
 		slackTransformer := NewTransformer("test", log.New())
 		ch1 := &IntermediateChannel{
@@ -1022,7 +1022,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			GroupChannels: []*IntermediateChannel{ch1, ch2},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
 		canonical := slackTransformer.Intermediate.GroupChannels[0]
@@ -1050,7 +1050,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			GroupChannels: []*IntermediateChannel{ch1, ch2},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 2)
 		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
@@ -1074,7 +1074,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			DirectChannels: []*IntermediateChannel{ch1, ch2},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.DirectChannels, 1)
 		assert.Equal(t, "D001", slackTransformer.Intermediate.DirectChannels[0].Id)
@@ -1099,7 +1099,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			}
 			slackTransformer := NewTransformer("test", log.New())
 			slackTransformer.Intermediate = &Intermediate{GroupChannels: channels}
-			slackTransformer.DeduplicateGroupChannelsByMembers()
+			slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 			require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
 			assert.Equal(t, "C01", slackTransformer.Intermediate.GroupChannels[0].Id,
@@ -1131,7 +1131,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			GroupChannels: []*IntermediateChannel{canonicalCh, duplicateCh},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
 		canonical := slackTransformer.Intermediate.GroupChannels[0]
@@ -1166,7 +1166,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 		slackTransformer.ComputeChannelPostStats()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
@@ -1188,8 +1188,8 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			GroupChannels: []*IntermediateChannel{ch},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 1)
 		assert.Empty(t, slackTransformer.Intermediate.GroupChannelAliases)
@@ -1212,7 +1212,7 @@ func TestDeduplicateGroupChannelsByMembers(t *testing.T) {
 			GroupChannels: []*IntermediateChannel{ch1, ch2},
 		}
 
-		slackTransformer.DeduplicateGroupChannelsByMembers()
+		slackTransformer.DeduplicateDirectAndGroupChannelsByMembers()
 
 		require.Len(t, slackTransformer.Intermediate.GroupChannels, 2,
 			"empty-member channels should never be merged with each other")

--- a/testhelper/slack_fixtures.go
+++ b/testhelper/slack_fixtures.go
@@ -585,3 +585,135 @@ func ExportWithDirectMessages() *SlackExportBuilder {
 			Type:      "message",
 		})
 }
+
+// ExportWithDuplicateMpims creates an export with three users and two distinct
+// Slack MPIMs (group DMs) that share the exact same member set. Slack permits
+// multiple MPIMs with identical membership, but Mattermost keys group channels
+// by member-set hash — so emitting two `direct_channel` JSONL lines for these
+// crashes the bulk importer (see MM-68736). Used to verify that mmetl
+// deduplicates them and preserves posts from both Slack channels.
+func ExportWithDuplicateMpims() *SlackExportBuilder {
+	return NewSlackExportBuilder().
+		AddUser(slack.SlackUser{
+			Id:       "U001",
+			Username: "alice",
+			Profile: slack.SlackProfile{
+				RealName: "Alice Anderson",
+				Email:    "alice@example.com",
+			},
+		}).
+		AddUser(slack.SlackUser{
+			Id:       "U002",
+			Username: "bob",
+			Profile: slack.SlackProfile{
+				RealName: "Bob Baker",
+				Email:    "bob@example.com",
+			},
+		}).
+		AddUser(slack.SlackUser{
+			Id:       "U003",
+			Username: "charlie",
+			Profile: slack.SlackProfile{
+				RealName: "Charlie Carter",
+				Email:    "charlie@example.com",
+			},
+		}).
+		// First MPIM. Created earlier; later sorted as the canonical via its
+		// lexicographically smaller Id (G001).
+		AddGroupChannel(slack.SlackChannel{
+			Id:      "G001",
+			Name:    "mpdm-alice--bob--charlie-1",
+			Creator: "U001",
+			Created: 1704067200,
+			Members: []string{"U001", "U002", "U003"},
+			Topic:   slack.SlackChannelSub{Value: "first mpim topic"},
+		}).
+		// Second MPIM with identical members but a different Slack channel.
+		AddGroupChannel(slack.SlackChannel{
+			Id:      "G002",
+			Name:    "mpdm-alice--bob--charlie-2",
+			Creator: "U002",
+			Created: 1704070800,
+			Members: []string{"U001", "U002", "U003"},
+		}).
+		// Two posts in the first MPIM directory.
+		AddPost("mpdm-alice--bob--charlie-1", slack.SlackPost{
+			User:      "U001",
+			Text:      "Message from the first MPIM",
+			TimeStamp: "1704067200.000100",
+			Type:      "message",
+		}).
+		AddPost("mpdm-alice--bob--charlie-1", slack.SlackPost{
+			User:      "U002",
+			Text:      "Reply in the first MPIM",
+			TimeStamp: "1704067260.000200",
+			Type:      "message",
+		}).
+		// Two posts in the second MPIM directory — must still appear after dedup.
+		AddPost("mpdm-alice--bob--charlie-2", slack.SlackPost{
+			User:      "U003",
+			Text:      "Message from the second MPIM",
+			TimeStamp: "1704070900.000100",
+			Type:      "message",
+		}).
+		AddPost("mpdm-alice--bob--charlie-2", slack.SlackPost{
+			User:      "U001",
+			Text:      "Another message from the second MPIM",
+			TimeStamp: "1704070960.000200",
+			Type:      "message",
+		})
+}
+
+// ExportWithOverlappingMpims creates an export with two MPIMs that share two
+// of three members but differ in the third. They must NOT be deduplicated:
+// Mattermost keys group channels by full member set, so {alice,bob,charlie}
+// and {alice,bob,dave} are distinct channels and both must survive.
+func ExportWithOverlappingMpims() *SlackExportBuilder {
+	return NewSlackExportBuilder().
+		AddUser(slack.SlackUser{
+			Id:       "U001",
+			Username: "alice",
+			Profile:  slack.SlackProfile{RealName: "Alice Anderson", Email: "alice@example.com"},
+		}).
+		AddUser(slack.SlackUser{
+			Id:       "U002",
+			Username: "bob",
+			Profile:  slack.SlackProfile{RealName: "Bob Baker", Email: "bob@example.com"},
+		}).
+		AddUser(slack.SlackUser{
+			Id:       "U003",
+			Username: "charlie",
+			Profile:  slack.SlackProfile{RealName: "Charlie Carter", Email: "charlie@example.com"},
+		}).
+		AddUser(slack.SlackUser{
+			Id:       "U004",
+			Username: "dave",
+			Profile:  slack.SlackProfile{RealName: "Dave Dawson", Email: "dave@example.com"},
+		}).
+		AddGroupChannel(slack.SlackChannel{
+			Id:      "G001",
+			Name:    "mpdm-alice--bob--charlie",
+			Creator: "U001",
+			Created: 1704067200,
+			Members: []string{"U001", "U002", "U003"},
+		}).
+		AddGroupChannel(slack.SlackChannel{
+			Id:      "G002",
+			Name:    "mpdm-alice--bob--dave",
+			Creator: "U001",
+			Created: 1704070800,
+			Members: []string{"U001", "U002", "U004"},
+		}).
+		AddPost("mpdm-alice--bob--charlie", slack.SlackPost{
+			User:      "U001",
+			Text:      "Hi charlie group",
+			TimeStamp: "1704067200.000100",
+			Type:      "message",
+		}).
+		AddPost("mpdm-alice--bob--dave", slack.SlackPost{
+			User:      "U002",
+			Text:      "Hi dave group",
+			TimeStamp: "1704070900.000100",
+			Type:      "message",
+		})
+}


### PR DESCRIPTION
## Summary

- Adds a deduplication pass to mmetl's Slack transformer so group/direct channels sharing the same member set collapse into a single canonical \`IntermediateChannel\`. Slack permits multiple MPIMs with identical members, but Mattermost keys group channels by member-set hash, so emitting two \`direct_channel\` JSONL lines crashes the bulk importer with \`ChannelMember not found\` — one of the four documented triggers in [MM-68736](https://mattermost.atlassian.net/browse/MM-68736).
- Canonical selection uses the lexicographically smallest Slack \`Id\` for determinism. \`Topic\`/\`Header\`/\`Purpose\` fall back to the first non-empty value across duplicates; \`Created\` takes the minimum.
- Dropped duplicates' \`OriginalName\` is recorded in \`Intermediate.GroupChannelAliases\` so \`buildChannelsByOriginalNameMap\` routes posts from every colliding Slack channel name to the surviving channel. Post stats then aggregate via the existing \`ComputeChannelPostStats\` path.

This is a defense-in-depth fix on the mmetl side; the underlying server bug in \`importDirectChannel\` still needs its own fix to address the concurrent-workers, partial-state, and drifted-membership triggers documented in the Jira issue.

## Test plan

- [x] \`make check-style\` — 0 issues
- [x] \`make test\` — all four packages green
- [x] Unit tests in \`services/slack/intermediate_test.go\`: identical-set merge, no false positives on distinct sets, direct-channel pairs, deterministic canonical across input orders, metadata merge rules, post-stats aggregation, idempotency, empty-member safety, alias resolution, stale-alias safety
- [x] Unit test in \`services/slack/export_test.go\`: one \`direct_channel\` line per unique member set after dedup
- [x] Integration test \`TestTransformSlackE2EMpimDedup\`: duplicate-MPIM fixture → end-to-end transform + import; verifies one GM with all four posts preserved
- [x] Integration test \`TestTransformSlackE2EMpimsNotMergedWhenMembersDiffer\`: overlapping-but-distinct member sets → two separate GMs with no cross-contamination