### PR TITLE
ci: remove .coderabbit.yaml to use org-wide defaults

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,0 @@
-language: en-US
-reviews:
-  auto_review:
-    enabled: true


### PR DESCRIPTION
## Summary
- Removes the repo-level `.coderabbit.yaml` so CodeRabbit reviews fall back to the organization-wide defaults.

## Test plan
- [x] Confirm CodeRabbit still posts reviews on this PR using org defaults.