### PR TITLE
MM-68915 - Populate SchemeUser on direct channel participants

### DIFF
--- a/services/slack/export.go
+++ b/services/slack/export.go
@@ -168,6 +168,7 @@ func GetImportLineFromDirectChannel(team string, channel *IntermediateChannel) *
 		p := &imports.DirectChannelMemberImportData{
 			Username:     model.NewPointer(username),
 			LastViewedAt: model.NewPointer(lastViewedAt),
+			SchemeUser:   model.NewPointer(true),
 		}
 		if channel.MsgCount > 0 {
 			p.MsgCount = model.NewPointer(channel.MsgCount)

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -701,6 +701,8 @@ func TestGetImportLineFromDirectChannel(t *testing.T) {
 			assert.Equal(t, int64(1704099999000), *p.LastViewedAt)
 			assert.Equal(t, int64(8), *p.MsgCount)
 			assert.Equal(t, int64(5), *p.MsgCountRoot)
+			require.NotNil(t, p.SchemeUser, "SchemeUser must be populated so the server import does not default it to false (MM-68915)")
+			assert.True(t, *p.SchemeUser)
 		}
 	})
 


### PR DESCRIPTION
#### Summary
`GetImportLineFromDirectChannel` was producing `DirectChannelMemberImportData` entries without `SchemeUser` set. When that import data reached a Mattermost server that defaulted missing scheme flags to `false`, channel members landed in the database with all scheme flags `false` and an empty `roles` string. The web client treats that as a missing role and the message input fails to load on the affected DM/GM channels. A customer reported 444 channel member rows in this state for a single user  after a Slack import.

Slack DM and MPIM participants are always regular users (Slack does not distinguish guests), so `SchemeUser = true` is the correct default. This PR sets the field explicitly on every participant. The existing `TestGetImportLineFromDirectChannel` assertion loop is extended to require the field is populated.

The companion server-side fix lives in mattermost/mattermost: defaults the scheme flags on the import side so older or third-party importers cannot reintroduce the same bug.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-68915