### PR TITLE
feat(rocketchat): add Rocket.Chat → Mattermost migration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp
 
 # IDE and editor files
 .idea
+CLAUDE.md
 
 # Locally installed tools
 tools/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,41 @@
 # Agents
 
+`mmetl` is a Go/Cobra CLI that transforms exports from other platforms (Slack
+zip, Rocket.Chat `mongodump`) into a Mattermost bulk-import JSONL file plus an
+attachments directory.
+
+## Architecture
+
+Pipeline is **Parse → Transform → Export** around a source-agnostic core:
+
+- `commands/` — Cobra layer; one `transform_<provider>.go` / `check_<provider>.go`
+  per provider. Command funcs read flags, open input, then drive a service.
+- `services/<provider>/` — provider-specific Parse + Transform (`slack`,
+  `rocketchat`, `slack_grid`).
+- `services/intermediate/` — the source-agnostic core. `types.go` defines the
+  `Intermediate` model; `export.go` defines `Exporter`, which emits the JSONL.
+  **Each provider's `Transformer` embeds `intermediate.Exporter`** — so adding a
+  provider means writing a parser + transformer that fill the Intermediate
+  model; the export side is shared.
+- `internal/tools/docgen/` — generates `docs/cli/` from the Cobra tree; do not
+  hand-edit `docs/cli/`.
+
+## Conventions
+
+- Any bot user in the source requires `--bot-owner`, or the transform errors.
+- Empty emails are invalid by default; relax with `--skip-empty-emails` or
+  `--default-email-domain`.
+- `intermediate.ExitFunc` / `NowFunc` are test seams for determinism — reuse
+  them rather than adding new globals.
+
 ## After making code changes
 
-Always run the following before considering work complete:
+Always run before considering work complete:
 
-1. `make check-style` — linting and style checks
-2. `make test` — full test suite
+1. `make check-style` — lint/style (this is what `build`/`install` gate on)
+2. `make test` — full suite. **Requires a running Docker daemon**: the
+   `*_e2e_test.go` files in `commands/` are not build-tagged and spin up real
+   Mattermost + Postgres containers via testcontainers. For fast unit tests,
+   target a service package directly (e.g. `go test ./services/rocketchat/`).
+3. If you changed any command or flag, also run `make docs` and commit the
+   regenerated `docs/cli/*.md` (CI enforces this via `make docs-check`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agents
 
 `mmetl` is a Go/Cobra CLI that transforms exports from other platforms (Slack
-zip, Rocket.Chat `mongodump`) into a Mattermost bulk-import JSONL file plus an
+zip, RocketChat `mongodump`) into a Mattermost bulk-import JSONL file plus an
 attachments directory.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # mmetl
 
-The Mattermost ETL is a tool to transform an export file from a given
-set of providers into a Mattermost compatible export file.
+The Mattermost ETL is a tool to transform an export from another platform into
+a Mattermost-compatible bulk import file (JSONL) plus an attachments directory,
+ready to be imported with `mmctl import`.
+
+## Supported providers
+
+| Provider | Input | Command |
+| --- | --- | --- |
+| Slack | export `.zip` | `mmetl transform slack` |
+| Slack Enterprise Grid | export `.zip` | `mmetl grid-transform` |
+| Rocket.Chat | `mongodump` directory | `mmetl transform rocketchat` |
 
 ## Installation
 
@@ -13,32 +22,38 @@ go install github.com/mattermost/mmetl@latest
 
 ## Usage
 
-The tool is self documented, so you can run it with with the `--help`
-flag and it will print the available subcommands and the options for
-the current command:
+The typical workflow is two steps — validate the export, then transform it:
 
 ```sh
-$ mmetl --help
+# 1. Check the export for issues before transforming
+mmetl check slack --file export.zip
+
+# 2. Transform it into a Mattermost import file
+mmetl transform slack --team myteam --file export.zip --output mm_export.jsonl
 ```
 
-You can also check the CLI generated documentation under [mmetl](docs/cli/mmetl.md).
+The tool is self-documented — run any command with `--help` to see its
+subcommands and options:
+
+```sh
+mmetl --help
+```
+
+Full CLI reference is generated under [docs/cli](docs/cli/mmetl.md). For the
+end-to-end Slack migration guide, see the
+[Mattermost docs](https://docs.mattermost.com/administration-guide/onboard/migrate-from-slack.html).
 
 ## Development
 
-### Updating Documentation
+See [AGENTS.md](AGENTS.md) for architecture, conventions, and the checks to run
+after making changes.
 
-The CLI documentation in `docs/cli/` is automatically generated from the Cobra command definitions. 
+### Documentation
 
-To regenerate the documentation after making changes to commands:
-
-```sh
-make docs
-```
-
-To verify documentation is up-to-date (useful before committing):
+The CLI docs in `docs/cli/` are generated from the Cobra command definitions.
+After changing any command or flag, regenerate and commit them:
 
 ```sh
-make docs-check
+make docs        # regenerate docs/cli/
+make docs-check  # verify they're up-to-date (CI enforces this on PRs)
 ```
-
-**Note:** The CI pipeline will automatically check if documentation is up-to-date on pull requests. If the check fails, run `make docs` and commit the updated files.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ subcommands and options:
 mmetl --help
 ```
 
+### RocketChat guest users
+
+RocketChat marks guests with a `guest` role (not a distinct user type). Control
+how they are migrated with `transform rocketchat --guest-handling`:
+
+- `guest` (default) — migrate them as Mattermost guests
+  (`system_guest`/`team_guest`/`channel_guest`). Highest fidelity. **This only
+  behaves correctly if the destination server has Guest Accounts licensed
+  (Professional/Enterprise) and enabled (`GuestAccountsSettings.Enable`).** The
+  import will not fail without it, but the accounts won't behave as guests — use
+  `user` mode for targets without guest licensing.
+- `user` — migrate them as regular Mattermost users. Works everywhere, but
+  grants guests full user permissions.
+- `skip` — drop guest users entirely, along with their memberships and authored
+  posts.
+
+Users whose RocketChat type is neither `user` nor `bot` (for example `app`
+accounts like `rocket.cat`) are always skipped, and any memberships, posts, and
+reactions referencing them are dropped so the import stays referentially
+consistent.
+
 Full CLI reference is generated under [docs/cli](docs/cli/mmetl.md). For the
 end-to-end Slack migration guide, see the
 [Mattermost docs](https://docs.mattermost.com/administration-guide/onboard/migrate-from-slack.html).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ready to be imported with `mmctl import`.
 | --- | --- | --- |
 | Slack | export `.zip` | `mmetl transform slack` |
 | Slack Enterprise Grid | export `.zip` | `mmetl grid-transform` |
-| Rocket.Chat | `mongodump` directory | `mmetl transform rocketchat` |
+| RocketChat | `mongodump` directory | `mmetl transform rocketchat` |
 
 ## Installation
 

--- a/commands/check_rocketchat.go
+++ b/commands/check_rocketchat.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mmetl/services/rocketchat"
+)
+
+var CheckRocketChatCmd = &cobra.Command{
+	Use:   "rocketchat",
+	Short: "Checks the integrity of a Rocket.Chat mongodump export.",
+	Long: `Checks the integrity of a Rocket.Chat mongodump export directory.
+
+Before running this command, export your Rocket.Chat MongoDB database using mongodump
+(https://www.mongodb.com/docs/database-tools/mongodump/):
+
+  mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
+
+Then pass the database subdirectory to --dump-dir (e.g. /tmp/rc-dump/meteor).`,
+	Example: "  check rocketchat --dump-dir /tmp/rc-dump/meteor",
+	Args:    cobra.NoArgs,
+	RunE:    checkRocketChatCmdF,
+}
+
+func init() {
+	CheckRocketChatCmd.Flags().StringP("dump-dir", "d", "", "path to the mongodump output directory")
+	if err := CheckRocketChatCmd.MarkFlagRequired("dump-dir"); err != nil {
+		panic(err)
+	}
+	CheckRocketChatCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
+	CheckRocketChatCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
+	CheckRocketChatCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+
+	CheckCmd.AddCommand(CheckRocketChatCmd)
+}
+
+func checkRocketChatCmdF(cmd *cobra.Command, args []string) error {
+	dumpDir, _ := cmd.Flags().GetString("dump-dir")
+	debug, _ := cmd.Flags().GetBool("debug")
+	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
+	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+
+	logger := log.New()
+	logFile, err := os.OpenFile("check-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	logger.SetOutput(logFile)
+	logger.SetFormatter(customLogFormatter)
+	logger.SetReportCaller(true)
+
+	if debug {
+		logger.Level = log.DebugLevel
+		logger.Info("Debug mode enabled")
+	}
+
+	parsed, err := rocketchat.ParseDump(dumpDir, logger)
+	if err != nil {
+		return err
+	}
+
+	transformer := rocketchat.NewTransformer("test", logger)
+
+	transformer.Transform(parsed, false, skipEmptyEmails, defaultEmailDomain)
+
+	transformer.CheckIntermediate()
+
+	return nil
+}

--- a/commands/check_rocketchat.go
+++ b/commands/check_rocketchat.go
@@ -44,7 +44,7 @@ func checkRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
 
 	logger := log.New()
-	logFile, err := os.OpenFile("check-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	logFile, err := os.OpenFile("check-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/commands/check_rocketchat.go
+++ b/commands/check_rocketchat.go
@@ -65,7 +65,7 @@ func checkRocketChatCmdF(cmd *cobra.Command, args []string) error {
 
 	transformer := rocketchat.NewTransformer("test", logger)
 
-	transformer.Transform(parsed, false, skipEmptyEmails, defaultEmailDomain)
+	transformer.Transform(parsed, false, skipEmptyEmails, defaultEmailDomain, rocketchat.GuestHandlingGuest)
 
 	transformer.CheckIntermediate()
 

--- a/commands/check_rocketchat.go
+++ b/commands/check_rocketchat.go
@@ -11,10 +11,10 @@ import (
 
 var CheckRocketChatCmd = &cobra.Command{
 	Use:   "rocketchat",
-	Short: "Checks the integrity of a Rocket.Chat mongodump export.",
-	Long: `Checks the integrity of a Rocket.Chat mongodump export directory.
+	Short: "Checks the integrity of a RocketChat mongodump export.",
+	Long: `Checks the integrity of a RocketChat mongodump export directory.
 
-Before running this command, export your Rocket.Chat MongoDB database using mongodump
+Before running this command, export your RocketChat MongoDB database using mongodump
 (https://www.mongodb.com/docs/database-tools/mongodump/):
 
   mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump

--- a/commands/check_rocketchat.go
+++ b/commands/check_rocketchat.go
@@ -33,6 +33,7 @@ func init() {
 	CheckRocketChatCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
 	CheckRocketChatCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
 	CheckRocketChatCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+	CheckRocketChatCmd.Flags().String("guest-handling", rocketchat.GuestHandlingGuest, `How guest users would be handled by "transform rocketchat", so their treatment can be previewed here. One of "guest", "user", or "skip" (see "transform rocketchat --help").`)
 
 	CheckCmd.AddCommand(CheckRocketChatCmd)
 }
@@ -42,16 +43,19 @@ func checkRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
 	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+	guestHandling, _ := cmd.Flags().GetString("guest-handling")
 
-	logger := log.New()
-	logFile, err := os.OpenFile("check-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
+	if err := rocketchat.ValidateGuestHandling(guestHandling); err != nil {
 		return err
 	}
-	defer logFile.Close()
-	logger.SetOutput(logFile)
-	logger.SetFormatter(customLogFormatter)
-	logger.SetReportCaller(true)
+
+	// check is a preview/diagnostic command, so log to stdout (with a plain,
+	// human-readable formatter) rather than a file — otherwise the guest
+	// decisions and validation warnings emitted below are invisible to the
+	// operator at check time.
+	logger := log.New()
+	logger.SetOutput(os.Stdout)
+	logger.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
 
 	if debug {
 		logger.Level = log.DebugLevel
@@ -65,7 +69,7 @@ func checkRocketChatCmdF(cmd *cobra.Command, args []string) error {
 
 	transformer := rocketchat.NewTransformer("test", logger)
 
-	transformer.Transform(parsed, false, skipEmptyEmails, defaultEmailDomain, rocketchat.GuestHandlingGuest)
+	transformer.Transform(parsed, false, skipEmptyEmails, defaultEmailDomain, guestHandling)
 
 	transformer.CheckIntermediate()
 

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mmetl/services/rocketchat"
+)
+
+var TransformRocketChatCmd = &cobra.Command{
+	Use:   "rocketchat",
+	Short: "Transforms a Rocket.Chat mongodump export.",
+	Long: `Transforms a Rocket.Chat mongodump directory into a Mattermost export JSONL file.
+
+Before running this command, export your Rocket.Chat MongoDB database using mongodump
+(https://www.mongodb.com/docs/database-tools/mongodump/):
+
+  mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
+
+Then pass the database subdirectory to --dump-dir (e.g. /tmp/rc-dump/meteor).`,
+	Example: "  transform rocketchat --team myteam --dump-dir /tmp/rc-dump/meteor --output mm_export.jsonl",
+	Args:    cobra.NoArgs,
+	RunE:    transformRocketChatCmdF,
+}
+
+func init() {
+	TransformRocketChatCmd.Flags().StringP("team", "t", "", "an existing team in Mattermost to import the data into")
+	if err := TransformRocketChatCmd.MarkFlagRequired("team"); err != nil {
+		panic(err)
+	}
+	TransformRocketChatCmd.Flags().StringP("dump-dir", "d", "", "path to the mongodump output directory (containing .bson files)")
+	if err := TransformRocketChatCmd.MarkFlagRequired("dump-dir"); err != nil {
+		panic(err)
+	}
+	TransformRocketChatCmd.Flags().StringP("output", "o", "bulk-export.jsonl", "the output path")
+	TransformRocketChatCmd.Flags().String("attachments-dir", "data", "the path for the attachments directory")
+	TransformRocketChatCmd.Flags().String("uploads-dir", "", "path to Rocket.Chat FileSystem uploads directory (if not using GridFS)")
+	TransformRocketChatCmd.Flags().BoolP("skip-attachments", "a", false, "Skips extracting file attachments")
+	TransformRocketChatCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
+	TransformRocketChatCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+	TransformRocketChatCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
+	TransformRocketChatCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the Rocket.Chat export contains bot users.")
+
+	TransformCmd.AddCommand(TransformRocketChatCmd)
+}
+
+func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
+	team, _ := cmd.Flags().GetString("team")
+	dumpDir, _ := cmd.Flags().GetString("dump-dir")
+	outputFilePath, _ := cmd.Flags().GetString("output")
+	attachmentsDir, _ := cmd.Flags().GetString("attachments-dir")
+	uploadsDir, _ := cmd.Flags().GetString("uploads-dir")
+	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
+	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
+	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+	debug, _ := cmd.Flags().GetBool("debug")
+	botOwner, _ := cmd.Flags().GetString("bot-owner")
+
+	team = strings.ToLower(team)
+
+	// Validate output path before doing any work, matching the guard in
+	// transformSlackCmdF.
+	if fileInfo, err := os.Stat(outputFilePath); err != nil && !os.IsNotExist(err) {
+		return err
+	} else if err == nil && fileInfo.IsDir() {
+		return fmt.Errorf("output file %q is a directory", outputFilePath)
+	}
+
+	logger := log.New()
+	logFile, err := os.OpenFile("transform-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	logger.SetOutput(logFile)
+	logger.SetFormatter(customLogFormatter)
+	logger.SetReportCaller(true)
+
+	if debug {
+		logger.Level = log.DebugLevel
+		logger.Info("Debug mode enabled")
+	}
+
+	parsed, err := rocketchat.ParseDump(dumpDir, logger)
+	if err != nil {
+		return err
+	}
+
+	transformer := rocketchat.NewTransformer(team, logger)
+	transformer.Transform(parsed, skipAttachments, skipEmptyEmails, defaultEmailDomain)
+
+	// Validate that --bot-owner is provided if there are bot users.
+	// Do this before attachment extraction so we fail fast without doing
+	// expensive I/O that would be wasted.
+	hasBots := false
+	for _, user := range transformer.Intermediate.UsersById {
+		if user.IsBot {
+			hasBots = true
+			break
+		}
+	}
+	botOwner = strings.TrimSpace(botOwner)
+	if hasBots && botOwner == "" {
+		return fmt.Errorf("the Rocket.Chat export contains bot users but --bot-owner was not specified. Please provide the username of a Mattermost user who will own the imported bots")
+	}
+
+	if !skipAttachments {
+		chunksFilePath := path.Join(dumpDir, "rocketchat_uploads.chunks.bson")
+		var gridfsChunks map[string][]rocketchat.GridFSChunk
+		if _, err := os.Stat(chunksFilePath); err == nil {
+			gridfsChunks, err = rocketchat.LoadGridFSChunks(chunksFilePath)
+			if err != nil {
+				logger.Warnf("Failed to load GridFS chunks: %v", err)
+			}
+		}
+
+		attachmentsOutput := path.Join(attachmentsDir, "bulk-export-attachments")
+		if err := rocketchat.ExtractAttachments(parsed.UploadsByID, gridfsChunks, attachmentsOutput, uploadsDir, logger); err != nil {
+			return err
+		}
+	}
+
+	if err := transformer.Export(outputFilePath, botOwner); err != nil {
+		return err
+	}
+
+	logger.Infof("Transformation succeeded! Users: %d, Public channels: %d, Private channels: %d, Posts: %d",
+		len(transformer.Intermediate.UsersById),
+		len(transformer.Intermediate.PublicChannels),
+		len(transformer.Intermediate.PrivateChannels),
+		len(transformer.Intermediate.Posts),
+	)
+
+	return nil
+}

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -72,7 +72,7 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	logger := log.New()
-	logFile, err := os.OpenFile("transform-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	logFile, err := os.OpenFile("transform-rocketchat.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,8 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 		if _, err := os.Stat(chunksFilePath); err == nil {
 			gridfsChunks, err = rocketchat.LoadGridFSChunks(chunksFilePath)
 			if err != nil {
-				logger.Warnf("Failed to load GridFS chunks: %v", err)
+				return fmt.Errorf("failed to load GridFS chunks from %s: %w. "+
+					"Fix the dump, or re-run with --skip-attachments to proceed without attachments", chunksFilePath, err)
 			}
 		}
 

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -43,6 +43,10 @@ func init() {
 	TransformRocketChatCmd.Flags().BoolP("skip-attachments", "a", false, "Skips extracting file attachments")
 	TransformRocketChatCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
 	TransformRocketChatCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
+	TransformRocketChatCmd.Flags().String("guest-handling", rocketchat.GuestHandlingGuest, `How to migrate RocketChat guest users (users whose roles include "guest"). One of:
+  "guest" - migrate them as Mattermost guests (system_guest/team_guest/channel_guest). Highest fidelity, but the destination server must have Guest Accounts licensed (Professional/Enterprise) and enabled (GuestAccountsSettings.Enable); otherwise the accounts won't behave correctly.
+  "user"  - migrate them as regular Mattermost users. Works everywhere, but grants guests full user permissions.
+  "skip"  - drop guest users entirely, along with their memberships and authored posts.`)
 	TransformRocketChatCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
 	TransformRocketChatCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the RocketChat export contains bot users.")
 
@@ -58,8 +62,13 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
 	skipEmptyEmails, _ := cmd.Flags().GetBool("skip-empty-emails")
 	defaultEmailDomain, _ := cmd.Flags().GetString("default-email-domain")
+	guestHandling, _ := cmd.Flags().GetString("guest-handling")
 	debug, _ := cmd.Flags().GetBool("debug")
 	botOwner, _ := cmd.Flags().GetString("bot-owner")
+
+	if err := rocketchat.ValidateGuestHandling(guestHandling); err != nil {
+		return err
+	}
 
 	team = strings.ToLower(team)
 
@@ -92,7 +101,7 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	transformer := rocketchat.NewTransformer(team, logger)
-	transformer.Transform(parsed, skipAttachments, skipEmptyEmails, defaultEmailDomain)
+	transformer.Transform(parsed, skipAttachments, skipEmptyEmails, defaultEmailDomain, guestHandling)
 
 	// Validate that --bot-owner is provided if there are bot users.
 	// Do this before attachment extraction so we fail fast without doing

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -127,6 +127,8 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to index GridFS chunks from %s: %w. "+
 					"Fix the dump, or re-run with --skip-attachments to proceed without attachments", chunksFilePath, err)
 			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat GridFS chunks file %s: %w", chunksFilePath, err)
 		}
 
 		attachmentsOutput := path.Join(attachmentsDir, "bulk-export-attachments")

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -120,17 +120,17 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 
 	if !skipAttachments {
 		chunksFilePath := path.Join(dumpDir, "rocketchat_uploads.chunks.bson")
-		var gridfsChunks map[string][]rocketchat.GridFSChunk
+		var gridfsIndex *rocketchat.GridFSIndex
 		if _, err := os.Stat(chunksFilePath); err == nil {
-			gridfsChunks, err = rocketchat.LoadGridFSChunks(chunksFilePath)
+			gridfsIndex, err = rocketchat.BuildGridFSIndex(chunksFilePath)
 			if err != nil {
-				return fmt.Errorf("failed to load GridFS chunks from %s: %w. "+
+				return fmt.Errorf("failed to index GridFS chunks from %s: %w. "+
 					"Fix the dump, or re-run with --skip-attachments to proceed without attachments", chunksFilePath, err)
 			}
 		}
 
 		attachmentsOutput := path.Join(attachmentsDir, "bulk-export-attachments")
-		if err := rocketchat.ExtractAttachments(parsed.UploadsByID, gridfsChunks, attachmentsOutput, uploadsDir, logger); err != nil {
+		if err := rocketchat.ExtractAttachments(parsed.UploadsByID, gridfsIndex, attachmentsOutput, uploadsDir, logger); err != nil {
 			return err
 		}
 	}

--- a/commands/transform_rocketchat.go
+++ b/commands/transform_rocketchat.go
@@ -14,10 +14,10 @@ import (
 
 var TransformRocketChatCmd = &cobra.Command{
 	Use:   "rocketchat",
-	Short: "Transforms a Rocket.Chat mongodump export.",
-	Long: `Transforms a Rocket.Chat mongodump directory into a Mattermost export JSONL file.
+	Short: "Transforms a RocketChat mongodump export.",
+	Long: `Transforms a RocketChat mongodump directory into a Mattermost export JSONL file.
 
-Before running this command, export your Rocket.Chat MongoDB database using mongodump
+Before running this command, export your RocketChat MongoDB database using mongodump
 (https://www.mongodb.com/docs/database-tools/mongodump/):
 
   mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
@@ -39,12 +39,12 @@ func init() {
 	}
 	TransformRocketChatCmd.Flags().StringP("output", "o", "bulk-export.jsonl", "the output path")
 	TransformRocketChatCmd.Flags().String("attachments-dir", "data", "the path for the attachments directory")
-	TransformRocketChatCmd.Flags().String("uploads-dir", "", "path to Rocket.Chat FileSystem uploads directory (if not using GridFS)")
+	TransformRocketChatCmd.Flags().String("uploads-dir", "", "path to RocketChat FileSystem uploads directory (if not using GridFS)")
 	TransformRocketChatCmd.Flags().BoolP("skip-attachments", "a", false, "Skips extracting file attachments")
 	TransformRocketChatCmd.Flags().Bool("skip-empty-emails", false, "Ignore empty email addresses from the import file. Note that this results in invalid data.")
 	TransformRocketChatCmd.Flags().String("default-email-domain", "", "If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.")
 	TransformRocketChatCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
-	TransformRocketChatCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the Rocket.Chat export contains bot users.")
+	TransformRocketChatCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the RocketChat export contains bot users.")
 
 	TransformCmd.AddCommand(TransformRocketChatCmd)
 }
@@ -106,7 +106,7 @@ func transformRocketChatCmdF(cmd *cobra.Command, args []string) error {
 	}
 	botOwner = strings.TrimSpace(botOwner)
 	if hasBots && botOwner == "" {
-		return fmt.Errorf("the Rocket.Chat export contains bot users but --bot-owner was not specified. Please provide the username of a Mattermost user who will own the imported bots")
+		return fmt.Errorf("the RocketChat export contains bot users but --bot-owner was not specified. Please provide the username of a Mattermost user who will own the imported bots")
 	}
 
 	if !skipAttachments {

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -1,0 +1,604 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/mattermost/mmetl/commands"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetRCFlags resets all Cobra flags to their defaults before each subtest so
+// that flag state does not leak between tests when reusing the global RootCmd.
+// (resetCobraFlags is defined in transform_slack_e2e_test.go and available here
+// since both files share the commands_test package.)
+func resetRCFlags() {
+	resetCobraFlags(commands.RootCmd)
+}
+
+// marshalBSONFileCmds serialises a slice of documents into a concatenated BSON
+// file (the format produced by mongodump) and writes it to filePath.
+func marshalBSONFileCmds(t *testing.T, filePath string, docs []any) {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, doc := range docs {
+		b, err := bson.Marshal(doc)
+		require.NoError(t, err)
+		_, err = buf.Write(b)
+		require.NoError(t, err)
+	}
+	err := os.WriteFile(filePath, buf.Bytes(), 0600)
+	require.NoError(t, err)
+}
+
+// rcBSONUser is a minimal BSON-serialisable struct mirroring RocketChatUser.
+// Using a local struct avoids importing the rocketchat package (which would
+// create a dependency cycle through commands → rocketchat in test code).
+type rcBSONUser struct {
+	ID       string   `bson:"_id"`
+	Username string   `bson:"username"`
+	Name     string   `bson:"name"`
+	Emails   []rcMail `bson:"emails"`
+	Active   bool     `bson:"active"`
+	Roles    []string `bson:"roles"`
+	Type     string   `bson:"type"`
+}
+
+type rcMail struct {
+	Address  string `bson:"address"`
+	Verified bool   `bson:"verified"`
+}
+
+type rcRoom struct {
+	ID        string   `bson:"_id"`
+	Type      string   `bson:"t"`
+	Name      string   `bson:"name"`
+	FName     string   `bson:"fname"`
+	Usernames []string `bson:"usernames"`
+	UIDs      []string `bson:"uids"`
+}
+
+type rcMessage struct {
+	ID        string    `bson:"_id"`
+	RoomID    string    `bson:"rid"`
+	User      rcMsgUser `bson:"u"`
+	Message   string    `bson:"msg"`
+	Timestamp time.Time `bson:"ts"`
+	ThreadID  string    `bson:"tmid"`
+}
+
+type rcMsgUser struct {
+	ID       string `bson:"_id"`
+	Username string `bson:"username"`
+}
+
+type rcSubscription struct {
+	RoomID string    `bson:"rid"`
+	User   rcMsgUser `bson:"u"`
+}
+
+func writeDumpDir(t *testing.T, dir string, users []any, rooms []any, messages []any, subs []any) {
+	t.Helper()
+	marshalBSONFileCmds(t, filepath.Join(dir, "users.bson"), users)
+	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_room.bson"), rooms)
+	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_message.bson"), messages)
+	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_subscription.bson"), subs)
+}
+
+func TestTransformRocketChatE2E(t *testing.T) {
+	ts1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2024, 1, 1, 12, 1, 0, 0, time.UTC)
+	ts3 := time.Date(2024, 1, 1, 12, 2, 0, 0, time.UTC)
+
+	defaultUsers := []any{
+		rcBSONUser{
+			ID:       "u1",
+			Username: "johndoe",
+			Name:     "John Doe",
+			Emails:   []rcMail{{Address: "john@example.com", Verified: true}},
+			Active:   true,
+			Roles:    []string{"user"},
+			Type:     "user",
+		},
+		rcBSONUser{
+			ID:       "u2",
+			Username: "janesmith",
+			Name:     "Jane Smith",
+			Emails:   []rcMail{{Address: "jane@example.com", Verified: true}},
+			Active:   true,
+			Roles:    []string{"user"},
+			Type:     "user",
+		},
+	}
+
+	defaultRooms := []any{
+		rcRoom{ID: "r1", Type: "c", Name: "general", FName: "General"},
+		rcRoom{ID: "r2", Type: "p", Name: "private-stuff", FName: "Private Stuff"},
+		rcRoom{
+			ID:        "r3",
+			Type:      "d",
+			Usernames: []string{"johndoe", "janesmith"},
+			UIDs:      []string{"u1", "u2"},
+		},
+	}
+
+	defaultMessages := []any{
+		rcMessage{ID: "m1", RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "johndoe"}, Message: "Hello world", Timestamp: ts1},
+		rcMessage{ID: "m2", RoomID: "r1", User: rcMsgUser{ID: "u2", Username: "janesmith"}, Message: "Hi there", Timestamp: ts2},
+		rcMessage{ID: "m3", RoomID: "r3", User: rcMsgUser{ID: "u1", Username: "johndoe"}, Message: "Direct message", Timestamp: ts3},
+	}
+
+	defaultSubs := []any{
+		rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "johndoe"}},
+		rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u2", Username: "janesmith"}},
+		rcSubscription{RoomID: "r2", User: rcMsgUser{ID: "u1", Username: "johndoe"}},
+	}
+
+	t.Run("valid export produces correct JSONL", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		writeDumpDir(t, dir, defaultUsers, defaultRooms, defaultMessages, defaultSubs)
+
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		err := c.Execute()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+
+		lines := splitJSONLLines(t, data)
+		require.NotEmpty(t, lines)
+
+		// First line must be version
+		assertJSONField(t, lines[0], "type", "version")
+		assert.Equal(t, float64(1), lines[0]["version"])
+
+		// Public channel (general)
+		channelLines := findLinesByType(lines, "channel")
+		require.NotEmpty(t, channelLines)
+		generalCh := findChannelByName(channelLines, "general")
+		require.NotNil(t, generalCh, "expected channel 'general'")
+		assert.Equal(t, "O", generalCh["type"])
+		assert.Equal(t, "General", generalCh["display_name"])
+
+		// Private channel (private-stuff)
+		privateCh := findChannelByName(channelLines, "private-stuff")
+		require.NotNil(t, privateCh, "expected channel 'private-stuff'")
+		assert.Equal(t, "P", privateCh["type"])
+
+		// User lines
+		userLines := findLinesByType(lines, "user")
+		require.Len(t, userLines, 2)
+		john := findUserByUsername(userLines, "johndoe")
+		require.NotNil(t, john, "expected user 'johndoe'")
+		assert.Equal(t, "john@example.com", john["email"])
+		assert.Equal(t, "John", john["first_name"])
+		assert.Equal(t, "Doe", john["last_name"])
+		// johndoe is subscribed to r1 (general) and r2 (private-stuff) but not r3 (DM)
+		teams := john["teams"].([]any)
+		require.Len(t, teams, 1)
+		teamEntry := teams[0].(map[string]any)
+		assert.Equal(t, "testteam", teamEntry["name"])
+		channels := teamEntry["channels"].([]any)
+		require.Len(t, channels, 2)
+
+		// Direct channel line
+		directChLines := findLinesByType(lines, "direct_channel")
+		require.NotEmpty(t, directChLines, "expected at least one direct_channel line")
+		// r3 has usernames johndoe and janesmith
+		dmLine := findDirectChannelWithMembers(directChLines, []string{"johndoe", "janesmith"})
+		require.NotNil(t, dmLine, "expected direct_channel with johndoe and janesmith")
+
+		// Post lines (non-direct)
+		postLines := findLinesByType(lines, "post")
+		require.Len(t, postLines, 2)
+		msgs := collectMessages(postLines)
+		assert.Contains(t, msgs, "Hello world")
+		assert.Contains(t, msgs, "Hi there")
+
+		// Direct post line
+		directPostLines := findLinesByType(lines, "direct_post")
+		require.Len(t, directPostLines, 1)
+		dp := directPostLines[0]
+		assert.Equal(t, "Direct message", dp["message"])
+	})
+
+	t.Run("team name uppercase is lowercased", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+		writeDumpDir(t, dir, defaultUsers, defaultRooms, defaultMessages, defaultSubs)
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "TestTeam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		// Team name should be lowercased in channel records.
+		channelLines := findLinesByType(lines, "channel")
+		require.NotEmpty(t, channelLines)
+		assert.Equal(t, "testteam", channelLines[0]["team"])
+	})
+
+	t.Run("thread replies nested under parent post", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		// root message m1 and a reply m2 (tmid = m1)
+		replyMsg := rcMessage{
+			ID:        "m2",
+			RoomID:    "r1",
+			User:      rcMsgUser{ID: "u2", Username: "janesmith"},
+			Message:   "This is a reply",
+			Timestamp: ts2,
+			ThreadID:  "m1",
+		}
+		rootMsg := rcMessage{
+			ID:        "m1",
+			RoomID:    "r1",
+			User:      rcMsgUser{ID: "u1", Username: "johndoe"},
+			Message:   "Root message",
+			Timestamp: ts1,
+		}
+		rooms := []any{rcRoom{ID: "r1", Type: "c", Name: "general", FName: "General"}}
+		subs := []any{
+			rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "johndoe"}},
+			rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u2", Username: "janesmith"}},
+		}
+		writeDumpDir(t, dir, defaultUsers, rooms, []any{rootMsg, replyMsg}, subs)
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		postLines := findLinesByType(lines, "post")
+		require.Len(t, postLines, 1, "only root post should be a top-level post line")
+
+		post := postLines[0]
+		assert.Equal(t, "Root message", post["message"])
+
+		replies, ok := post["replies"].([]any)
+		require.True(t, ok, "expected replies array on root post")
+		require.Len(t, replies, 1)
+		reply := replies[0].(map[string]any)
+		assert.Equal(t, "This is a reply", reply["message"])
+		assert.Equal(t, "janesmith", reply["user"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Edge case tests (Phase 5.2)
+// ---------------------------------------------------------------------------
+
+func TestTransformRocketChatEdgeCases(t *testing.T) {
+	t.Run("empty collections produce minimal JSONL", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+		writeDumpDir(t, dir, []any{}, []any{}, []any{}, []any{})
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		// Must have only the version line, nothing else
+		require.Len(t, lines, 1)
+		assertJSONField(t, lines[0], "type", "version")
+	})
+
+	t.Run("message with username not in UsersById uses username from message", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		users := []any{
+			rcBSONUser{ID: "u1", Username: "alice", Emails: []rcMail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		rooms := []any{rcRoom{ID: "r1", Type: "c", Name: "general", FName: "General"}}
+		// "ghost" user ID and username is not in the users collection.
+		// The transformer uses the username from the message directly.
+		messages := []any{
+			rcMessage{ID: "m1", RoomID: "r1", User: rcMsgUser{ID: "ghost", Username: "ghost"}, Message: "ghost message", Timestamp: time.Now()},
+			rcMessage{ID: "m2", RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "alice"}, Message: "real message", Timestamp: time.Now()},
+		}
+		subs := []any{rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "alice"}}}
+		writeDumpDir(t, dir, users, rooms, messages, subs)
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		postLines := findLinesByType(lines, "post")
+		msgs := collectMessages(postLines)
+		// Both messages should appear — the ghost user's username is taken from the message.
+		assert.Contains(t, msgs, "ghost message")
+		assert.Contains(t, msgs, "real message")
+	})
+
+	t.Run("encrypted room is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		rooms := []any{
+			rcRoom{ID: "r1", Type: "c", Name: "general", FName: "General"},
+		}
+		// Encrypted rooms cannot be represented with the simple rcRoom struct (no Encrypted field).
+		// Use a raw bson.D to include the encrypted: true field.
+		encryptedRoom := bson.D{
+			{Key: "_id", Value: "r2"},
+			{Key: "t", Value: "c"},
+			{Key: "name", Value: "encrypted-channel"},
+			{Key: "fname", Value: "Encrypted Channel"},
+			{Key: "encrypted", Value: true},
+		}
+		users := []any{
+			rcBSONUser{ID: "u1", Username: "alice", Emails: []rcMail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		subs := []any{rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "alice"}}}
+		marshalBSONFileCmds(t, filepath.Join(dir, "users.bson"), users)
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_room.bson"), append(rooms, encryptedRoom))
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_message.bson"), []any{})
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_subscription.bson"), subs)
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		chLines := findLinesByType(lines, "channel")
+		names := make([]string, 0, len(chLines))
+		for _, ch := range chLines {
+			if n, ok := ch["name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+		assert.Contains(t, names, "general")
+		assert.NotContains(t, names, "encrypted-channel")
+	})
+
+	t.Run("discussion room is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		regularRoom := bson.D{
+			{Key: "_id", Value: "r1"},
+			{Key: "t", Value: "c"},
+			{Key: "name", Value: "general"},
+			{Key: "fname", Value: "General"},
+		}
+		discussionRoom := bson.D{
+			{Key: "_id", Value: "r2"},
+			{Key: "t", Value: "p"},
+			{Key: "name", Value: "discussion-room"},
+			{Key: "fname", Value: "Discussion Room"},
+			{Key: "prid", Value: "r1"}, // marks it as a discussion
+		}
+		users := []any{
+			rcBSONUser{ID: "u1", Username: "alice", Emails: []rcMail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		subs := []any{rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "alice"}}}
+		marshalBSONFileCmds(t, filepath.Join(dir, "users.bson"), users)
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_room.bson"), []any{regularRoom, discussionRoom})
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_message.bson"), []any{})
+		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_subscription.bson"), subs)
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		chLines := findLinesByType(lines, "channel")
+		names := make([]string, 0, len(chLines))
+		for _, ch := range chLines {
+			if n, ok := ch["name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+		assert.Contains(t, names, "general")
+		assert.NotContains(t, names, "discussion-room")
+	})
+
+	t.Run("user with no email and default-email-domain generates email", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "output.jsonl")
+
+		users := []any{
+			rcBSONUser{ID: "u1", Username: "noemail", Name: "No Email", Active: true, Type: "user"},
+		}
+		writeDumpDir(t, dir, users, []any{}, []any{}, []any{})
+		defer os.Remove("transform-rocketchat.log")
+
+		c := commands.RootCmd
+		resetRCFlags()
+		c.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", "testteam",
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+			"--default-email-domain", "myorg.com",
+		})
+		require.NoError(t, c.Execute())
+
+		data, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		lines := splitJSONLLines(t, data)
+
+		userLines := findLinesByType(lines, "user")
+		require.Len(t, userLines, 1)
+		assert.Equal(t, "noemail@myorg.com", userLines[0]["email"])
+	})
+}
+
+// --- helpers ---
+
+func splitJSONLLines(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	for _, raw := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+		if len(raw) == 0 {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(raw, &m), "invalid JSON line: %s", string(raw))
+		lines = append(lines, m)
+	}
+	return lines
+}
+
+func assertJSONField(t *testing.T, m map[string]any, key string, expected any) {
+	t.Helper()
+	assert.Equal(t, expected, m[key])
+}
+
+func findLinesByType(lines []map[string]any, typeName string) []map[string]any {
+	var result []map[string]any
+	for _, l := range lines {
+		if l["type"] == typeName {
+			inner, ok := l[typeName].(map[string]any)
+			if ok {
+				result = append(result, inner)
+			}
+		}
+	}
+	return result
+}
+
+func findChannelByName(channelLines []map[string]any, name string) map[string]any {
+	for _, ch := range channelLines {
+		if ch["name"] == name {
+			return ch
+		}
+	}
+	return nil
+}
+
+func findUserByUsername(userLines []map[string]any, username string) map[string]any {
+	for _, u := range userLines {
+		if u["username"] == username {
+			return u
+		}
+	}
+	return nil
+}
+
+func findDirectChannelWithMembers(dcLines []map[string]any, members []string) map[string]any {
+	memberSet := make(map[string]bool)
+	for _, m := range members {
+		memberSet[m] = true
+	}
+	for _, dc := range dcLines {
+		rawMembers, ok := dc["members"].([]any)
+		if !ok {
+			continue
+		}
+		if len(rawMembers) != len(members) {
+			continue
+		}
+		match := true
+		for _, rm := range rawMembers {
+			if s, ok := rm.(string); !ok || !memberSet[s] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return dc
+		}
+	}
+	return nil
+}
+
+func collectMessages(postLines []map[string]any) []string {
+	var msgs []string
+	for _, p := range postLines {
+		if m, ok := p["message"].(string); ok {
+			msgs = append(msgs, m)
+		}
+	}
+	return msgs
+}

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -209,9 +209,9 @@ func TestTransformRocketChatImportE2E(t *testing.T) {
 
 // TestTransformRocketChatE2EGuestImport verifies guest handling end to end:
 // a guest with a channel membership is imported as a Mattermost guest
-// (system_guest + scheme_guest at team and channel level), while a channel-less
-// guest (present only in a DM) is dropped in guest mode with no dangling
-// references.
+// (system_guest + scheme_guest at team, channel, and DM level), while a
+// channel-less guest (present only in a DM) is dropped in guest mode with no
+// dangling references.
 func TestTransformRocketChatE2EGuestImport(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -231,6 +231,9 @@ func TestTransformRocketChatE2EGuestImport(t *testing.T) {
 	}
 	rooms := []any{
 		rcRoom{ID: "engineering-id", Type: "c", Name: "engineering", FName: "Engineering"},
+		// bob (an effective guest) shares a DM with alice → exercises the DM guest
+		// scheme fix.
+		rcRoom{ID: "alice-bob-dm", Type: "d", Usernames: []string{"alice", "bob"}, UIDs: []string{"alice-id", "bob-id"}},
 		// carol only appears in a DM (no channel subscription) → channel-less.
 		rcRoom{ID: "alice-carol-dm", Type: "d", Usernames: []string{"alice", "carol"}, UIDs: []string{"alice-id", "carol-id"}},
 	}
@@ -238,7 +241,8 @@ func TestTransformRocketChatE2EGuestImport(t *testing.T) {
 	messages := []any{
 		rcMessage{ID: "eng-root", RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}, Message: "Welcome!", Timestamp: baseTime},
 		rcMessage{ID: "eng-guest", RoomID: "engineering-id", User: rcMsgUser{ID: "bob-id", Username: "bob"}, Message: "Thanks for having me", Timestamp: baseTime.Add(time.Minute)},
-		rcMessage{ID: "carol-dm", RoomID: "alice-carol-dm", User: rcMsgUser{ID: "carol-id", Username: "carol"}, Message: "should be dropped", Timestamp: baseTime.Add(2 * time.Minute)},
+		rcMessage{ID: "bob-dm", RoomID: "alice-bob-dm", User: rcMsgUser{ID: "bob-id", Username: "bob"}, Message: "guest DM hello", Timestamp: baseTime.Add(2 * time.Minute)},
+		rcMessage{ID: "carol-dm", RoomID: "alice-carol-dm", User: rcMsgUser{ID: "carol-id", Username: "carol"}, Message: "should be dropped", Timestamp: baseTime.Add(3 * time.Minute)},
 	}
 	subscriptions := []any{
 		rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}},
@@ -258,7 +262,11 @@ func TestTransformRocketChatE2EGuestImport(t *testing.T) {
 	})
 	require.NoError(t, commands.RootCmd.Execute())
 
-	th.ValidateImportFileOrFail(ctx, outputPath)
+	// Carol (channel-less guest) and her DM post are dropped, so only alice+bob
+	// and bob's single direct post survive.
+	validation := th.ValidateImportFileOrFail(ctx, outputPath)
+	assert.Equal(t, uint64(2), validation.UserCount, "channel-less guest carol should be dropped")
+	assert.Equal(t, uint64(1), validation.DirectPostCount, "carol's DM post should be dropped, leaving only bob's")
 	require.NoError(t, th.ImportBulkData(ctx, outputPath))
 
 	alice := th.AssertUserExists(ctx, "alice")
@@ -295,10 +303,28 @@ func TestTransformRocketChatE2EGuestImport(t *testing.T) {
 	assert.False(t, channelByUserID[bob.Id].SchemeUser)
 	assert.False(t, channelByUserID[alice.Id].SchemeGuest)
 
-	// carol's DM message must not have been imported.
-	engPosts, err := th.GetChannelPosts(ctx, engineering.Id, 0, 100)
+	// DM-level scheme flags: bob is an effective guest, so he must be scheme_guest
+	// in the DM he shares with alice too (the direct-channel guest fix).
+	aliceBobDM, _, err := th.Client.CreateDirectChannel(ctx, alice.Id, bob.Id)
 	require.NoError(t, err)
-	assert.Nil(t, findPostByMessage(engPosts, "should be dropped"))
+	dmMembers, err := th.GetChannelMembers(ctx, aliceBobDM.Id)
+	require.NoError(t, err)
+	dmByUserID := map[string]*model.ChannelMember{}
+	for i := range dmMembers {
+		dmByUserID[dmMembers[i].UserId] = &dmMembers[i]
+	}
+	require.NotNil(t, dmByUserID[bob.Id])
+	assert.True(t, dmByUserID[bob.Id].SchemeGuest, "guest must be scheme_guest in the DM too")
+	assert.False(t, dmByUserID[bob.Id].SchemeUser)
+	require.NotNil(t, dmByUserID[alice.Id])
+	assert.False(t, dmByUserID[alice.Id].SchemeGuest)
+
+	// bob's DM message imported; carol's DM post was already shown to be dropped
+	// by the DirectPostCount assertion above.
+	dmPosts, err := th.GetChannelPosts(ctx, aliceBobDM.Id, 0, 100)
+	require.NoError(t, err)
+	assert.NotNil(t, findPostByMessage(dmPosts, "guest DM hello"))
+	assert.Nil(t, findPostByMessage(dmPosts, "should be dropped"))
 }
 
 func TestTransformRocketChatE2EBotImport(t *testing.T) {

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -308,6 +308,76 @@ func TestTransformRocketChatE2EBotImport(t *testing.T) {
 	})
 }
 
+func TestTransformRocketChatE2EGroupDMs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "mattermost_import.jsonl")
+	teamName := uniqueTeamName("rcgdm")
+	t.Cleanup(func() { os.Remove("transform-rocketchat.log") })
+
+	users := []any{
+		rcBSONUser{ID: "alice-id", Username: "alice", Name: "Alice Anderson", Emails: []rcMail{{Address: "alice@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "bob-id", Username: "bob", Name: "Bob Brown", Emails: []rcMail{{Address: "bob@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "carol-id", Username: "carol", Name: "Carol Clark", Emails: []rcMail{{Address: "carol@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "dave-id", Username: "dave", Name: "Dave Davis", Emails: []rcMail{{Address: "dave@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+	}
+	rooms := []any{
+		rcRoom{ID: "release-gdm", Type: "d", UIDs: []string{"alice-id", "bob-id", "carol-id"}, Usernames: []string{"alice", "bob", "carol"}},
+		rcRoom{ID: "ops-gdm", Type: "d", UIDs: []string{"alice-id", "bob-id", "dave-id"}, Usernames: []string{"alice", "bob", "dave"}},
+	}
+	baseTime := time.Date(2024, 3, 1, 11, 0, 0, 0, time.UTC)
+	messages := []any{
+		rcMessage{ID: "release-post", RoomID: "release-gdm", User: rcMsgUser{ID: "carol-id", Username: "carol"}, Message: "Release checklist is ready", Timestamp: baseTime},
+		rcMessage{ID: "ops-post", RoomID: "ops-gdm", User: rcMsgUser{ID: "dave-id", Username: "dave"}, Message: "Operations handoff is ready", Timestamp: baseTime.Add(time.Minute)},
+	}
+	writeDumpDir(t, dir, users, rooms, messages, []any{})
+
+	team := th.CreateTeam(ctx, teamName, "RocketChat Group DM E2E Team")
+	resetRCFlags()
+	commands.RootCmd.SetArgs([]string{
+		"transform", "rocketchat",
+		"--team", teamName,
+		"--dump-dir", dir,
+		"--output", outputPath,
+		"--skip-attachments",
+	})
+	require.NoError(t, commands.RootCmd.Execute())
+
+	exportData, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	exportLines := splitJSONLLines(t, exportData)
+	require.Len(t, findLinesByType(exportLines, "direct_channel"), 2)
+	require.Len(t, findLinesByType(exportLines, "direct_post"), 2)
+	th.ValidateImportFileOrFail(ctx, outputPath)
+	require.NoError(t, th.ImportBulkData(ctx, outputPath))
+
+	alice := th.AssertUserExists(ctx, "alice")
+	bob := th.AssertUserExists(ctx, "bob")
+	carol := th.AssertUserExists(ctx, "carol")
+	dave := th.AssertUserExists(ctx, "dave")
+	for _, user := range []*model.User{alice, bob, carol, dave} {
+		th.AssertUserInTeam(ctx, team.Id, user.Id)
+	}
+
+	releaseChannel := findGroupChannelByMembers(t, th, ctx, alice.Id, []string{alice.Id, bob.Id, carol.Id})
+	require.NotNil(t, releaseChannel)
+	opsChannel := findGroupChannelByMembers(t, th, ctx, alice.Id, []string{alice.Id, bob.Id, dave.Id})
+	require.NotNil(t, opsChannel)
+	assert.NotEqual(t, releaseChannel.Id, opsChannel.Id)
+
+	releasePosts, err := th.GetChannelPosts(ctx, releaseChannel.Id, 0, 100)
+	require.NoError(t, err)
+	require.NotNil(t, findPostByMessage(releasePosts, "Release checklist is ready"))
+	opsPosts, err := th.GetChannelPosts(ctx, opsChannel.Id, 0, 100)
+	require.NoError(t, err)
+	require.NotNil(t, findPostByMessage(opsPosts, "Operations handoff is ready"))
+}
+
 func TestTransformRocketChatE2E(t *testing.T) {
 	ts1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2024, 1, 1, 12, 1, 0, 0, time.UTC)
@@ -793,4 +863,36 @@ func assertChannelMembers(t *testing.T, th *testhelper.TestHelper, ctx context.C
 	for _, userID := range unexpected {
 		assert.NotContains(t, memberIDs, userID)
 	}
+}
+
+func findGroupChannelByMembers(t *testing.T, th *testhelper.TestHelper, ctx context.Context, userID string, expectedIDs []string) *model.Channel {
+	t.Helper()
+	channels, _, err := th.Client.GetChannelsForUserWithLastDeleteAt(ctx, userID, 0)
+	require.NoError(t, err)
+
+	expected := make(map[string]struct{}, len(expectedIDs))
+	for _, id := range expectedIDs {
+		expected[id] = struct{}{}
+	}
+	for _, channel := range channels {
+		if channel.Type != model.ChannelTypeGroup {
+			continue
+		}
+		members, memberErr := th.GetChannelMembers(ctx, channel.Id)
+		require.NoError(t, memberErr)
+		if len(members) != len(expected) {
+			continue
+		}
+		matches := true
+		for _, member := range members {
+			if _, ok := expected[member.UserId]; !ok {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return channel
+		}
+	}
+	return nil
 }

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -278,6 +278,9 @@ func TestTransformRocketChatE2EBotImport(t *testing.T) {
 		oldBot := th.AssertBotExists(ctx, "oldbot")
 		assert.Equal(t, "Old Bot", oldBot.DisplayName)
 		assert.Equal(t, th.AdminUser.Id, oldBot.OwnerId)
+		// Mattermost's importBot does not currently apply delete_at. The JSONL
+		// assertion above verifies that mmetl exports the inactive state; here we
+		// only verify the properties that the server preserves.
 
 		engineering := th.AssertChannelExists(ctx, teamName, "engineering")
 		posts, err := th.GetChannelPosts(ctx, engineering.Id, 0, 100)

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -207,6 +207,107 @@ func TestTransformRocketChatImportE2E(t *testing.T) {
 	require.NotNil(t, findPostByMessage(dmPosts, "Can we sync on the migration?"))
 }
 
+func TestTransformRocketChatE2EBotImport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	t.Cleanup(func() { os.Remove("transform-rocketchat.log") })
+
+	t.Run("bots and deactivated users import with posts and ownership", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "mattermost_import.jsonl")
+		teamName := uniqueTeamName("rcbots")
+		baseTime := time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC)
+
+		users := []any{
+			rcBSONUser{ID: "alice-id", Username: "alice", Name: "Alice Anderson", Emails: []rcMail{{Address: "alice@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+			rcBSONUser{ID: "former-id", Username: "former", Name: "Former Employee", Emails: []rcMail{{Address: "former@example.com", Verified: true}}, Active: false, Roles: []string{"user"}, Type: "user"},
+			rcBSONUser{ID: "helperbot-id", Username: "helperbot", Name: "Helper Bot", Active: true, Roles: []string{"bot", "user"}, Type: "bot"},
+			rcBSONUser{ID: "oldbot-id", Username: "oldbot", Name: "Old Bot", Active: false, Roles: []string{"bot", "user"}, Type: "bot"},
+		}
+		rooms := []any{rcRoom{ID: "engineering-id", Type: "c", Name: "engineering", FName: "Engineering"}}
+		messages := []any{
+			rcMessage{ID: "human-post", RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}, Message: "Starting the deploy", Timestamp: baseTime},
+			rcMessage{ID: "bot-post", RoomID: "engineering-id", User: rcMsgUser{ID: "helperbot-id", Username: "helperbot"}, Message: "Deployment completed successfully", Timestamp: baseTime.Add(time.Minute)},
+		}
+		subscriptions := []any{
+			rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}},
+			rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "former-id", Username: "former"}},
+		}
+		writeDumpDir(t, dir, users, rooms, messages, subscriptions)
+
+		team := th.CreateTeam(ctx, teamName, "RocketChat Bots E2E Team")
+		resetRCFlags()
+		commands.RootCmd.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", teamName,
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+			"--bot-owner", "admin",
+		})
+		require.NoError(t, commands.RootCmd.Execute())
+
+		exportData, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		botLines := findLinesByType(splitJSONLLines(t, exportData), "bot")
+		oldBotLine := findUserByUsername(botLines, "oldbot")
+		require.NotNil(t, oldBotLine)
+		assert.NotZero(t, oldBotLine["delete_at"])
+
+		th.ValidateImportFileOrFail(ctx, outputPath)
+		require.NoError(t, th.ImportBulkData(ctx, outputPath))
+
+		alice := th.AssertUserExists(ctx, "alice")
+		assert.False(t, alice.IsBot)
+		th.AssertUserInTeam(ctx, team.Id, alice.Id)
+
+		former := th.AssertUserExists(ctx, "former")
+		assert.NotZero(t, former.DeleteAt)
+
+		helperBot := th.AssertBotExists(ctx, "helperbot")
+		assert.Equal(t, "Helper Bot", helperBot.DisplayName)
+		assert.Zero(t, helperBot.DeleteAt)
+		assert.Equal(t, th.AdminUser.Id, helperBot.OwnerId)
+		helperBotUser := th.AssertUserExists(ctx, "helperbot")
+		assert.True(t, helperBotUser.IsBot)
+
+		oldBot := th.AssertBotExists(ctx, "oldbot")
+		assert.Equal(t, "Old Bot", oldBot.DisplayName)
+		assert.Equal(t, th.AdminUser.Id, oldBot.OwnerId)
+
+		engineering := th.AssertChannelExists(ctx, teamName, "engineering")
+		posts, err := th.GetChannelPosts(ctx, engineering.Id, 0, 100)
+		require.NoError(t, err)
+		botPost := findPostByMessage(posts, "Deployment completed successfully")
+		require.NotNil(t, botPost)
+		assert.Equal(t, helperBotUser.Id, botPost.UserId)
+	})
+
+	t.Run("transform fails without bot owner", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "mattermost_import.jsonl")
+		writeDumpDir(t, dir,
+			[]any{rcBSONUser{ID: "bot-id", Username: "buildbot", Name: "Build Bot", Active: true, Roles: []string{"bot", "user"}, Type: "bot"}},
+			[]any{}, []any{}, []any{})
+
+		resetRCFlags()
+		commands.RootCmd.SetArgs([]string{
+			"transform", "rocketchat",
+			"--team", uniqueTeamName("rcnoowner"),
+			"--dump-dir", dir,
+			"--output", outputPath,
+			"--skip-attachments",
+		})
+		err := commands.RootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--bot-owner")
+	})
+}
+
 func TestTransformRocketChatE2E(t *testing.T) {
 	ts1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2024, 1, 1, 12, 1, 0, 0, time.UTC)

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -429,59 +429,6 @@ func TestTransformRocketChatEdgeCases(t *testing.T) {
 		assert.NotContains(t, names, "encrypted-channel")
 	})
 
-	t.Run("discussion room is skipped", func(t *testing.T) {
-		dir := t.TempDir()
-		outputPath := filepath.Join(dir, "output.jsonl")
-
-		regularRoom := bson.D{
-			{Key: "_id", Value: "r1"},
-			{Key: "t", Value: "c"},
-			{Key: "name", Value: "general"},
-			{Key: "fname", Value: "General"},
-		}
-		discussionRoom := bson.D{
-			{Key: "_id", Value: "r2"},
-			{Key: "t", Value: "p"},
-			{Key: "name", Value: "discussion-room"},
-			{Key: "fname", Value: "Discussion Room"},
-			{Key: "prid", Value: "r1"}, // marks it as a discussion
-		}
-		users := []any{
-			rcBSONUser{ID: "u1", Username: "alice", Emails: []rcMail{{Address: "a@a.com"}}, Active: true, Type: "user"},
-		}
-		subs := []any{rcSubscription{RoomID: "r1", User: rcMsgUser{ID: "u1", Username: "alice"}}}
-		marshalBSONFileCmds(t, filepath.Join(dir, "users.bson"), users)
-		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_room.bson"), []any{regularRoom, discussionRoom})
-		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_message.bson"), []any{})
-		marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_subscription.bson"), subs)
-		defer os.Remove("transform-rocketchat.log")
-
-		c := commands.RootCmd
-		resetRCFlags()
-		c.SetArgs([]string{
-			"transform", "rocketchat",
-			"--team", "testteam",
-			"--dump-dir", dir,
-			"--output", outputPath,
-			"--skip-attachments",
-		})
-		require.NoError(t, c.Execute())
-
-		data, err := os.ReadFile(outputPath)
-		require.NoError(t, err)
-		lines := splitJSONLLines(t, data)
-
-		chLines := findLinesByType(lines, "channel")
-		names := make([]string, 0, len(chLines))
-		for _, ch := range chLines {
-			if n, ok := ch["name"].(string); ok {
-				names = append(names, n)
-			}
-		}
-		assert.Contains(t, names, "general")
-		assert.NotContains(t, names, "discussion-room")
-	})
-
 	t.Run("user with no email and default-email-domain generates email", func(t *testing.T) {
 		dir := t.TempDir()
 		outputPath := filepath.Join(dir, "output.jsonl")

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -2,15 +2,18 @@ package commands_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/mattermost/mmetl/commands"
+	"github.com/mattermost/mmetl/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,21 +60,28 @@ type rcMail struct {
 }
 
 type rcRoom struct {
-	ID        string   `bson:"_id"`
-	Type      string   `bson:"t"`
-	Name      string   `bson:"name"`
-	FName     string   `bson:"fname"`
-	Usernames []string `bson:"usernames"`
-	UIDs      []string `bson:"uids"`
+	ID          string   `bson:"_id"`
+	Type        string   `bson:"t"`
+	Name        string   `bson:"name"`
+	FName       string   `bson:"fname"`
+	Description *string  `bson:"description"`
+	Topic       string   `bson:"topic"`
+	Usernames   []string `bson:"usernames"`
+	UIDs        []string `bson:"uids"`
 }
 
 type rcMessage struct {
-	ID        string    `bson:"_id"`
-	RoomID    string    `bson:"rid"`
-	User      rcMsgUser `bson:"u"`
-	Message   string    `bson:"msg"`
-	Timestamp time.Time `bson:"ts"`
-	ThreadID  string    `bson:"tmid"`
+	ID        string                    `bson:"_id"`
+	RoomID    string                    `bson:"rid"`
+	User      rcMsgUser                 `bson:"u"`
+	Message   string                    `bson:"msg"`
+	Timestamp time.Time                 `bson:"ts"`
+	ThreadID  string                    `bson:"tmid"`
+	Reactions map[string]rcReactionInfo `bson:"reactions"`
+}
+
+type rcReactionInfo struct {
+	Usernames []string `bson:"usernames"`
 }
 
 type rcMsgUser struct {
@@ -90,6 +100,111 @@ func writeDumpDir(t *testing.T, dir string, users []any, rooms []any, messages [
 	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_room.bson"), rooms)
 	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_message.bson"), messages)
 	marshalBSONFileCmds(t, filepath.Join(dir, "rocketchat_subscription.bson"), subs)
+}
+
+// TestTransformRocketChatImportE2E exercises the documented migration path:
+// mongodump-shaped BSON -> mmetl transform -> Mattermost bulk import -> API checks.
+func TestTransformRocketChatImportE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "mattermost_import.jsonl")
+	teamName := uniqueTeamName("rce2e")
+	t.Cleanup(func() { os.Remove("transform-rocketchat.log") })
+
+	description := "Coordination for the engineering team"
+	users := []any{
+		rcBSONUser{ID: "alice-id", Username: "alice", Name: "Alice Anderson", Emails: []rcMail{{Address: "alice@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "bob-id", Username: "bob", Name: "Bob Brown", Emails: []rcMail{{Address: "bob@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "carol-id", Username: "carol", Name: "Carol Clark", Emails: []rcMail{{Address: "carol@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+	}
+	rooms := []any{
+		rcRoom{ID: "engineering-id", Type: "c", Name: "engineering", FName: "Engineering", Description: &description, Topic: "Sprint planning and code review"},
+		rcRoom{ID: "secret-id", Type: "p", Name: "secret-project", FName: "Secret Project"},
+		rcRoom{ID: "alice-bob-dm", Type: "d", Usernames: []string{"alice", "bob"}, UIDs: []string{"alice-id", "bob-id"}},
+	}
+	baseTime := time.Date(2024, 1, 2, 9, 30, 0, 0, time.UTC)
+	messages := []any{
+		rcMessage{
+			ID: "engineering-root", RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"},
+			Message: "Morning all! Kicking off the sprint", Timestamp: baseTime,
+			Reactions: map[string]rcReactionInfo{":thumbsup:": {Usernames: []string{"bob"}}},
+		},
+		rcMessage{ID: "engineering-reply", RoomID: "engineering-id", User: rcMsgUser{ID: "bob-id", Username: "bob"}, Message: "I can review the migration PR", Timestamp: baseTime.Add(time.Minute), ThreadID: "engineering-root"},
+		rcMessage{ID: "secret-root", RoomID: "secret-id", User: rcMsgUser{ID: "carol-id", Username: "carol"}, Message: "Confidential prototype update", Timestamp: baseTime.Add(2 * time.Minute)},
+		rcMessage{ID: "dm-root", RoomID: "alice-bob-dm", User: rcMsgUser{ID: "alice-id", Username: "alice"}, Message: "Can we sync on the migration?", Timestamp: baseTime.Add(3 * time.Minute)},
+	}
+	subscriptions := []any{
+		rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}},
+		rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "bob-id", Username: "bob"}},
+		rcSubscription{RoomID: "secret-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}},
+		rcSubscription{RoomID: "secret-id", User: rcMsgUser{ID: "carol-id", Username: "carol"}},
+	}
+	writeDumpDir(t, dir, users, rooms, messages, subscriptions)
+
+	team := th.CreateTeam(ctx, teamName, "RocketChat E2E Team")
+	resetRCFlags()
+	commands.RootCmd.SetArgs([]string{
+		"transform", "rocketchat",
+		"--team", teamName,
+		"--dump-dir", dir,
+		"--output", outputPath,
+		"--skip-attachments",
+	})
+	require.NoError(t, commands.RootCmd.Execute())
+
+	validation := th.ValidateImportFileOrFail(ctx, outputPath)
+	assert.Equal(t, uint64(3), validation.UserCount)
+	assert.Equal(t, uint64(2), validation.ChannelCount)
+	assert.Equal(t, uint64(2), validation.PostCount)
+	assert.Equal(t, uint64(1), validation.DirectPostCount)
+	require.NoError(t, th.ImportBulkData(ctx, outputPath))
+
+	alice := th.AssertUserExists(ctx, "alice")
+	bob := th.AssertUserExists(ctx, "bob")
+	carol := th.AssertUserExists(ctx, "carol")
+	assert.Equal(t, "alice@example.com", alice.Email)
+	assert.Equal(t, "Alice", alice.FirstName)
+	assert.Equal(t, "Anderson", alice.LastName)
+	th.AssertUserInTeam(ctx, team.Id, alice.Id)
+	th.AssertUserInTeam(ctx, team.Id, bob.Id)
+	th.AssertUserInTeam(ctx, team.Id, carol.Id)
+
+	engineering := th.AssertChannelExists(ctx, teamName, "engineering")
+	assert.Equal(t, model.ChannelTypeOpen, engineering.Type)
+	assert.Equal(t, description, engineering.Purpose)
+	assert.Equal(t, "Sprint planning and code review", engineering.Header)
+	assertChannelMembers(t, th, ctx, engineering.Id, []string{alice.Id, bob.Id}, []string{carol.Id})
+
+	secret := th.AssertChannelExists(ctx, teamName, "secret-project")
+	assert.Equal(t, model.ChannelTypePrivate, secret.Type)
+	assertChannelMembers(t, th, ctx, secret.Id, []string{alice.Id, carol.Id}, []string{bob.Id})
+	secretPosts, err := th.GetChannelPosts(ctx, secret.Id, 0, 100)
+	require.NoError(t, err)
+	require.NotNil(t, findPostByMessage(secretPosts, "Confidential prototype update"))
+
+	engineeringPosts, err := th.GetChannelPosts(ctx, engineering.Id, 0, 100)
+	require.NoError(t, err)
+	root := findPostByMessage(engineeringPosts, "Morning all! Kicking off the sprint")
+	require.NotNil(t, root)
+	reply := findPostByMessage(engineeringPosts, "I can review the migration PR")
+	require.NotNil(t, reply)
+	assert.Equal(t, root.Id, reply.RootId)
+	reactions, _, err := th.Client.GetReactions(ctx, root.Id)
+	require.NoError(t, err)
+	require.Len(t, reactions, 1)
+	assert.Equal(t, bob.Id, reactions[0].UserId)
+	assert.Equal(t, "thumbsup", reactions[0].EmojiName)
+
+	dm, _, err := th.Client.CreateDirectChannel(ctx, alice.Id, bob.Id)
+	require.NoError(t, err)
+	dmPosts, err := th.GetChannelPosts(ctx, dm.Id, 0, 100)
+	require.NoError(t, err)
+	require.NotNil(t, findPostByMessage(dmPosts, "Can we sync on the migration?"))
 }
 
 func TestTransformRocketChatE2E(t *testing.T) {
@@ -548,4 +663,33 @@ func collectMessages(postLines []map[string]any) []string {
 		}
 	}
 	return msgs
+}
+
+func findPostByMessage(posts *model.PostList, message string) *model.Post {
+	if posts == nil {
+		return nil
+	}
+	for _, post := range posts.Posts {
+		if post.Message == message {
+			return post
+		}
+	}
+	return nil
+}
+
+func assertChannelMembers(t *testing.T, th *testhelper.TestHelper, ctx context.Context, channelID string, expected, unexpected []string) {
+	t.Helper()
+	members, err := th.GetChannelMembers(ctx, channelID)
+	require.NoError(t, err)
+
+	memberIDs := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		memberIDs[member.UserId] = struct{}{}
+	}
+	for _, userID := range expected {
+		assert.Contains(t, memberIDs, userID)
+	}
+	for _, userID := range unexpected {
+		assert.NotContains(t, memberIDs, userID)
+	}
 }

--- a/commands/transform_rocketchat_e2e_test.go
+++ b/commands/transform_rocketchat_e2e_test.go
@@ -207,6 +207,100 @@ func TestTransformRocketChatImportE2E(t *testing.T) {
 	require.NotNil(t, findPostByMessage(dmPosts, "Can we sync on the migration?"))
 }
 
+// TestTransformRocketChatE2EGuestImport verifies guest handling end to end:
+// a guest with a channel membership is imported as a Mattermost guest
+// (system_guest + scheme_guest at team and channel level), while a channel-less
+// guest (present only in a DM) is dropped in guest mode with no dangling
+// references.
+func TestTransformRocketChatE2EGuestImport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	th := testhelper.SetupHelper(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "mattermost_import.jsonl")
+	teamName := uniqueTeamName("rcguest")
+	t.Cleanup(func() { os.Remove("transform-rocketchat.log") })
+
+	users := []any{
+		rcBSONUser{ID: "alice-id", Username: "alice", Name: "Alice Anderson", Emails: []rcMail{{Address: "alice@example.com", Verified: true}}, Active: true, Roles: []string{"user"}, Type: "user"},
+		rcBSONUser{ID: "bob-id", Username: "bob", Name: "Bob Guest", Emails: []rcMail{{Address: "bob@example.com", Verified: true}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+		rcBSONUser{ID: "carol-id", Username: "carol", Name: "Carol Guest", Emails: []rcMail{{Address: "carol@example.com", Verified: true}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+	}
+	rooms := []any{
+		rcRoom{ID: "engineering-id", Type: "c", Name: "engineering", FName: "Engineering"},
+		// carol only appears in a DM (no channel subscription) → channel-less.
+		rcRoom{ID: "alice-carol-dm", Type: "d", Usernames: []string{"alice", "carol"}, UIDs: []string{"alice-id", "carol-id"}},
+	}
+	baseTime := time.Date(2024, 1, 2, 9, 30, 0, 0, time.UTC)
+	messages := []any{
+		rcMessage{ID: "eng-root", RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}, Message: "Welcome!", Timestamp: baseTime},
+		rcMessage{ID: "eng-guest", RoomID: "engineering-id", User: rcMsgUser{ID: "bob-id", Username: "bob"}, Message: "Thanks for having me", Timestamp: baseTime.Add(time.Minute)},
+		rcMessage{ID: "carol-dm", RoomID: "alice-carol-dm", User: rcMsgUser{ID: "carol-id", Username: "carol"}, Message: "should be dropped", Timestamp: baseTime.Add(2 * time.Minute)},
+	}
+	subscriptions := []any{
+		rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "alice-id", Username: "alice"}},
+		rcSubscription{RoomID: "engineering-id", User: rcMsgUser{ID: "bob-id", Username: "bob"}},
+	}
+	writeDumpDir(t, dir, users, rooms, messages, subscriptions)
+
+	team := th.CreateTeam(ctx, teamName, "RocketChat Guest E2E Team")
+	resetRCFlags()
+	commands.RootCmd.SetArgs([]string{
+		"transform", "rocketchat",
+		"--team", teamName,
+		"--dump-dir", dir,
+		"--output", outputPath,
+		"--skip-attachments",
+		"--guest-handling", "guest",
+	})
+	require.NoError(t, commands.RootCmd.Execute())
+
+	th.ValidateImportFileOrFail(ctx, outputPath)
+	require.NoError(t, th.ImportBulkData(ctx, outputPath))
+
+	alice := th.AssertUserExists(ctx, "alice")
+	bob := th.AssertUserExists(ctx, "bob")
+	assert.False(t, alice.IsGuest(), "alice should be a regular user")
+	assert.True(t, bob.IsGuest(), "bob has a channel membership, so should be imported as a guest")
+
+	// carol is channel-less, so must be dropped entirely in guest mode.
+	_, err := th.GetUserByUsername(ctx, "carol")
+	assert.Error(t, err, "channel-less guest carol should not be imported")
+
+	// Team-level scheme flags.
+	teamMembers, err := th.GetTeamMembers(ctx, team.Id)
+	require.NoError(t, err)
+	teamByUserID := map[string]*model.TeamMember{}
+	for _, tm := range teamMembers {
+		teamByUserID[tm.UserId] = tm
+	}
+	require.NotNil(t, teamByUserID[bob.Id])
+	assert.True(t, teamByUserID[bob.Id].SchemeGuest)
+	assert.False(t, teamByUserID[bob.Id].SchemeUser)
+	assert.False(t, teamByUserID[alice.Id].SchemeGuest)
+
+	// Channel-level scheme flags.
+	engineering := th.AssertChannelExists(ctx, teamName, "engineering")
+	channelMembers, err := th.GetChannelMembers(ctx, engineering.Id)
+	require.NoError(t, err)
+	channelByUserID := map[string]*model.ChannelMember{}
+	for i := range channelMembers {
+		channelByUserID[channelMembers[i].UserId] = &channelMembers[i]
+	}
+	require.NotNil(t, channelByUserID[bob.Id])
+	assert.True(t, channelByUserID[bob.Id].SchemeGuest)
+	assert.False(t, channelByUserID[bob.Id].SchemeUser)
+	assert.False(t, channelByUserID[alice.Id].SchemeGuest)
+
+	// carol's DM message must not have been imported.
+	engPosts, err := th.GetChannelPosts(ctx, engineering.Id, 0, 100)
+	require.NoError(t, err)
+	assert.Nil(t, findPostByMessage(engPosts, "should be dropped"))
+}
+
 func TestTransformRocketChatE2EBotImport(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/docs/cli/mmetl_check.md
+++ b/docs/cli/mmetl_check.md
@@ -21,5 +21,6 @@ Checks the integrity and entities of export files from different providers.
 ### SEE ALSO
 
 * [mmetl](mmetl.md)	 - ETL tool to transform the export files from different providers to be compatible with Mattermost.
+* [mmetl check rocketchat](mmetl_check_rocketchat.md)	 - Checks the integrity of a Rocket.Chat mongodump export.
 * [mmetl check slack](mmetl_check_slack.md)	 - Checks the integrity of a Slack export.
 

--- a/docs/cli/mmetl_check.md
+++ b/docs/cli/mmetl_check.md
@@ -21,6 +21,6 @@ Checks the integrity and entities of export files from different providers.
 ### SEE ALSO
 
 * [mmetl](mmetl.md)	 - ETL tool to transform the export files from different providers to be compatible with Mattermost.
-* [mmetl check rocketchat](mmetl_check_rocketchat.md)	 - Checks the integrity of a Rocket.Chat mongodump export.
+* [mmetl check rocketchat](mmetl_check_rocketchat.md)	 - Checks the integrity of a RocketChat mongodump export.
 * [mmetl check slack](mmetl_check_slack.md)	 - Checks the integrity of a Slack export.
 

--- a/docs/cli/mmetl_check_rocketchat.md
+++ b/docs/cli/mmetl_check_rocketchat.md
@@ -1,0 +1,45 @@
+---
+title: "mmetl check rocketchat"
+slug: "mmetl_check_rocketchat"
+description: "CLI reference for mmetl check rocketchat"
+---
+
+## mmetl check rocketchat
+
+Checks the integrity of a Rocket.Chat mongodump export.
+
+### Synopsis
+
+Checks the integrity of a Rocket.Chat mongodump export directory.
+
+Before running this command, export your Rocket.Chat MongoDB database using mongodump
+(https://www.mongodb.com/docs/database-tools/mongodump/):
+
+  mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
+
+Then pass the database subdirectory to --dump-dir (e.g. /tmp/rc-dump/meteor).
+
+```
+mmetl check rocketchat [flags]
+```
+
+### Examples
+
+```
+  check rocketchat --dump-dir /tmp/rc-dump/meteor
+```
+
+### Options
+
+```
+      --debug                         Whether to show debug logs or not
+      --default-email-domain string   If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.
+  -d, --dump-dir string               path to the mongodump output directory
+  -h, --help                          help for rocketchat
+      --skip-empty-emails             Ignore empty email addresses from the import file. Note that this results in invalid data.
+```
+
+### SEE ALSO
+
+* [mmetl check](mmetl_check.md)	 - Checks the integrity of export files.
+

--- a/docs/cli/mmetl_check_rocketchat.md
+++ b/docs/cli/mmetl_check_rocketchat.md
@@ -6,13 +6,13 @@ description: "CLI reference for mmetl check rocketchat"
 
 ## mmetl check rocketchat
 
-Checks the integrity of a Rocket.Chat mongodump export.
+Checks the integrity of a RocketChat mongodump export.
 
 ### Synopsis
 
-Checks the integrity of a Rocket.Chat mongodump export directory.
+Checks the integrity of a RocketChat mongodump export directory.
 
-Before running this command, export your Rocket.Chat MongoDB database using mongodump
+Before running this command, export your RocketChat MongoDB database using mongodump
 (https://www.mongodb.com/docs/database-tools/mongodump/):
 
   mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump

--- a/docs/cli/mmetl_check_rocketchat.md
+++ b/docs/cli/mmetl_check_rocketchat.md
@@ -35,6 +35,7 @@ mmetl check rocketchat [flags]
       --debug                         Whether to show debug logs or not
       --default-email-domain string   If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.
   -d, --dump-dir string               path to the mongodump output directory
+      --guest-handling string         How guest users would be handled by "transform rocketchat", so their treatment can be previewed here. One of "guest", "user", or "skip" (see "transform rocketchat --help"). (default "guest")
   -h, --help                          help for rocketchat
       --skip-empty-emails             Ignore empty email addresses from the import file. Note that this results in invalid data.
 ```

--- a/docs/cli/mmetl_transform.md
+++ b/docs/cli/mmetl_transform.md
@@ -17,5 +17,6 @@ Transforms export files into Mattermost import files
 ### SEE ALSO
 
 * [mmetl](mmetl.md)	 - ETL tool to transform the export files from different providers to be compatible with Mattermost.
+* [mmetl transform rocketchat](mmetl_transform_rocketchat.md)	 - Transforms a Rocket.Chat mongodump export.
 * [mmetl transform slack](mmetl_transform_slack.md)	 - Transforms a Slack export.
 

--- a/docs/cli/mmetl_transform.md
+++ b/docs/cli/mmetl_transform.md
@@ -17,6 +17,6 @@ Transforms export files into Mattermost import files
 ### SEE ALSO
 
 * [mmetl](mmetl.md)	 - ETL tool to transform the export files from different providers to be compatible with Mattermost.
-* [mmetl transform rocketchat](mmetl_transform_rocketchat.md)	 - Transforms a Rocket.Chat mongodump export.
+* [mmetl transform rocketchat](mmetl_transform_rocketchat.md)	 - Transforms a RocketChat mongodump export.
 * [mmetl transform slack](mmetl_transform_slack.md)	 - Transforms a Slack export.
 

--- a/docs/cli/mmetl_transform_rocketchat.md
+++ b/docs/cli/mmetl_transform_rocketchat.md
@@ -1,0 +1,51 @@
+---
+title: "mmetl transform rocketchat"
+slug: "mmetl_transform_rocketchat"
+description: "CLI reference for mmetl transform rocketchat"
+---
+
+## mmetl transform rocketchat
+
+Transforms a Rocket.Chat mongodump export.
+
+### Synopsis
+
+Transforms a Rocket.Chat mongodump directory into a Mattermost export JSONL file.
+
+Before running this command, export your Rocket.Chat MongoDB database using mongodump
+(https://www.mongodb.com/docs/database-tools/mongodump/):
+
+  mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
+
+Then pass the database subdirectory to --dump-dir (e.g. /tmp/rc-dump/meteor).
+
+```
+mmetl transform rocketchat [flags]
+```
+
+### Examples
+
+```
+  transform rocketchat --team myteam --dump-dir /tmp/rc-dump/meteor --output mm_export.jsonl
+```
+
+### Options
+
+```
+      --attachments-dir string        the path for the attachments directory (default "data")
+      --bot-owner string              Username of the Mattermost user who will own all imported bots. Required if the Rocket.Chat export contains bot users.
+      --debug                         Whether to show debug logs or not
+      --default-email-domain string   If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.
+  -d, --dump-dir string               path to the mongodump output directory (containing .bson files)
+  -h, --help                          help for rocketchat
+  -o, --output string                 the output path (default "bulk-export.jsonl")
+  -a, --skip-attachments              Skips extracting file attachments
+      --skip-empty-emails             Ignore empty email addresses from the import file. Note that this results in invalid data.
+  -t, --team string                   an existing team in Mattermost to import the data into
+      --uploads-dir string            path to Rocket.Chat FileSystem uploads directory (if not using GridFS)
+```
+
+### SEE ALSO
+
+* [mmetl transform](mmetl_transform.md)	 - Transforms export files into Mattermost import files
+

--- a/docs/cli/mmetl_transform_rocketchat.md
+++ b/docs/cli/mmetl_transform_rocketchat.md
@@ -6,13 +6,13 @@ description: "CLI reference for mmetl transform rocketchat"
 
 ## mmetl transform rocketchat
 
-Transforms a Rocket.Chat mongodump export.
+Transforms a RocketChat mongodump export.
 
 ### Synopsis
 
-Transforms a Rocket.Chat mongodump directory into a Mattermost export JSONL file.
+Transforms a RocketChat mongodump directory into a Mattermost export JSONL file.
 
-Before running this command, export your Rocket.Chat MongoDB database using mongodump
+Before running this command, export your RocketChat MongoDB database using mongodump
 (https://www.mongodb.com/docs/database-tools/mongodump/):
 
   mongodump --uri="mongodb://localhost:3001/meteor" --out=/tmp/rc-dump
@@ -33,7 +33,7 @@ mmetl transform rocketchat [flags]
 
 ```
       --attachments-dir string        the path for the attachments directory (default "data")
-      --bot-owner string              Username of the Mattermost user who will own all imported bots. Required if the Rocket.Chat export contains bot users.
+      --bot-owner string              Username of the Mattermost user who will own all imported bots. Required if the RocketChat export contains bot users.
       --debug                         Whether to show debug logs or not
       --default-email-domain string   If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.
   -d, --dump-dir string               path to the mongodump output directory (containing .bson files)
@@ -42,7 +42,7 @@ mmetl transform rocketchat [flags]
   -a, --skip-attachments              Skips extracting file attachments
       --skip-empty-emails             Ignore empty email addresses from the import file. Note that this results in invalid data.
   -t, --team string                   an existing team in Mattermost to import the data into
-      --uploads-dir string            path to Rocket.Chat FileSystem uploads directory (if not using GridFS)
+      --uploads-dir string            path to RocketChat FileSystem uploads directory (if not using GridFS)
 ```
 
 ### SEE ALSO

--- a/docs/cli/mmetl_transform_rocketchat.md
+++ b/docs/cli/mmetl_transform_rocketchat.md
@@ -37,6 +37,10 @@ mmetl transform rocketchat [flags]
       --debug                         Whether to show debug logs or not
       --default-email-domain string   If this flag is provided: When a user's email address is empty, the output's email address will be generated from their username and the provided domain.
   -d, --dump-dir string               path to the mongodump output directory (containing .bson files)
+      --guest-handling string         How to migrate RocketChat guest users (users whose roles include "guest"). One of:
+                                        "guest" - migrate them as Mattermost guests (system_guest/team_guest/channel_guest). Highest fidelity, but the destination server must have Guest Accounts licensed (Professional/Enterprise) and enabled (GuestAccountsSettings.Enable); otherwise the accounts won't behave correctly.
+                                        "user"  - migrate them as regular Mattermost users. Works everywhere, but grants guests full user permissions.
+                                        "skip"  - drop guest users entirely, along with their memberships and authored posts. (default "guest")
   -h, --help                          help for rocketchat
   -o, --output string                 the output path (default "bulk-export.jsonl")
   -a, --skip-attachments              Skips extracting file attachments

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
+	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/text v0.34.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/wiggin77/srslog v1.0.1 h1:gA2XjSMy3DrRdX9UqLuDtuVAAshb8bE1NhX1YK0Qe+8
 github.com/wiggin77/srslog v1.0.1/go.mod h1:fehkyYDq1QfuYn60TDPu9YdY2bB85VUW2mvN1WynEls=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
+go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=

--- a/services/intermediate/export.go
+++ b/services/intermediate/export.go
@@ -27,6 +27,49 @@ type Exporter struct {
 	// guests are exported with regular user roles, and in "skip" mode they are
 	// not present at all.
 	EmitGuestRoles bool
+
+	// guestUsernames memoizes the set of effective-guest usernames (see
+	// isEffectiveGuest) so it is computed once and reused across the group- and
+	// direct-channel export passes rather than rebuilt on each call.
+	guestUsernames map[string]bool
+}
+
+// isEffectiveGuest reports whether user should be exported with Mattermost
+// guest roles/scheme flags: emitGuestRoles is enabled, the user is flagged as
+// a guest, and they have at least one regular (public/private) channel
+// membership. The membership requirement exists because Mattermost's importer
+// rejects a user that is a guest in only some of system/team/channel scope
+// (see isValidGuestRoles in mattermost/server's import_validators.go), so a
+// guest with no channel memberships is exported as a regular member instead of
+// producing an invalid line that would abort the whole bulk import. Using the
+// same rule everywhere a user's guest status is exported (their "user" line and
+// any direct/group channel they participate in) keeps a single user's guest
+// status consistent across every line that references them.
+//
+// Note: for RocketChat, channel-less guests are dropped upstream in the
+// transformer (guest mode), so this fallback is a last-resort safety net rather
+// than the primary path.
+func isEffectiveGuest(user *IntermediateUser, emitGuestRoles bool) bool {
+	return emitGuestRoles && user.IsGuest && len(user.Memberships) > 0
+}
+
+// effectiveGuestUsernames returns (memoized) the set of usernames that should
+// be marked as guests wherever they appear. Empty when guest roles are not
+// being emitted.
+func (e *Exporter) effectiveGuestUsernames() map[string]bool {
+	if e.guestUsernames != nil {
+		return e.guestUsernames
+	}
+	set := make(map[string]bool)
+	if e.EmitGuestRoles {
+		for _, user := range e.Intermediate.UsersById {
+			if isEffectiveGuest(user, e.EmitGuestRoles) {
+				set[user.Username] = true
+			}
+		}
+	}
+	e.guestUsernames = set
+	return set
 }
 
 func GetImportLineFromChannel(team string, channel *IntermediateChannel) *imports.LineImportData {
@@ -49,17 +92,23 @@ func GetImportLineFromChannel(team string, channel *IntermediateChannel) *import
 	}
 }
 
-func GetImportLineFromDirectChannel(team string, channel *IntermediateChannel) *imports.LineImportData {
+// GetImportLineFromDirectChannel builds the bulk-import "direct_channel" line.
+// guestUsernames is the set of usernames (from isEffectiveGuest) that should be
+// marked as guests in this channel's participant list, so a guest's status is
+// consistent with their "user" line.
+func GetImportLineFromDirectChannel(team string, channel *IntermediateChannel, guestUsernames map[string]bool) *imports.LineImportData {
 	var participants []*imports.DirectChannelMemberImportData
 	lastViewedAt := channel.LastPostAt
 	if lastViewedAt == 0 {
 		lastViewedAt = channel.CreatedMillis()
 	}
 	for _, username := range channel.MembersUsernames {
+		isGuest := guestUsernames[username]
 		p := &imports.DirectChannelMemberImportData{
 			Username:     model.NewPointer(username),
 			LastViewedAt: model.NewPointer(lastViewedAt),
-			SchemeUser:   model.NewPointer(true),
+			SchemeUser:   model.NewPointer(!isGuest),
+			SchemeGuest:  model.NewPointer(isGuest),
 		}
 		if channel.MsgCount > 0 {
 			p.MsgCount = model.NewPointer(channel.MsgCount)
@@ -83,10 +132,12 @@ func GetImportLineFromDirectChannel(team string, channel *IntermediateChannel) *
 // to Mattermost's guest roles; otherwise the regular user roles are used. Bots
 // are never guests, so the caller should pass a non-guest user here.
 func GetImportLineFromUser(user *IntermediateUser, team string, emitGuestRoles bool) *imports.LineImportData {
+	isGuest := isEffectiveGuest(user, emitGuestRoles)
+
 	systemRole := model.SystemUserRoleId
 	teamRole := model.TeamUserRoleId
 	channelRole := model.ChannelUserRoleId
-	if emitGuestRoles && user.IsGuest {
+	if isGuest {
 		systemRole = model.SystemGuestRoleId
 		teamRole = model.TeamGuestRoleId
 		channelRole = model.ChannelGuestRoleId
@@ -324,11 +375,12 @@ func (e *Exporter) ExportChannels(channels []*IntermediateChannel, writer io.Wri
 
 // ExportDirectChannels is valid for group or direct channels, as they export with members.
 func (e *Exporter) ExportDirectChannels(channels []*IntermediateChannel, writer io.Writer) error {
+	guestUsernames := e.effectiveGuestUsernames()
 	for _, channel := range channels {
 		if channel.LastPostAt == 0 && channel.Created <= 0 {
 			e.Logger.Warnf("Direct/group channel %s has no valid creation timestamp; using current time for LastViewedAt", channel.Name)
 		}
-		line := GetImportLineFromDirectChannel(e.TeamName, channel)
+		line := GetImportLineFromDirectChannel(e.TeamName, channel, guestUsernames)
 		if err := ExportWriteLine(writer, line); err != nil {
 			return err
 		}
@@ -359,6 +411,13 @@ func (e *Exporter) ExportUsers(writer io.Writer, botOwner string) error {
 
 	// Write regular users first (bot owner must exist before bots)
 	for _, user := range users {
+		// A guest with no channel memberships can't be a valid Mattermost guest
+		// (see isEffectiveGuest); it falls back to a regular member here. For
+		// RocketChat these are dropped upstream in the transformer, so this only
+		// fires as a safety net for any that slip through.
+		if e.EmitGuestRoles && user.IsGuest && len(user.Memberships) == 0 {
+			e.Logger.Warnf("Guest user %s has no channel memberships; importing as a regular member instead, since Mattermost requires guests to have at least one channel", user.Username)
+		}
 		line := GetImportLineFromUser(user, e.TeamName, e.EmitGuestRoles)
 		if err := ExportWriteLine(writer, line); err != nil {
 			return err

--- a/services/intermediate/export.go
+++ b/services/intermediate/export.go
@@ -20,6 +20,13 @@ type Exporter struct {
 	TeamName     string
 	Intermediate *Intermediate
 	Logger       log.FieldLogger
+
+	// EmitGuestRoles controls whether users flagged with IsGuest are exported
+	// with Mattermost guest roles (system_guest / team_guest / channel_guest).
+	// It is true only when guest handling is set to "guest"; in "user" mode
+	// guests are exported with regular user roles, and in "skip" mode they are
+	// not present at all.
+	EmitGuestRoles bool
 }
 
 func GetImportLineFromChannel(team string, channel *IntermediateChannel) *imports.LineImportData {
@@ -71,12 +78,25 @@ func GetImportLineFromDirectChannel(team string, channel *IntermediateChannel) *
 	}
 }
 
-func GetImportLineFromUser(user *IntermediateUser, team string) *imports.LineImportData {
+// GetImportLineFromUser builds a user import line. When emitGuestRoles is true
+// and the user is flagged as a guest, the user, team, and channel roles are set
+// to Mattermost's guest roles; otherwise the regular user roles are used. Bots
+// are never guests, so the caller should pass a non-guest user here.
+func GetImportLineFromUser(user *IntermediateUser, team string, emitGuestRoles bool) *imports.LineImportData {
+	systemRole := model.SystemUserRoleId
+	teamRole := model.TeamUserRoleId
+	channelRole := model.ChannelUserRoleId
+	if emitGuestRoles && user.IsGuest {
+		systemRole = model.SystemGuestRoleId
+		teamRole = model.TeamGuestRoleId
+		channelRole = model.ChannelGuestRoleId
+	}
+
 	channelMemberships := []imports.UserChannelImportData{}
 	for _, membership := range user.Memberships {
 		ch := imports.UserChannelImportData{
 			Name:  model.NewPointer(membership.Name),
-			Roles: model.NewPointer(model.ChannelUserRoleId),
+			Roles: model.NewPointer(channelRole),
 		}
 		if membership.LastViewedAt > 0 {
 			ch.LastViewedAt = model.NewPointer(membership.LastViewedAt)
@@ -107,13 +127,13 @@ func GetImportLineFromUser(user *IntermediateUser, team string) *imports.LineImp
 			FirstName: model.NewPointer(user.FirstName),
 			LastName:  model.NewPointer(user.LastName),
 			Position:  model.NewPointer(user.Position),
-			Roles:     model.NewPointer(model.SystemUserRoleId),
+			Roles:     model.NewPointer(systemRole),
 			DeleteAt:  deleteAt,
 			Teams: &[]imports.UserTeamImportData{
 				{
 					Name:     model.NewPointer(team),
 					Channels: channelsPtr,
-					Roles:    model.NewPointer(model.TeamUserRoleId),
+					Roles:    model.NewPointer(teamRole),
 				},
 			},
 		},
@@ -339,7 +359,7 @@ func (e *Exporter) ExportUsers(writer io.Writer, botOwner string) error {
 
 	// Write regular users first (bot owner must exist before bots)
 	for _, user := range users {
-		line := GetImportLineFromUser(user, e.TeamName)
+		line := GetImportLineFromUser(user, e.TeamName, e.EmitGuestRoles)
 		if err := ExportWriteLine(writer, line); err != nil {
 			return err
 		}

--- a/services/intermediate/types.go
+++ b/services/intermediate/types.go
@@ -192,6 +192,7 @@ type IntermediateUser struct {
 	Memberships []IntermediateMembership `json:"memberships"`
 	DeleteAt    int64                    `json:"delete_at"`
 	IsBot       bool                     `json:"is_bot"`
+	IsGuest     bool                     `json:"is_guest"`
 	DisplayName string                   `json:"display_name"`
 }
 

--- a/services/intermediate/types.go
+++ b/services/intermediate/types.go
@@ -1,6 +1,6 @@
 // Package intermediate holds the source-agnostic representation of a workspace
 // migration (channels, users, posts) together with the exporter that writes the
-// Mattermost bulk-import JSONL. Source-specific services (Slack, Rocket.Chat,
+// Mattermost bulk-import JSONL. Source-specific services (Slack, RocketChat,
 // ...) transform their exports into these types and embed the Exporter to
 // produce the final import file.
 package intermediate

--- a/services/rocketchat/attachments.go
+++ b/services/rocketchat/attachments.go
@@ -67,12 +67,19 @@ func ExtractAttachments(
 		var extractErr error
 		switch {
 		case strings.HasPrefix(upload.Store, "GridFS:"):
-			if gridfsIndex == nil || !gridfsIndex.Has(upload.ID) {
+			switch {
+			case gridfsIndex != nil && gridfsIndex.Has(upload.ID):
+				extractErr = gridfsIndex.reassembleFrom(chunksFile, upload.ID, destPath)
+			case upload.Size == 0:
+				// GridFS deliberately stores zero-byte files without any chunk
+				// documents. The complete upload metadata is sufficient to recreate
+				// an empty attachment even when the chunks file is absent.
+				extractErr = createEmptyFile(destPath)
+			default:
 				logger.Warnf("GridFS chunks not found for upload %s (%s), skipping", upload.ID, upload.Name)
 				skipped++
 				continue
 			}
-			extractErr = gridfsIndex.reassembleFrom(chunksFile, upload.ID, destPath)
 
 		case upload.Store == "FileSystem":
 			if uploadsDir == "" {
@@ -118,6 +125,17 @@ func ExtractAttachments(
 	}
 
 	logger.Infof("Extracted %d attachments, skipped %d", done, skipped)
+	return nil
+}
+
+func createEmptyFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating empty attachment %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", path, err)
+	}
 	return nil
 }
 

--- a/services/rocketchat/attachments.go
+++ b/services/rocketchat/attachments.go
@@ -12,20 +12,33 @@ import (
 )
 
 // ExtractAttachments extracts all complete uploads into outputDir.
-// For GridFS uploads (store starts with "GridFS:"), binary data is read from
-// gridfsChunks (keyed by upload._id). For FileSystem uploads, files are copied
-// from uploadsDir (the path provided by the user via --uploads-dir).
+// For GridFS uploads (store starts with "GridFS:"), binary data is streamed one
+// chunk at a time from gridfsIndex (which may be nil if the export has no GridFS
+// chunks file). For FileSystem uploads, files are copied from uploadsDir (the
+// path provided by the user via --uploads-dir).
 //
 // Skips uploads that are incomplete or whose source cannot be found.
 func ExtractAttachments(
 	uploads map[string]*RocketChatUpload,
-	gridfsChunks map[string][]GridFSChunk,
+	gridfsIndex *GridFSIndex,
 	outputDir string,
 	uploadsDir string,
 	logger log.FieldLogger,
 ) error {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return fmt.Errorf("creating attachments directory %s: %w", outputDir, err)
+	}
+
+	// Open the GridFS chunks file once and share it across all GridFS uploads for
+	// random-access reads, rather than re-opening it for every attachment.
+	var chunksFile *os.File
+	if gridfsIndex != nil {
+		var err error
+		chunksFile, err = os.Open(gridfsIndex.path)
+		if err != nil {
+			return fmt.Errorf("opening GridFS chunks file %s: %w", gridfsIndex.path, err)
+		}
+		defer chunksFile.Close()
 	}
 
 	done := 0
@@ -54,13 +67,12 @@ func ExtractAttachments(
 		var extractErr error
 		switch {
 		case strings.HasPrefix(upload.Store, "GridFS:"):
-			chunks, ok := gridfsChunks[upload.ID]
-			if !ok || len(chunks) == 0 {
+			if gridfsIndex == nil || !gridfsIndex.Has(upload.ID) {
 				logger.Warnf("GridFS chunks not found for upload %s (%s), skipping", upload.ID, upload.Name)
 				skipped++
 				continue
 			}
-			extractErr = ReassembleGridFSFile(chunks, destPath)
+			extractErr = gridfsIndex.reassembleFrom(chunksFile, upload.ID, destPath)
 
 		case upload.Store == "FileSystem":
 			if uploadsDir == "" {

--- a/services/rocketchat/attachments.go
+++ b/services/rocketchat/attachments.go
@@ -36,6 +36,11 @@ func ExtractAttachments(
 			continue
 		}
 
+		if upload.TypeGroup == "thumb" {
+			skipped++
+			continue
+		}
+
 		// Apply NFC normalization before sanitizing so that combining characters
 		// are composed into their canonical form first (e.g. NFD "e" + combining
 		// acute → NFC "é") before any character-stripping takes place.

--- a/services/rocketchat/attachments.go
+++ b/services/rocketchat/attachments.go
@@ -122,7 +122,7 @@ func ExtractAttachments(
 }
 
 // copyFile copies src to dst, creating dst if necessary.
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("opening source file %s: %w", src, err)
@@ -133,10 +133,17 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("creating destination file %s: %w", dst, err)
 	}
-	defer out.Close()
+	// Surface a delayed write error from Close (e.g. a failed flush) so a
+	// truncated copy is not reported as success, without masking an earlier
+	// copy error.
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing %s: %w", dst, cerr)
+		}
+	}()
 
-	if _, err := io.Copy(out, in); err != nil {
-		return fmt.Errorf("copying %s to %s: %w", src, dst, err)
+	if _, cerr := io.Copy(out, in); cerr != nil {
+		return fmt.Errorf("copying %s to %s: %w", src, dst, cerr)
 	}
 	return nil
 }

--- a/services/rocketchat/attachments.go
+++ b/services/rocketchat/attachments.go
@@ -1,0 +1,125 @@
+package rocketchat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/unicode/norm"
+)
+
+// ExtractAttachments extracts all complete uploads into outputDir.
+// For GridFS uploads (store starts with "GridFS:"), binary data is read from
+// gridfsChunks (keyed by upload._id). For FileSystem uploads, files are copied
+// from uploadsDir (the path provided by the user via --uploads-dir).
+//
+// Skips uploads that are incomplete or whose source cannot be found.
+func ExtractAttachments(
+	uploads map[string]*RocketChatUpload,
+	gridfsChunks map[string][]GridFSChunk,
+	outputDir string,
+	uploadsDir string,
+	logger log.FieldLogger,
+) error {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("creating attachments directory %s: %w", outputDir, err)
+	}
+
+	done := 0
+	skipped := 0
+	for _, upload := range uploads {
+		if !upload.Complete {
+			skipped++
+			continue
+		}
+
+		// Apply NFC normalization before sanitizing so that combining characters
+		// are composed into their canonical form first (e.g. NFD "e" + combining
+		// acute → NFC "é") before any character-stripping takes place.
+		sanitizedName := sanitizeFilename(norm.NFC.String(upload.Name))
+		// Sanitize the upload ID as well to prevent path traversal attacks via
+		// crafted IDs containing ".." or path separators.
+		sanitizedID := sanitizeFilename(upload.ID)
+		destFilename := fmt.Sprintf("%s_%s", sanitizedID, sanitizedName)
+		destPath := filepath.Join(outputDir, destFilename)
+
+		var extractErr error
+		switch {
+		case strings.HasPrefix(upload.Store, "GridFS:"):
+			chunks, ok := gridfsChunks[upload.ID]
+			if !ok || len(chunks) == 0 {
+				logger.Warnf("GridFS chunks not found for upload %s (%s), skipping", upload.ID, upload.Name)
+				skipped++
+				continue
+			}
+			extractErr = ReassembleGridFSFile(chunks, destPath)
+
+		case upload.Store == "FileSystem":
+			if uploadsDir == "" {
+				logger.Warnf("FileSystem upload %s (%s) skipped: --uploads-dir not provided", upload.ID, upload.Name)
+				skipped++
+				continue
+			}
+			// The path field is a URL path like "/file-upload/{id}/{name}".
+			// Extract the filename from the last segment. Sanitise it and reject
+			// traversal sentinels so a malicious dump path (e.g. "/file-upload/..")
+			// cannot escape uploadsDir. filepath.Base collapses to a single path
+			// element, so "." and ".." are the only escape vectors that remain.
+			srcFilename := sanitizeFilename(filepath.Base(upload.Path))
+			if srcFilename == "" || srcFilename == "." || srcFilename == ".." {
+				logger.Warnf("FileSystem upload %s (%s) skipped: unsafe source path %q", upload.ID, upload.Name, upload.Path)
+				skipped++
+				continue
+			}
+			srcPath := filepath.Join(uploadsDir, srcFilename)
+			extractErr = copyFile(srcPath, destPath)
+
+		default:
+			logger.Warnf("Unknown upload store %q for %s (%s), skipping", upload.Store, upload.ID, upload.Name)
+			skipped++
+			continue
+		}
+
+		if extractErr != nil {
+			// Remove any partial file left by a failed write so it cannot be
+			// imported later as a corrupt attachment.
+			if removeErr := os.Remove(destPath); removeErr != nil && !os.IsNotExist(removeErr) {
+				logger.Warnf("Failed to clean up partial attachment %s: %v", destPath, removeErr)
+			}
+			logger.Warnf("Failed to extract upload %s (%s): %v", upload.ID, upload.Name, extractErr)
+			skipped++
+			continue
+		}
+
+		done++
+		if done%100 == 0 {
+			logger.Infof("Extracted %d attachments so far...", done)
+		}
+	}
+
+	logger.Infof("Extracted %d attachments, skipped %d", done, skipped)
+	return nil
+}
+
+// copyFile copies src to dst, creating dst if necessary.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source file %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("creating destination file %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copying %s to %s: %w", src, dst, err)
+	}
+	return nil
+}

--- a/services/rocketchat/check.go
+++ b/services/rocketchat/check.go
@@ -1,0 +1,141 @@
+package rocketchat
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/mattermost/mmetl/services/intermediate"
+)
+
+// CheckIntermediate performs basic validation of the intermediate data,
+// logging warnings for inconsistencies such as duplicate channel names,
+// posts referencing missing channels, and channels with invalid members.
+func (t *Transformer) CheckIntermediate() {
+	t.Logger.Info("Checking intermediate resources")
+
+	// Build channel index (name → channel) for public and private channels.
+	channelsByName := map[string]*intermediate.IntermediateChannel{}
+	for _, ch := range t.Intermediate.PublicChannels {
+		if _, ok := channelsByName[ch.Name]; ok {
+			t.Logger.Warnf("Duplicate public channel name: %s", ch.Name)
+			continue
+		}
+		channelsByName[ch.Name] = ch
+	}
+	for _, ch := range t.Intermediate.PrivateChannels {
+		if _, ok := channelsByName[ch.Name]; ok {
+			t.Logger.Warnf("Duplicate private channel name: %s", ch.Name)
+			continue
+		}
+		channelsByName[ch.Name] = ch
+	}
+
+	// Build DM channel name from sorted members (using usernames, matching
+	// the names stored on posts' ChannelMembers).
+	getDirectName := func(members []string) string {
+		sorted := append([]string{}, members...)
+		sort.Strings(sorted)
+		return strings.Join(sorted, "_")
+	}
+
+	for _, ch := range t.Intermediate.GroupChannels {
+		name := getDirectName(ch.MembersUsernames)
+		if _, ok := channelsByName[name]; ok {
+			t.Logger.Warnf("Duplicate group channel: %s", name)
+			continue
+		}
+		channelsByName[name] = ch
+	}
+	for _, ch := range t.Intermediate.DirectChannels {
+		name := getDirectName(ch.MembersUsernames)
+		if _, ok := channelsByName[name]; ok {
+			t.Logger.Warnf("Duplicate direct channel: %s", name)
+			continue
+		}
+		channelsByName[name] = ch
+	}
+
+	// Validate named-channel members (by user ID) exist in UsersById.
+	for _, ch := range append(t.Intermediate.PublicChannels, t.Intermediate.PrivateChannels...) {
+		for _, memberID := range ch.Members {
+			if _, ok := t.Intermediate.UsersById[memberID]; !ok {
+				t.Logger.Warnf("Channel %s has member %s not found in users", ch.Name, memberID)
+			}
+		}
+	}
+
+	// Validate group/direct channel members (by username) exist in UsersById.
+	knownUsernames := make(map[string]bool, len(t.Intermediate.UsersById))
+	for _, u := range t.Intermediate.UsersById {
+		knownUsernames[u.Username] = true
+	}
+	for _, ch := range append(t.Intermediate.GroupChannels, t.Intermediate.DirectChannels...) {
+		for _, memberUsername := range ch.MembersUsernames {
+			if !knownUsernames[memberUsername] {
+				t.Logger.Warnf("Direct/group channel %s has member username %s not found in users", ch.Id, memberUsername)
+			}
+		}
+	}
+
+	// Build post-by-channel index.
+	postsByChannelName := map[string][]*intermediate.IntermediatePost{}
+	for _, post := range t.Intermediate.Posts {
+		channelName := post.Channel
+		if post.IsDirect && len(post.ChannelMembers) != 0 {
+			channelName = getDirectName(post.ChannelMembers)
+		}
+		postsByChannelName[channelName] = append(postsByChannelName[channelName], post)
+	}
+
+	// Per-channel debug summary: type, post count, resolved member usernames.
+	visitedChannels := map[string]bool{}
+	for channelName, ch := range channelsByName {
+		visitedChannels[channelName] = true
+
+		// For DM/group channels, memberships are stored in MembersUsernames
+		// (already resolved). For public/private channels, resolve via Members
+		// (RC user IDs) against UsersById.
+		usernames := []string{}
+		if len(ch.MembersUsernames) > 0 {
+			usernames = append(usernames, ch.MembersUsernames...)
+		} else {
+			for _, memberID := range ch.Members {
+				if user, ok := t.Intermediate.UsersById[memberID]; ok {
+					usernames = append(usernames, user.Username)
+				} else {
+					t.Logger.Warnf("-- Invalid member: %s", memberID)
+				}
+			}
+		}
+
+		t.Logger.Debugf("Channel: %q Type: %q Post count: %d Members: %q",
+			channelName, ch.Type, len(postsByChannelName[channelName]), strings.Join(usernames, ", "))
+	}
+
+	// Detect posts whose channel was not found in the channel index.
+	for channelName, posts := range postsByChannelName {
+		if !visitedChannels[channelName] {
+			t.Logger.Warnf("-- Channel %s has %d posts but is not a known channel", channelName, len(posts))
+		}
+	}
+
+	// Count bot users so the operator knows whether --bot-owner is needed.
+	botCount := 0
+	for _, u := range t.Intermediate.UsersById {
+		if u.IsBot {
+			botCount++
+		}
+	}
+	if botCount > 0 {
+		t.Logger.Infof("Found %d bot user(s). You will need to provide the --bot-owner flag when running the transform command.", botCount)
+	}
+
+	t.Logger.Infof("Check complete: %d users (%d bots), %d public channels, %d private channels, %d direct/group channels, %d posts",
+		len(t.Intermediate.UsersById),
+		botCount,
+		len(t.Intermediate.PublicChannels),
+		len(t.Intermediate.PrivateChannels),
+		len(t.Intermediate.DirectChannels)+len(t.Intermediate.GroupChannels),
+		len(t.Intermediate.Posts),
+	)
+}

--- a/services/rocketchat/export_test.go
+++ b/services/rocketchat/export_test.go
@@ -1,0 +1,274 @@
+package rocketchat
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/app/imports"
+
+	"github.com/mattermost/mmetl/services/intermediate"
+)
+
+func newExportLogger() log.FieldLogger {
+	l := log.New()
+	l.SetOutput(os.Stderr)
+	return l
+}
+
+// readLines splits a JSONL buffer into individual JSON objects.
+func readLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var result []map[string]any
+	dec := json.NewDecoder(buf)
+	for dec.More() {
+		var obj map[string]any
+		require.NoError(t, dec.Decode(&obj))
+		result = append(result, obj)
+	}
+	return result
+}
+
+func TestExportVersion(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportVersion(&buf))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "version", lines[0]["type"])
+	assert.Equal(t, float64(1), lines[0]["version"])
+}
+
+func TestExportChannels(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	channels := []*intermediate.IntermediateChannel{
+		{Name: "general", DisplayName: "General", Type: model.ChannelTypeOpen},
+		{Name: "random", DisplayName: "Random", Type: model.ChannelTypeOpen},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportChannels(channels, &buf))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 2)
+	for _, line := range lines {
+		assert.Equal(t, "channel", line["type"])
+	}
+}
+
+func TestExportUsers(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+		"u2": {Id: "u2", Username: "bob", Email: "bob@b.com", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+		"u1": {Id: "u1", Username: "alice", Email: "alice@a.com", Memberships: []intermediate.IntermediateMembership{{Name: "general"}, {Name: "random"}}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportUsers(&buf, ""))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 2)
+	// Should be sorted by username: alice first
+	assert.Equal(t, "user", lines[0]["type"])
+	user0 := lines[0]["user"].(map[string]any)
+	assert.Equal(t, "alice", user0["username"])
+
+	user1 := lines[1]["user"].(map[string]any)
+	assert.Equal(t, "bob", user1["username"])
+
+	// Alice should have 2 channel memberships
+	teams0 := user0["teams"].([]any)
+	require.Len(t, teams0, 1)
+	team0 := teams0[0].(map[string]any)
+	channels0 := team0["channels"].([]any)
+	assert.Len(t, channels0, 2)
+}
+
+func TestExportPosts(t *testing.T) {
+	now := time.Now().UnixMilli()
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate.Posts = []*intermediate.IntermediatePost{
+		{
+			User:     "alice",
+			Channel:  "general",
+			Message:  "Hello!",
+			CreateAt: now,
+			Reactions: []*intermediate.IntermediateReaction{
+				{User: "bob", EmojiName: "thumbsup", CreateAt: now + 1},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportPosts(&buf))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "post", lines[0]["type"])
+	post := lines[0]["post"].(map[string]any)
+	assert.Equal(t, "alice", post["user"])
+	assert.Equal(t, "general", post["channel"])
+	assert.Equal(t, "Hello!", post["message"])
+	reactions := post["reactions"].([]any)
+	require.Len(t, reactions, 1)
+	r := reactions[0].(map[string]any)
+	assert.Equal(t, "thumbsup", r["emoji_name"])
+}
+
+func TestExportPostsWithReplies(t *testing.T) {
+	now := time.Now().UnixMilli()
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate.Posts = []*intermediate.IntermediatePost{
+		{
+			User:     "alice",
+			Channel:  "general",
+			Message:  "Root post",
+			CreateAt: now,
+			Replies: []*intermediate.IntermediatePost{
+				{User: "bob", Channel: "general", Message: "Reply", CreateAt: now + 1},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportPosts(&buf))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 1)
+	post := lines[0]["post"].(map[string]any)
+	replies := post["replies"].([]any)
+	require.Len(t, replies, 1)
+	reply := replies[0].(map[string]any)
+	assert.Equal(t, "Reply", reply["message"])
+}
+
+func TestExportDirectPosts(t *testing.T) {
+	now := time.Now().UnixMilli()
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate.Posts = []*intermediate.IntermediatePost{
+		{
+			User:           "alice",
+			Message:        "Hey Bob!",
+			CreateAt:       now,
+			IsDirect:       true,
+			ChannelMembers: []string{"alice", "bob"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportPosts(&buf))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "direct_post", lines[0]["type"])
+	dp := lines[0]["direct_post"].(map[string]any)
+	assert.Equal(t, "alice", dp["user"])
+	members := dp["channel_members"].([]any)
+	assert.Len(t, members, 2)
+}
+
+func TestExportOrder(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate = &intermediate.Intermediate{
+		PublicChannels:  []*intermediate.IntermediateChannel{{Name: "general", DisplayName: "General", Type: model.ChannelTypeOpen}},
+		PrivateChannels: []*intermediate.IntermediateChannel{{Name: "secret", DisplayName: "Secret", Type: model.ChannelTypePrivate}},
+		UsersById: map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Email: "a@a.com"},
+		},
+		DirectChannels: []*intermediate.IntermediateChannel{
+			{MembersUsernames: []string{"alice", "bob"}},
+		},
+		Posts: []*intermediate.IntermediatePost{
+			{User: "alice", Channel: "general", Message: "hi", CreateAt: 1000},
+		},
+	}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "export-*.jsonl")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	require.NoError(t, tr.Export(tmpFile.Name(), ""))
+
+	data, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	var types []string
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for dec.More() {
+		var line imports.LineImportData
+		require.NoError(t, dec.Decode(&line))
+		types = append(types, line.Type)
+	}
+
+	// Expected order: version, public channel, private channel, user,
+	// direct channel, post
+	require.Len(t, types, 6)
+	assert.Equal(t, "version", types[0])
+	assert.Equal(t, "channel", types[1]) // public channel
+	assert.Equal(t, "channel", types[2]) // private channel
+	assert.Equal(t, "user", types[3])
+	assert.Equal(t, "direct_channel", types[4])
+	assert.Equal(t, "post", types[5])
+}
+
+func TestExportUsersIncludeTeamMemberships(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+		"u1": {Id: "u1", Username: "alice", Email: "a@a.com", Memberships: []intermediate.IntermediateMembership{{Name: "general"}, {Name: "random"}}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportUsers(&buf, ""))
+
+	lines := readLines(t, &buf)
+	require.Len(t, lines, 1)
+	user := lines[0]["user"].(map[string]any)
+	teams := user["teams"].([]any)
+	require.Len(t, teams, 1)
+	team := teams[0].(map[string]any)
+	assert.Equal(t, "myteam", team["name"])
+	channels := team["channels"].([]any)
+	assert.Len(t, channels, 2)
+	channelNames := []string{}
+	for _, c := range channels {
+		ch := c.(map[string]any)
+		channelNames = append(channelNames, ch["name"].(string))
+	}
+	assert.Contains(t, channelNames, "general")
+	assert.Contains(t, channelNames, "random")
+}
+
+func TestExportLinesAreValidJSON(t *testing.T) {
+	tr := NewTransformer("myteam", newExportLogger())
+	tr.Intermediate = &intermediate.Intermediate{
+		PublicChannels: []*intermediate.IntermediateChannel{{Name: "gen", DisplayName: "Gen", Type: model.ChannelTypeOpen}},
+		UsersById: map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Email: "a@a.com"},
+		},
+		Posts: []*intermediate.IntermediatePost{
+			{User: "alice", Channel: "gen", Message: "hello", CreateAt: 1000},
+		},
+	}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "export-*.jsonl")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	require.NoError(t, tr.Export(tmpFile.Name(), ""))
+
+	data, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var obj map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &obj), "invalid JSON line: %s", line)
+	}
+}

--- a/services/rocketchat/export_test.go
+++ b/services/rocketchat/export_test.go
@@ -246,6 +246,56 @@ func TestExportUsersIncludeTeamMemberships(t *testing.T) {
 	assert.Contains(t, channelNames, "random")
 }
 
+func TestExportDirectChannelsMarksGuests(t *testing.T) {
+	// alice is a regular member, bob is a guest with a channel membership.
+	newTransformer := func(emitGuestRoles bool) *Transformer {
+		tr := NewTransformer("myteam", newExportLogger())
+		tr.EmitGuestRoles = emitGuestRoles
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Email: "a@a.com", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"g1": {Id: "g1", Username: "bob", Email: "b@b.com", IsGuest: true, Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+		}
+		return tr
+	}
+	channels := []*intermediate.IntermediateChannel{
+		{Id: "dm1", Type: model.ChannelTypeDirect, MembersUsernames: []string{"alice", "bob"}, Created: 1704067200},
+	}
+
+	participantsByName := func(t *testing.T, tr *Transformer) map[string]*imports.DirectChannelMemberImportData {
+		t.Helper()
+		var buf bytes.Buffer
+		require.NoError(t, tr.ExportDirectChannels(channels, &buf))
+		var line imports.LineImportData
+		require.NoError(t, json.NewDecoder(&buf).Decode(&line))
+		require.NotNil(t, line.DirectChannel)
+		require.Len(t, line.DirectChannel.Participants, 2)
+		byName := map[string]*imports.DirectChannelMemberImportData{}
+		for _, p := range line.DirectChannel.Participants {
+			byName[*p.Username] = p
+		}
+		return byName
+	}
+
+	t.Run("guest mode marks the guest participant with SchemeGuest", func(t *testing.T) {
+		byName := participantsByName(t, newTransformer(true))
+		require.NotNil(t, byName["alice"])
+		assert.True(t, *byName["alice"].SchemeUser)
+		assert.False(t, *byName["alice"].SchemeGuest)
+		require.NotNil(t, byName["bob"])
+		assert.False(t, *byName["bob"].SchemeUser)
+		assert.True(t, *byName["bob"].SchemeGuest)
+	})
+
+	t.Run("user mode marks everyone as SchemeUser", func(t *testing.T) {
+		byName := participantsByName(t, newTransformer(false))
+		for _, name := range []string{"alice", "bob"} {
+			require.NotNil(t, byName[name])
+			assert.True(t, *byName[name].SchemeUser)
+			assert.False(t, *byName[name].SchemeGuest)
+		}
+	})
+}
+
 func TestExportLinesAreValidJSON(t *testing.T) {
 	tr := NewTransformer("myteam", newExportLogger())
 	tr.Intermediate = &intermediate.Intermediate{

--- a/services/rocketchat/gridfs.go
+++ b/services/rocketchat/gridfs.go
@@ -1,0 +1,73 @@
+package rocketchat
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+// GridFSChunk represents one chunk of a GridFS file as stored in
+// rocketchat_uploads.chunks.bson.
+type GridFSChunk struct {
+	ID      any    `bson:"_id"`
+	FilesID string `bson:"files_id"` // References the upload _id
+	N       int    `bson:"n"`        // Chunk number (0-indexed)
+	Data    []byte `bson:"data"`     // Binary chunk data (typically 255 KB)
+}
+
+// LoadGridFSChunks reads all chunks from chunksFilePath (which must be a BSON file
+// in mongodump format, i.e. rocketchat_uploads.chunks.bson) and returns a map of
+// fileID → chunks sorted by chunk number (n).
+func LoadGridFSChunks(chunksFilePath string) (map[string][]GridFSChunk, error) {
+	chunks, err := readBSONFile[GridFSChunk](chunksFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("loading GridFS chunks from %s: %w", chunksFilePath, err)
+	}
+
+	byFile := make(map[string][]GridFSChunk)
+	for _, c := range chunks {
+		byFile[c.FilesID] = append(byFile[c.FilesID], c)
+	}
+
+	// Sort each group by chunk number.
+	for fid := range byFile {
+		group := byFile[fid]
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].N < group[j].N
+		})
+		byFile[fid] = group
+	}
+
+	return byFile, nil
+}
+
+// ReassembleGridFSFile writes the binary data from sorted chunks to outputPath,
+// creating (or truncating) the file.
+//
+// Chunks must be sorted by N (as LoadGridFSChunks guarantees) and must form a
+// complete, contiguous sequence starting at 0. A gap or duplicate chunk number
+// is treated as a corrupt file and returns an error rather than silently
+// producing a truncated or garbled output file.
+func ReassembleGridFSFile(chunks []GridFSChunk, outputPath string) error {
+	// Validate that chunks form the contiguous sequence 0, 1, 2, …, len-1.
+	// LoadGridFSChunks sorts by N, so we only need to check that each chunk's N
+	// matches its position in the slice (catching both gaps and duplicates).
+	for i, chunk := range chunks {
+		if chunk.N != i {
+			return fmt.Errorf("chunk sequence error for %s: expected chunk %d but got chunk %d (gap or duplicate)", outputPath, i, chunk.N)
+		}
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("creating output file %s: %w", outputPath, err)
+	}
+	defer f.Close()
+
+	for _, chunk := range chunks {
+		if _, err := f.Write(chunk.Data); err != nil {
+			return fmt.Errorf("writing chunk %d to %s: %w", chunk.N, outputPath, err)
+		}
+	}
+	return nil
+}

--- a/services/rocketchat/gridfs.go
+++ b/services/rocketchat/gridfs.go
@@ -2,8 +2,11 @@ package rocketchat
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // GridFSChunk represents one chunk of a GridFS file as stored in
@@ -15,59 +18,157 @@ type GridFSChunk struct {
 	Data    []byte `bson:"data"`     // Binary chunk data (typically 255 KB)
 }
 
-// LoadGridFSChunks reads all chunks from chunksFilePath (which must be a BSON file
-// in mongodump format, i.e. rocketchat_uploads.chunks.bson) and returns a map of
-// fileID → chunks sorted by chunk number (n).
-func LoadGridFSChunks(chunksFilePath string) (map[string][]GridFSChunk, error) {
-	chunks, err := readBSONFile[GridFSChunk](chunksFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("loading GridFS chunks from %s: %w", chunksFilePath, err)
-	}
-
-	byFile := make(map[string][]GridFSChunk)
-	for _, c := range chunks {
-		byFile[c.FilesID] = append(byFile[c.FilesID], c)
-	}
-
-	// Sort each group by chunk number.
-	for fid := range byFile {
-		group := byFile[fid]
-		sort.Slice(group, func(i, j int) bool {
-			return group[i].N < group[j].N
-		})
-		byFile[fid] = group
-	}
-
-	return byFile, nil
+// gridFSChunkMeta decodes only the lightweight metadata of a chunk. The Data
+// field is deliberately omitted so the BSON decoder skips the (large) binary
+// payload rather than allocating and retaining it while the index is built.
+type gridFSChunkMeta struct {
+	FilesID string `bson:"files_id"`
+	N       int    `bson:"n"`
 }
 
-// ReassembleGridFSFile writes the binary data from sorted chunks to outputPath,
-// creating (or truncating) the file.
-//
-// Chunks must be sorted by N (as LoadGridFSChunks guarantees) and must form a
-// complete, contiguous sequence starting at 0. A gap or duplicate chunk number
-// is treated as a corrupt file and returns an error rather than silently
-// producing a truncated or garbled output file.
-func ReassembleGridFSFile(chunks []GridFSChunk, outputPath string) error {
-	// Validate that chunks form the contiguous sequence 0, 1, 2, …, len-1.
-	// LoadGridFSChunks sorts by N, so we only need to check that each chunk's N
-	// matches its position in the slice (catching both gaps and duplicates).
-	for i, chunk := range chunks {
-		if chunk.N != i {
-			return fmt.Errorf("chunk sequence error for %s: expected chunk %d but got chunk %d (gap or duplicate)", outputPath, i, chunk.N)
-		}
-	}
+// gridFSChunkLoc records where a single chunk lives within the chunks BSON file,
+// so its data can be streamed on demand instead of held in memory.
+type gridFSChunkLoc struct {
+	offset int64 // byte offset of the chunk document within the chunks file
+	n      int   // chunk number (0-indexed)
+}
 
-	f, err := os.Create(outputPath)
+// GridFSIndex is a memory-light index over rocketchat_uploads.chunks.bson.
+//
+// A GridFS export concatenates the binary data of every uploaded file, which can
+// be many gigabytes. Rather than loading all of it into memory at once, the index
+// records only the byte offset and chunk number of each chunk (grouped by upload
+// ID and sorted by chunk number). Attachment data is then streamed one chunk at a
+// time during extraction, bounding peak memory to roughly a single chunk.
+type GridFSIndex struct {
+	path   string
+	byFile map[string][]gridFSChunkLoc
+}
+
+// BuildGridFSIndex scans chunksFilePath (a mongodump BSON file, i.e.
+// rocketchat_uploads.chunks.bson) and builds an index of chunk locations without
+// retaining any chunk data.
+func BuildGridFSIndex(chunksFilePath string) (*GridFSIndex, error) {
+	f, err := os.Open(chunksFilePath)
 	if err != nil {
-		return fmt.Errorf("creating output file %s: %w", outputPath, err)
+		return nil, fmt.Errorf("opening GridFS chunks file %s: %w", chunksFilePath, err)
 	}
 	defer f.Close()
 
-	for _, chunk := range chunks {
-		if _, err := f.Write(chunk.Data); err != nil {
-			return fmt.Errorf("writing chunk %d to %s: %w", chunk.N, outputPath, err)
+	br := newBSONDocReader(f)
+	byFile := make(map[string][]gridFSChunkLoc)
+	for {
+		doc, offset, err := br.next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading GridFS chunk from %s: %w", chunksFilePath, err)
+		}
+
+		// Decode metadata only; the transient doc buffer (including the binary
+		// payload) is discarded each iteration, so peak memory stays around one
+		// chunk rather than the whole attachment corpus.
+		var meta gridFSChunkMeta
+		if err := bson.Unmarshal(doc, &meta); err != nil {
+			return nil, fmt.Errorf("unmarshalling GridFS chunk metadata from %s: %w", chunksFilePath, err)
+		}
+		byFile[meta.FilesID] = append(byFile[meta.FilesID], gridFSChunkLoc{offset: offset, n: meta.N})
+	}
+
+	// Sort each group by chunk number so reassembly streams in order and can
+	// validate that the sequence is contiguous.
+	for fid := range byFile {
+		locs := byFile[fid]
+		sort.Slice(locs, func(i, j int) bool {
+			return locs[i].n < locs[j].n
+		})
+		byFile[fid] = locs
+	}
+
+	return &GridFSIndex{path: chunksFilePath, byFile: byFile}, nil
+}
+
+// Has reports whether the index contains at least one chunk for filesID.
+func (idx *GridFSIndex) Has(filesID string) bool {
+	return len(idx.byFile[filesID]) > 0
+}
+
+// WriteFile reassembles the file identified by filesID into outputPath, opening
+// the chunks file for the duration of the call. Prefer reassembleFrom when
+// extracting many files so the chunks file is opened only once.
+func (idx *GridFSIndex) WriteFile(filesID, outputPath string) error {
+	f, err := os.Open(idx.path)
+	if err != nil {
+		return fmt.Errorf("opening GridFS chunks file %s: %w", idx.path, err)
+	}
+	defer f.Close()
+	return idx.reassembleFrom(f, filesID, outputPath)
+}
+
+// reassembleFrom writes the binary data of the file identified by filesID to
+// outputPath, streaming one chunk at a time from r (which must read the chunks
+// file this index was built from).
+//
+// The chunks must form a complete, contiguous sequence starting at 0. A gap or
+// duplicate chunk number is treated as a corrupt file and returns an error
+// (before any output file is created) rather than silently producing a truncated
+// or garbled output file.
+func (idx *GridFSIndex) reassembleFrom(r io.ReaderAt, filesID, outputPath string) error {
+	locs := idx.byFile[filesID]
+
+	// Validate that chunks form the contiguous sequence 0, 1, 2, …, len-1 before
+	// creating any output. locs is sorted by chunk number at index-build time, so
+	// a value not matching its position catches both gaps and duplicates.
+	for i, loc := range locs {
+		if loc.n != i {
+			return fmt.Errorf("chunk sequence error for %s: expected chunk %d but got chunk %d (gap or duplicate)", outputPath, i, loc.n)
+		}
+	}
+
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("creating output file %s: %w", outputPath, err)
+	}
+	defer out.Close()
+
+	for _, loc := range locs {
+		chunk, err := readChunkAt(r, loc.offset)
+		if err != nil {
+			return fmt.Errorf("reading chunk %d of %s: %w", loc.n, outputPath, err)
+		}
+		if _, err := out.Write(chunk.Data); err != nil {
+			return fmt.Errorf("writing chunk %d to %s: %w", loc.n, outputPath, err)
 		}
 	}
 	return nil
+}
+
+// readChunkAt reads and decodes the single GridFS chunk document that begins at
+// offset in r.
+func readChunkAt(r io.ReaderAt, offset int64) (*GridFSChunk, error) {
+	// The document's total length is encoded in its first 4 bytes (little-endian
+	// int32), so read that first to know how many bytes the chunk occupies.
+	var sizeBuf [4]byte
+	if _, err := r.ReadAt(sizeBuf[:], offset); err != nil {
+		return nil, fmt.Errorf("reading chunk size at offset %d: %w", offset, err)
+	}
+	docSize := int32(sizeBuf[0]) | int32(sizeBuf[1])<<8 | int32(sizeBuf[2])<<16 | int32(sizeBuf[3])<<24
+	if docSize < 5 {
+		return nil, fmt.Errorf("invalid chunk document size %d at offset %d", docSize, offset)
+	}
+	if docSize > maxBSONDocSize {
+		return nil, fmt.Errorf("chunk document size %d at offset %d exceeds maximum allowed %d", docSize, offset, maxBSONDocSize)
+	}
+
+	buf := make([]byte, int(docSize))
+	if _, err := r.ReadAt(buf, offset); err != nil {
+		return nil, fmt.Errorf("reading chunk body at offset %d: %w", offset, err)
+	}
+
+	var chunk GridFSChunk
+	if err := bson.Unmarshal(buf, &chunk); err != nil {
+		return nil, fmt.Errorf("unmarshalling chunk at offset %d: %w", offset, err)
+	}
+	return &chunk, nil
 }

--- a/services/rocketchat/gridfs.go
+++ b/services/rocketchat/gridfs.go
@@ -130,15 +130,28 @@ func (idx *GridFSIndex) reassembleFrom(r io.ReaderAt, filesID, outputPath string
 	if err != nil {
 		return fmt.Errorf("creating output file %s: %w", outputPath, err)
 	}
-	defer out.Close()
+	return writeChunks(out, r, locs, outputPath)
+}
+
+// writeChunks streams each chunk in locs from r into out, in order, and closes
+// out. It reports a delayed write error surfaced by Close — e.g. a failed flush
+// on a full disk or network filesystem — rather than discarding it, so a
+// truncated output file is never mistaken for a successful extraction. An
+// earlier read/write error takes precedence over the Close error.
+func writeChunks(out io.WriteCloser, r io.ReaderAt, locs []gridFSChunkLoc, name string) (err error) {
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing %s: %w", name, cerr)
+		}
+	}()
 
 	for _, loc := range locs {
-		chunk, err := readChunkAt(r, loc.offset)
-		if err != nil {
-			return fmt.Errorf("reading chunk %d of %s: %w", loc.n, outputPath, err)
+		chunk, rerr := readChunkAt(r, loc.offset)
+		if rerr != nil {
+			return fmt.Errorf("reading chunk %d of %s: %w", loc.n, name, rerr)
 		}
-		if _, err := out.Write(chunk.Data); err != nil {
-			return fmt.Errorf("writing chunk %d to %s: %w", loc.n, outputPath, err)
+		if _, werr := out.Write(chunk.Data); werr != nil {
+			return fmt.Errorf("writing chunk %d to %s: %w", loc.n, name, werr)
 		}
 	}
 	return nil

--- a/services/rocketchat/gridfs_test.go
+++ b/services/rocketchat/gridfs_test.go
@@ -1,0 +1,254 @@
+package rocketchat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// buildBSONChunksFile creates a BSON file containing the given chunks.
+func buildBSONChunksFile(t *testing.T, dir string, chunks []GridFSChunk) string {
+	t.Helper()
+	docs := make([]any, len(chunks))
+	for i, c := range chunks {
+		docs[i] = c
+	}
+	p := filepath.Join(dir, "chunks.bson")
+	marshalBSONFile(t, p, docs)
+	return p
+}
+
+func TestLoadGridFSChunks(t *testing.T) {
+	t.Run("single chunk file", func(t *testing.T) {
+		dir := t.TempDir()
+		chunks := []GridFSChunk{
+			{FilesID: "file1", N: 0, Data: []byte("hello world")},
+		}
+		p := buildBSONChunksFile(t, dir, chunks)
+
+		result, err := LoadGridFSChunks(p)
+		require.NoError(t, err)
+		require.Len(t, result["file1"], 1)
+		assert.Equal(t, []byte("hello world"), result["file1"][0].Data)
+	})
+
+	t.Run("multiple chunks sorted by n", func(t *testing.T) {
+		dir := t.TempDir()
+		// Write in reverse order — Load should sort by N.
+		chunks := []GridFSChunk{
+			{FilesID: "file1", N: 2, Data: []byte("world")},
+			{FilesID: "file1", N: 0, Data: []byte("hello ")},
+			{FilesID: "file1", N: 1, Data: []byte("brave ")},
+		}
+		p := buildBSONChunksFile(t, dir, chunks)
+
+		result, err := LoadGridFSChunks(p)
+		require.NoError(t, err)
+		require.Len(t, result["file1"], 3)
+		assert.Equal(t, 0, result["file1"][0].N)
+		assert.Equal(t, 1, result["file1"][1].N)
+		assert.Equal(t, 2, result["file1"][2].N)
+	})
+
+	t.Run("multiple files grouped correctly", func(t *testing.T) {
+		dir := t.TempDir()
+		chunks := []GridFSChunk{
+			{FilesID: "file1", N: 0, Data: []byte("fileone")},
+			{FilesID: "file2", N: 0, Data: []byte("filetwo")},
+		}
+		p := buildBSONChunksFile(t, dir, chunks)
+
+		result, err := LoadGridFSChunks(p)
+		require.NoError(t, err)
+		assert.Len(t, result["file1"], 1)
+		assert.Len(t, result["file2"], 1)
+	})
+
+	t.Run("empty chunks file", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "chunks.bson")
+		require.NoError(t, os.WriteFile(p, []byte{}, 0600))
+
+		result, err := LoadGridFSChunks(p)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+func TestReassembleGridFSFile(t *testing.T) {
+	t.Run("single chunk", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.bin")
+		chunks := []GridFSChunk{
+			{N: 0, Data: []byte("hello world")},
+		}
+		require.NoError(t, ReassembleGridFSFile(chunks, outPath))
+		data, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hello world"), data)
+	})
+
+	t.Run("multiple chunks concatenated in order", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.bin")
+		chunks := []GridFSChunk{
+			{N: 0, Data: []byte("Hello, ")},
+			{N: 1, Data: []byte("brave ")},
+			{N: 2, Data: []byte("new world!")},
+		}
+		require.NoError(t, ReassembleGridFSFile(chunks, outPath))
+		data, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("Hello, brave new world!"), data)
+	})
+
+	t.Run("empty chunks produces empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.bin")
+		require.NoError(t, ReassembleGridFSFile(nil, outPath))
+		data, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+
+	t.Run("gap in sequence returns error and no output file", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.bin")
+		chunks := []GridFSChunk{
+			{N: 0, Data: []byte("part0")},
+			{N: 2, Data: []byte("part2")}, // N:1 missing
+		}
+		err := ReassembleGridFSFile(chunks, outPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gap or duplicate")
+		_, statErr := os.Stat(outPath)
+		assert.True(t, os.IsNotExist(statErr), "output file must not be created on error")
+	})
+
+	t.Run("duplicate chunk N returns error and no output file", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.bin")
+		chunks := []GridFSChunk{
+			{N: 0, Data: []byte("part0")},
+			{N: 0, Data: []byte("dup0")},
+		}
+		err := ReassembleGridFSFile(chunks, outPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gap or duplicate")
+		_, statErr := os.Stat(outPath)
+		assert.True(t, os.IsNotExist(statErr), "output file must not be created on error")
+	})
+}
+
+func TestExtractAttachments(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(os.Stderr)
+
+	t.Run("GridFS extraction end-to-end", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		content := []byte("binary file content")
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "photo.jpg", Store: "GridFS:Uploads", Complete: true},
+		}
+		chunks := map[string][]GridFSChunk{
+			"up1": {{N: 0, Data: content}},
+		}
+
+		err := ExtractAttachments(uploads, chunks, outDir, "", logger)
+		require.NoError(t, err)
+
+		expectedPath := filepath.Join(outDir, "up1_photo.jpg")
+		data, err := os.ReadFile(expectedPath)
+		require.NoError(t, err)
+		assert.Equal(t, content, data)
+	})
+
+	t.Run("FileSystem copy", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+		uploadsDir := filepath.Join(dir, "uploads")
+		require.NoError(t, os.MkdirAll(uploadsDir, 0755))
+
+		srcContent := []byte("filesystem file content")
+		srcPath := filepath.Join(uploadsDir, "photo.png")
+		require.NoError(t, os.WriteFile(srcPath, srcContent, 0600))
+
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "photo.png", Store: "FileSystem", Path: "/file-upload/up1/photo.png", Complete: true},
+		}
+
+		err := ExtractAttachments(uploads, nil, outDir, uploadsDir, logger)
+		require.NoError(t, err)
+
+		expectedPath := filepath.Join(outDir, "up1_photo.png")
+		data, err := os.ReadFile(expectedPath)
+		require.NoError(t, err)
+		assert.Equal(t, srcContent, data)
+	})
+
+	t.Run("skip incomplete upload", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "incomplete.jpg", Store: "GridFS:Uploads", Complete: false},
+		}
+
+		err := ExtractAttachments(uploads, nil, outDir, "", logger)
+		require.NoError(t, err)
+		// output dir might not exist since nothing was written
+		_, statErr := os.Stat(filepath.Join(outDir, "up1_incomplete.jpg"))
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("skip missing GridFS chunks with warning", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "missing.jpg", Store: "GridFS:Uploads", Complete: true},
+		}
+
+		err := ExtractAttachments(uploads, map[string][]GridFSChunk{}, outDir, "", logger)
+		require.NoError(t, err) // should not error, just warn
+	})
+
+	t.Run("NFC normalization on filename", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		// Use NFD decomposed form: 'e' + U+0301 COMBINING ACUTE ACCENT.
+		// ExtractAttachments must apply NFC *before* sanitizing so that the
+		// two-codepoint sequence is composed into the single precomposed 'é'
+		// (U+00E9) and then sanitized to '_'.  If NFC were applied after
+		// sanitization the combining accent would have already been stripped to
+		// '_' and the 'e' would remain, yielding a longer filename.
+		filename := "cafe\u0301.txt" // NFD: 'e' + combining acute accent
+		content := []byte("text")
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: filename, Store: "GridFS:Uploads", Complete: true},
+		}
+		chunks := map[string][]GridFSChunk{
+			"up1": {{N: 0, Data: content}},
+		}
+
+		err := ExtractAttachments(uploads, chunks, outDir, "", logger)
+		require.NoError(t, err)
+
+		// NFC normalization composes "e" + combining accent → "é", then
+		// sanitizeFilename replaces the non-ASCII "é" with "_", producing
+		// "caf_.txt".  Without NFC-first the combining accent would be stripped
+		// separately and "e" would remain, yielding the longer "cafe_.txt".
+		entries, err := os.ReadDir(outDir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "up1_caf_.txt", entries[0].Name())
+	})
+}

--- a/services/rocketchat/gridfs_test.go
+++ b/services/rocketchat/gridfs_test.go
@@ -1,6 +1,8 @@
 package rocketchat
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +12,60 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+// fakeWriteCloser lets a test deterministically trigger write and/or close
+// failures that are otherwise hard to provoke against a real filesystem.
+type fakeWriteCloser struct {
+	buf       bytes.Buffer
+	failWrite bool
+	failClose bool
+}
+
+func (f *fakeWriteCloser) Write(p []byte) (int, error) {
+	if f.failWrite {
+		return 0, fmt.Errorf("simulated write failure")
+	}
+	return f.buf.Write(p)
+}
+
+func (f *fakeWriteCloser) Close() error {
+	if f.failClose {
+		return fmt.Errorf("simulated close failure")
+	}
+	return nil
+}
+
+func TestWriteChunks(t *testing.T) {
+	dir := t.TempDir()
+	// A single-chunk BSON file; the chunk document begins at offset 0.
+	chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
+		{FilesID: "f1", N: 0, Data: []byte("payload")},
+	})
+	f, err := os.Open(chunksPath)
+	require.NoError(t, err)
+	defer f.Close()
+	locs := []gridFSChunkLoc{{offset: 0, n: 0}}
+
+	t.Run("writes chunk data and succeeds", func(t *testing.T) {
+		w := &fakeWriteCloser{}
+		require.NoError(t, writeChunks(w, f, locs, "out.bin"))
+		assert.Equal(t, "payload", w.buf.String())
+	})
+
+	t.Run("propagates a delayed Close error", func(t *testing.T) {
+		w := &fakeWriteCloser{failClose: true}
+		err := writeChunks(w, f, locs, "out.bin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "closing out.bin")
+	})
+
+	t.Run("write error takes precedence over Close error", func(t *testing.T) {
+		w := &fakeWriteCloser{failWrite: true, failClose: true}
+		err := writeChunks(w, f, locs, "out.bin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "writing chunk 0")
+	})
+}
 
 // buildBSONChunksFile creates a BSON file containing the given chunks.
 func buildBSONChunksFile(t *testing.T, dir string, chunks []GridFSChunk) string {

--- a/services/rocketchat/gridfs_test.go
+++ b/services/rocketchat/gridfs_test.go
@@ -216,7 +216,7 @@ func TestExtractAttachments(t *testing.T) {
 
 		content := []byte("binary file content")
 		uploads := map[string]*RocketChatUpload{
-			"up1": {ID: "up1", Name: "photo.jpg", Store: "GridFS:Uploads", Complete: true},
+			"up1": {ID: "up1", Name: "photo.jpg", Size: int64(len(content)), Store: "GridFS:Uploads", Complete: true},
 		}
 		chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
 			{FilesID: "up1", N: 0, Data: content},
@@ -276,7 +276,7 @@ func TestExtractAttachments(t *testing.T) {
 		outDir := filepath.Join(dir, "output")
 
 		uploads := map[string]*RocketChatUpload{
-			"up1": {ID: "up1", Name: "missing.jpg", Store: "GridFS:Uploads", Complete: true},
+			"up1": {ID: "up1", Name: "missing.jpg", Size: 1, Store: "GridFS:Uploads", Complete: true},
 		}
 
 		// Index built from an empty chunks file — up1 has no chunks.
@@ -287,6 +287,45 @@ func TestExtractAttachments(t *testing.T) {
 
 		err = ExtractAttachments(uploads, idx, outDir, "", logger)
 		require.NoError(t, err) // should not error, just warn
+	})
+
+	t.Run("extract zero-byte GridFS upload without chunks file", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "empty.txt", Size: 0, Store: "GridFS:Uploads", Complete: true},
+		}
+
+		err := ExtractAttachments(uploads, nil, outDir, "", logger)
+		require.NoError(t, err)
+
+		extractedPath := filepath.Join(outDir, "up1_empty.txt")
+		info, err := os.Stat(extractedPath)
+		require.NoError(t, err)
+		assert.Zero(t, info.Size())
+	})
+
+	t.Run("prefer GridFS chunks over inconsistent zero size metadata", func(t *testing.T) {
+		dir := t.TempDir()
+		outDir := filepath.Join(dir, "output")
+
+		content := []byte("content despite bogus metadata")
+		uploads := map[string]*RocketChatUpload{
+			"up1": {ID: "up1", Name: "preserved.txt", Size: 0, Store: "GridFS:Uploads", Complete: true},
+		}
+		chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "up1", N: 0, Data: content},
+		})
+		idx, err := BuildGridFSIndex(chunksPath)
+		require.NoError(t, err)
+
+		err = ExtractAttachments(uploads, idx, outDir, "", logger)
+		require.NoError(t, err)
+
+		extracted, err := os.ReadFile(filepath.Join(outDir, "up1_preserved.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, content, extracted)
 	})
 
 	t.Run("NFC normalization on filename", func(t *testing.T) {
@@ -302,7 +341,7 @@ func TestExtractAttachments(t *testing.T) {
 		filename := "cafe\u0301.txt" // NFD: 'e' + combining acute accent
 		content := []byte("text")
 		uploads := map[string]*RocketChatUpload{
-			"up1": {ID: "up1", Name: filename, Store: "GridFS:Uploads", Complete: true},
+			"up1": {ID: "up1", Name: filename, Size: int64(len(content)), Store: "GridFS:Uploads", Complete: true},
 		}
 		chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
 			{FilesID: "up1", N: 0, Data: content},

--- a/services/rocketchat/gridfs_test.go
+++ b/services/rocketchat/gridfs_test.go
@@ -23,7 +23,7 @@ func buildBSONChunksFile(t *testing.T, dir string, chunks []GridFSChunk) string 
 	return p
 }
 
-func TestLoadGridFSChunks(t *testing.T) {
+func TestBuildGridFSIndex(t *testing.T) {
 	t.Run("single chunk file", func(t *testing.T) {
 		dir := t.TempDir()
 		chunks := []GridFSChunk{
@@ -31,15 +31,15 @@ func TestLoadGridFSChunks(t *testing.T) {
 		}
 		p := buildBSONChunksFile(t, dir, chunks)
 
-		result, err := LoadGridFSChunks(p)
+		idx, err := BuildGridFSIndex(p)
 		require.NoError(t, err)
-		require.Len(t, result["file1"], 1)
-		assert.Equal(t, []byte("hello world"), result["file1"][0].Data)
+		require.Len(t, idx.byFile["file1"], 1)
+		assert.True(t, idx.Has("file1"))
 	})
 
 	t.Run("multiple chunks sorted by n", func(t *testing.T) {
 		dir := t.TempDir()
-		// Write in reverse order — Load should sort by N.
+		// Write in reverse order — the index should sort by N.
 		chunks := []GridFSChunk{
 			{FilesID: "file1", N: 2, Data: []byte("world")},
 			{FilesID: "file1", N: 0, Data: []byte("hello ")},
@@ -47,12 +47,12 @@ func TestLoadGridFSChunks(t *testing.T) {
 		}
 		p := buildBSONChunksFile(t, dir, chunks)
 
-		result, err := LoadGridFSChunks(p)
+		idx, err := BuildGridFSIndex(p)
 		require.NoError(t, err)
-		require.Len(t, result["file1"], 3)
-		assert.Equal(t, 0, result["file1"][0].N)
-		assert.Equal(t, 1, result["file1"][1].N)
-		assert.Equal(t, 2, result["file1"][2].N)
+		require.Len(t, idx.byFile["file1"], 3)
+		assert.Equal(t, 0, idx.byFile["file1"][0].n)
+		assert.Equal(t, 1, idx.byFile["file1"][1].n)
+		assert.Equal(t, 2, idx.byFile["file1"][2].n)
 	})
 
 	t.Run("multiple files grouped correctly", func(t *testing.T) {
@@ -63,10 +63,10 @@ func TestLoadGridFSChunks(t *testing.T) {
 		}
 		p := buildBSONChunksFile(t, dir, chunks)
 
-		result, err := LoadGridFSChunks(p)
+		idx, err := BuildGridFSIndex(p)
 		require.NoError(t, err)
-		assert.Len(t, result["file1"], 1)
-		assert.Len(t, result["file2"], 1)
+		assert.Len(t, idx.byFile["file1"], 1)
+		assert.Len(t, idx.byFile["file2"], 1)
 	})
 
 	t.Run("empty chunks file", func(t *testing.T) {
@@ -74,20 +74,24 @@ func TestLoadGridFSChunks(t *testing.T) {
 		p := filepath.Join(dir, "chunks.bson")
 		require.NoError(t, os.WriteFile(p, []byte{}, 0600))
 
-		result, err := LoadGridFSChunks(p)
+		idx, err := BuildGridFSIndex(p)
 		require.NoError(t, err)
-		assert.Empty(t, result)
+		assert.Empty(t, idx.byFile)
+		assert.False(t, idx.Has("file1"))
 	})
 }
 
-func TestReassembleGridFSFile(t *testing.T) {
+func TestGridFSIndexWriteFile(t *testing.T) {
 	t.Run("single chunk", func(t *testing.T) {
 		dir := t.TempDir()
 		outPath := filepath.Join(dir, "out.bin")
-		chunks := []GridFSChunk{
-			{N: 0, Data: []byte("hello world")},
-		}
-		require.NoError(t, ReassembleGridFSFile(chunks, outPath))
+		p := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "file1", N: 0, Data: []byte("hello world")},
+		})
+		idx, err := BuildGridFSIndex(p)
+		require.NoError(t, err)
+
+		require.NoError(t, idx.WriteFile("file1", outPath))
 		data, err := os.ReadFile(outPath)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("hello world"), data)
@@ -96,34 +100,32 @@ func TestReassembleGridFSFile(t *testing.T) {
 	t.Run("multiple chunks concatenated in order", func(t *testing.T) {
 		dir := t.TempDir()
 		outPath := filepath.Join(dir, "out.bin")
-		chunks := []GridFSChunk{
-			{N: 0, Data: []byte("Hello, ")},
-			{N: 1, Data: []byte("brave ")},
-			{N: 2, Data: []byte("new world!")},
-		}
-		require.NoError(t, ReassembleGridFSFile(chunks, outPath))
+		// Deliberately out of order on disk — reassembly must follow chunk number.
+		p := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "file1", N: 2, Data: []byte("new world!")},
+			{FilesID: "file1", N: 0, Data: []byte("Hello, ")},
+			{FilesID: "file1", N: 1, Data: []byte("brave ")},
+		})
+		idx, err := BuildGridFSIndex(p)
+		require.NoError(t, err)
+
+		require.NoError(t, idx.WriteFile("file1", outPath))
 		data, err := os.ReadFile(outPath)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("Hello, brave new world!"), data)
 	})
 
-	t.Run("empty chunks produces empty file", func(t *testing.T) {
-		dir := t.TempDir()
-		outPath := filepath.Join(dir, "out.bin")
-		require.NoError(t, ReassembleGridFSFile(nil, outPath))
-		data, err := os.ReadFile(outPath)
-		require.NoError(t, err)
-		assert.Empty(t, data)
-	})
-
 	t.Run("gap in sequence returns error and no output file", func(t *testing.T) {
 		dir := t.TempDir()
 		outPath := filepath.Join(dir, "out.bin")
-		chunks := []GridFSChunk{
-			{N: 0, Data: []byte("part0")},
-			{N: 2, Data: []byte("part2")}, // N:1 missing
-		}
-		err := ReassembleGridFSFile(chunks, outPath)
+		p := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "file1", N: 0, Data: []byte("part0")},
+			{FilesID: "file1", N: 2, Data: []byte("part2")}, // N:1 missing
+		})
+		idx, err := BuildGridFSIndex(p)
+		require.NoError(t, err)
+
+		err = idx.WriteFile("file1", outPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "gap or duplicate")
 		_, statErr := os.Stat(outPath)
@@ -133,11 +135,14 @@ func TestReassembleGridFSFile(t *testing.T) {
 	t.Run("duplicate chunk N returns error and no output file", func(t *testing.T) {
 		dir := t.TempDir()
 		outPath := filepath.Join(dir, "out.bin")
-		chunks := []GridFSChunk{
-			{N: 0, Data: []byte("part0")},
-			{N: 0, Data: []byte("dup0")},
-		}
-		err := ReassembleGridFSFile(chunks, outPath)
+		p := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "file1", N: 0, Data: []byte("part0")},
+			{FilesID: "file1", N: 0, Data: []byte("dup0")},
+		})
+		idx, err := BuildGridFSIndex(p)
+		require.NoError(t, err)
+
+		err = idx.WriteFile("file1", outPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "gap or duplicate")
 		_, statErr := os.Stat(outPath)
@@ -157,11 +162,13 @@ func TestExtractAttachments(t *testing.T) {
 		uploads := map[string]*RocketChatUpload{
 			"up1": {ID: "up1", Name: "photo.jpg", Store: "GridFS:Uploads", Complete: true},
 		}
-		chunks := map[string][]GridFSChunk{
-			"up1": {{N: 0, Data: content}},
-		}
+		chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "up1", N: 0, Data: content},
+		})
+		idx, err := BuildGridFSIndex(chunksPath)
+		require.NoError(t, err)
 
-		err := ExtractAttachments(uploads, chunks, outDir, "", logger)
+		err = ExtractAttachments(uploads, idx, outDir, "", logger)
 		require.NoError(t, err)
 
 		expectedPath := filepath.Join(outDir, "up1_photo.jpg")
@@ -216,7 +223,13 @@ func TestExtractAttachments(t *testing.T) {
 			"up1": {ID: "up1", Name: "missing.jpg", Store: "GridFS:Uploads", Complete: true},
 		}
 
-		err := ExtractAttachments(uploads, map[string][]GridFSChunk{}, outDir, "", logger)
+		// Index built from an empty chunks file — up1 has no chunks.
+		emptyChunks := filepath.Join(dir, "empty.chunks.bson")
+		require.NoError(t, os.WriteFile(emptyChunks, []byte{}, 0600))
+		idx, err := BuildGridFSIndex(emptyChunks)
+		require.NoError(t, err)
+
+		err = ExtractAttachments(uploads, idx, outDir, "", logger)
 		require.NoError(t, err) // should not error, just warn
 	})
 
@@ -235,11 +248,13 @@ func TestExtractAttachments(t *testing.T) {
 		uploads := map[string]*RocketChatUpload{
 			"up1": {ID: "up1", Name: filename, Store: "GridFS:Uploads", Complete: true},
 		}
-		chunks := map[string][]GridFSChunk{
-			"up1": {{N: 0, Data: content}},
-		}
+		chunksPath := buildBSONChunksFile(t, dir, []GridFSChunk{
+			{FilesID: "up1", N: 0, Data: content},
+		})
+		idx, err := BuildGridFSIndex(chunksPath)
+		require.NoError(t, err)
 
-		err := ExtractAttachments(uploads, chunks, outDir, "", logger)
+		err = ExtractAttachments(uploads, idx, outDir, "", logger)
 		require.NoError(t, err)
 
 		// NFC normalization composes "e" + combining accent → "é", then

--- a/services/rocketchat/intermediate.go
+++ b/services/rocketchat/intermediate.go
@@ -1,0 +1,122 @@
+package rocketchat
+
+import "time"
+
+// RocketChatUser maps to the MongoDB `users` collection.
+type RocketChatUser struct {
+	ID        string    `bson:"_id"`
+	Username  string    `bson:"username"`
+	Name      string    `bson:"name"`
+	Emails    []RCEmail `bson:"emails"`
+	Active    bool      `bson:"active"`
+	Roles     []string  `bson:"roles"`
+	Type      string    `bson:"type"` // "user", "bot"
+	CreatedAt time.Time `bson:"createdAt"`
+}
+
+// RCEmail is an email address entry on a RocketChatUser.
+type RCEmail struct {
+	Address  string `bson:"address"`
+	Verified bool   `bson:"verified"`
+}
+
+// RocketChatRoom maps to the MongoDB `rocketchat_room` collection.
+type RocketChatRoom struct {
+	ID          string    `bson:"_id"`
+	Type        string    `bson:"t"` // c, p, d
+	Name        string    `bson:"name"`
+	FName       string    `bson:"fname"`       // Display name (absent on DM rooms)
+	Description *string   `bson:"description"` // Can be null — use pointer
+	Topic       string    `bson:"topic"`
+	UIDs        []string  `bson:"uids"`      // User IDs for DM rooms
+	Usernames   []string  `bson:"usernames"` // Usernames for DM rooms (parallel to UIDs)
+	Archived    bool      `bson:"archived"`
+	Encrypted   bool      `bson:"encrypted"` // If true, skip — E2E encrypted room
+	ParentRID   string    `bson:"prid"`      // If present, this is a discussion room
+	TeamID      string    `bson:"teamId"`    // RC team association
+	TeamMain    bool      `bson:"teamMain"`  // Whether this is the main channel of an RC team
+	ReadOnly    bool      `bson:"ro"`
+	CreatedAt   time.Time `bson:"ts"`
+}
+
+// RocketChatMessage maps to the MongoDB `rocketchat_message` collection.
+type RocketChatMessage struct {
+	ID            string                    `bson:"_id"`
+	RoomID        string                    `bson:"rid"`
+	User          RCMessageUser             `bson:"u"`
+	Message       string                    `bson:"msg"`
+	Type          string                    `bson:"t"` // System message type (empty for regular messages)
+	Timestamp     time.Time                 `bson:"ts"`
+	EditedAt      *time.Time                `bson:"editedAt"`
+	ThreadID      string                    `bson:"tmid"`   // Thread parent message ID
+	ThreadCount   int                       `bson:"tcount"` // Number of replies (only on root)
+	ThreadLastMsg *time.Time                `bson:"tlm"`    // Thread last message timestamp (only on root)
+	Reactions     map[string]RCReactionInfo `bson:"reactions"`
+	Mentions      []RCMention               `bson:"mentions"`
+	Channels      []RCChannelRef            `bson:"channels"`
+	Files         []RCFileRef               `bson:"files"`
+	Replies       []string                  `bson:"replies"` // User IDs who replied (only on root)
+	Pinned        bool                      `bson:"pinned"`
+	Groupable     bool                      `bson:"groupable"`
+}
+
+// RCMessageUser is the nested user object on a message.
+type RCMessageUser struct {
+	ID       string `bson:"_id"`
+	Username string `bson:"username"`
+	Name     string `bson:"name"`
+}
+
+// RCReactionInfo holds the list of usernames who reacted with a given emoji.
+type RCReactionInfo struct {
+	Usernames []string `bson:"usernames"`
+}
+
+// RCMention is a @mention reference within a message.
+type RCMention struct {
+	ID       string `bson:"_id"`
+	Username string `bson:"username"`
+	Name     string `bson:"name"`
+	Type     string `bson:"type"` // "user"
+}
+
+// RCChannelRef is a #channel reference within a message.
+type RCChannelRef struct {
+	ID    string `bson:"_id"`
+	FName string `bson:"fname"`
+	Name  string `bson:"name"`
+}
+
+// RCFileRef is a file attachment reference on a message.
+type RCFileRef struct {
+	ID   string `bson:"_id"`
+	Name string `bson:"name"`
+	Type string `bson:"type"` // MIME type
+	Size int64  `bson:"size"`
+}
+
+// RocketChatSubscription maps to the MongoDB `rocketchat_subscription` collection.
+type RocketChatSubscription struct {
+	RoomID   string        `bson:"rid"`
+	User     RCMessageUser `bson:"u"` // Nested object {_id, username, name}
+	Roles    []string      `bson:"roles"`
+	Favorite bool          `bson:"f"`
+	LastSeen time.Time     `bson:"ls"`
+	RoomType string        `bson:"t"`    // Room type: c, p, d
+	Name     string        `bson:"name"` // Room name
+}
+
+// RocketChatUpload maps to the MongoDB `rocketchat_uploads` collection.
+type RocketChatUpload struct {
+	ID          string    `bson:"_id"`
+	Name        string    `bson:"name"`
+	Type        string    `bson:"type"` // MIME type e.g. "image/jpeg"
+	Size        int64     `bson:"size"`
+	RoomID      string    `bson:"rid"`
+	UserID      string    `bson:"userId"`
+	Store       string    `bson:"store"` // "GridFS:Uploads", "FileSystem", etc. Match prefix "GridFS:"
+	Path        string    `bson:"path"`  // URL path like "/file-upload/{id}/{name}"
+	Description string    `bson:"description"`
+	Complete    bool      `bson:"complete"` // Only process if true
+	UploadedAt  time.Time `bson:"uploadedAt"`
+}

--- a/services/rocketchat/intermediate.go
+++ b/services/rocketchat/intermediate.go
@@ -93,7 +93,7 @@ type RCFileRef struct {
 	Name string `bson:"name"`
 	Type string `bson:"type"` // MIME type
 	Size int64  `bson:"size"`
-	// TypeGroup categorises the file, e.g. "image", "thumb", "video". Rocket.Chat
+	// TypeGroup categorises the file, e.g. "image", "thumb", "video". RocketChat
 	// stores a generated thumbnail as a separate file ref (and upload) alongside
 	// the original image; we skip "thumb" entries to avoid duplicate attachments.
 	TypeGroup string `bson:"typeGroup"`
@@ -124,7 +124,7 @@ type RocketChatUpload struct {
 	Complete    bool      `bson:"complete"` // Only process if true
 	UploadedAt  time.Time `bson:"uploadedAt"`
 	// TypeGroup categorises the upload, e.g. "image", "thumb", "video".
-	// Rocket.Chat stores a generated thumbnail as its own upload document; we
+	// RocketChat stores a generated thumbnail as its own upload document; we
 	// skip "thumb" uploads so they are neither extracted nor attached.
 	TypeGroup string `bson:"typeGroup"`
 }

--- a/services/rocketchat/intermediate.go
+++ b/services/rocketchat/intermediate.go
@@ -93,6 +93,10 @@ type RCFileRef struct {
 	Name string `bson:"name"`
 	Type string `bson:"type"` // MIME type
 	Size int64  `bson:"size"`
+	// TypeGroup categorises the file, e.g. "image", "thumb", "video". Rocket.Chat
+	// stores a generated thumbnail as a separate file ref (and upload) alongside
+	// the original image; we skip "thumb" entries to avoid duplicate attachments.
+	TypeGroup string `bson:"typeGroup"`
 }
 
 // RocketChatSubscription maps to the MongoDB `rocketchat_subscription` collection.
@@ -119,4 +123,8 @@ type RocketChatUpload struct {
 	Description string    `bson:"description"`
 	Complete    bool      `bson:"complete"` // Only process if true
 	UploadedAt  time.Time `bson:"uploadedAt"`
+	// TypeGroup categorises the upload, e.g. "image", "thumb", "video".
+	// Rocket.Chat stores a generated thumbnail as its own upload document; we
+	// skip "thumb" uploads so they are neither extracted nor attached.
+	TypeGroup string `bson:"typeGroup"`
 }

--- a/services/rocketchat/parse.go
+++ b/services/rocketchat/parse.go
@@ -1,0 +1,158 @@
+package rocketchat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ParsedData holds all data read from a Rocket.Chat mongodump directory.
+type ParsedData struct {
+	Users         []RocketChatUser
+	Rooms         []RocketChatRoom
+	Messages      []RocketChatMessage
+	Subscriptions []RocketChatSubscription
+	UploadsByID   map[string]*RocketChatUpload
+}
+
+// maxBSONDocSize is the maximum allowed BSON document size (16 MiB), matching
+// MongoDB's enforced limit. Any document claiming to be larger is treated as
+// corrupt to prevent unbounded memory allocation.
+const maxBSONDocSize = 16 * 1024 * 1024
+
+// readBSONFile reads a concatenated BSON file (as produced by mongodump) and
+// deserializes each document into type T.
+func readBSONFile[T any](filePath string) ([]T, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening BSON file %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	// A mongodump .bson file is a raw stream of back-to-back BSON documents
+	// with no delimiter between them. Each document encodes its own total byte
+	// length in the first 4 bytes, so we use that to frame each read.
+	var results []T
+	for {
+		// Every BSON document begins with a 4-byte little-endian int32 that
+		// gives the total length of the document in bytes, length field included.
+		// io.ReadFull is used instead of Read to guarantee all 4 bytes are
+		// returned even if the underlying Read returns a short count.
+		var sizeBuf [4]byte
+		_, err := io.ReadFull(f, sizeBuf[:])
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading BSON document size from %s: %w", filePath, err)
+		}
+
+		// Decode the 4 bytes as a little-endian int32 (LSB first, as the BSON
+		// spec requires). The result is the total document size in bytes.
+		docSize := int32(sizeBuf[0]) | int32(sizeBuf[1])<<8 | int32(sizeBuf[2])<<16 | int32(sizeBuf[3])<<24
+		if docSize < 5 {
+			// A valid BSON document is at minimum 5 bytes: 4-byte length + 1-byte
+			// null terminator. Anything smaller indicates a corrupt file.
+			return nil, fmt.Errorf("invalid BSON document size %d in %s", docSize, filePath)
+		}
+		if docSize > maxBSONDocSize {
+			// Guard against corrupt or malicious files that declare an enormous
+			// document size, which would cause a huge allocation.
+			return nil, fmt.Errorf("BSON document size %d exceeds maximum allowed %d in %s", docSize, maxBSONDocSize, filePath)
+		}
+
+		// Allocate a buffer for the complete document and copy the 4 size bytes
+		// we already consumed back into the front of it. bson.Unmarshal expects
+		// the full raw document including the leading length prefix, so we must
+		// reconstruct it before passing the buffer to the decoder.
+		remaining := int(docSize) - 4
+		doc := make([]byte, int(docSize))
+		copy(doc[:4], sizeBuf[:])
+
+		_, err = io.ReadFull(f, doc[4:4+remaining])
+		if err != nil {
+			return nil, fmt.Errorf("reading BSON document body from %s: %w", filePath, err)
+		}
+
+		var item T
+		if err := bson.Unmarshal(doc, &item); err != nil {
+			return nil, fmt.Errorf("unmarshalling BSON document from %s: %w", filePath, err)
+		}
+		results = append(results, item)
+	}
+
+	return results, nil
+}
+
+// ParseDump reads all required BSON files from dumpDir and returns a ParsedData
+// struct with lookup maps ready for transformation.
+func ParseDump(dumpDir string, logger log.FieldLogger) (*ParsedData, error) {
+	required := []string{
+		"users.bson",
+		"rocketchat_room.bson",
+		"rocketchat_message.bson",
+		"rocketchat_subscription.bson",
+	}
+	for _, name := range required {
+		p := filepath.Join(dumpDir, name)
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			return nil, fmt.Errorf("required BSON file not found: %s", p)
+		}
+	}
+
+	// --- users ---
+	users, err := readBSONFile[RocketChatUser](filepath.Join(dumpDir, "users.bson"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing users: %w", err)
+	}
+
+	// --- rooms ---
+	rooms, err := readBSONFile[RocketChatRoom](filepath.Join(dumpDir, "rocketchat_room.bson"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing rooms: %w", err)
+	}
+
+	// --- messages ---
+	messages, err := readBSONFile[RocketChatMessage](filepath.Join(dumpDir, "rocketchat_message.bson"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing messages: %w", err)
+	}
+
+	// --- subscriptions ---
+	subscriptions, err := readBSONFile[RocketChatSubscription](filepath.Join(dumpDir, "rocketchat_subscription.bson"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing subscriptions: %w", err)
+	}
+
+	// --- uploads (optional) ---
+	var uploads []RocketChatUpload
+	uploadsBSON := filepath.Join(dumpDir, "rocketchat_uploads.bson")
+	if _, err := os.Stat(uploadsBSON); err == nil {
+		uploads, err = readBSONFile[RocketChatUpload](uploadsBSON)
+		if err != nil {
+			return nil, fmt.Errorf("parsing uploads: %w", err)
+		}
+	}
+
+	// Build upload lookup map.
+	uploadsByID := make(map[string]*RocketChatUpload, len(uploads))
+	for i := range uploads {
+		uploadsByID[uploads[i].ID] = &uploads[i]
+	}
+
+	logger.Infof("Parsed %d users, %d rooms, %d messages, %d subscriptions, %d uploads",
+		len(users), len(rooms), len(messages), len(subscriptions), len(uploads))
+
+	return &ParsedData{
+		Users:         users,
+		Rooms:         rooms,
+		Messages:      messages,
+		Subscriptions: subscriptions,
+		UploadsByID:   uploadsByID,
+	}, nil
+}

--- a/services/rocketchat/parse.go
+++ b/services/rocketchat/parse.go
@@ -1,6 +1,7 @@
 package rocketchat
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -25,6 +26,72 @@ type ParsedData struct {
 // corrupt to prevent unbounded memory allocation.
 const maxBSONDocSize = 16 * 1024 * 1024
 
+// bsonReadBufSize is the size of the buffer used to read BSON files. A mongodump
+// stream is millions of small back-to-back documents, so reading directly from
+// the *os.File would issue two syscalls per document (size prefix + body).
+// Wrapping it in a bufio.Reader this size amortises those into a handful of
+// large reads.
+const bsonReadBufSize = 1 << 20 // 1 MiB
+
+// bsonDocReader frames a mongodump .bson stream — a raw sequence of back-to-back
+// BSON documents with no delimiter between them — into individual documents. It
+// buffers the underlying reader and tracks the byte offset of each document so
+// callers that need random access later (e.g. the GridFS index) can record where
+// a document begins.
+type bsonDocReader struct {
+	r      *bufio.Reader
+	offset int64 // byte offset of the next document to be read
+}
+
+func newBSONDocReader(r io.Reader) *bsonDocReader {
+	return &bsonDocReader{r: bufio.NewReaderSize(r, bsonReadBufSize)}
+}
+
+// next returns the next raw BSON document (including its leading length prefix,
+// as bson.Unmarshal expects) and the byte offset at which it began in the
+// stream. It returns io.EOF once the stream is cleanly exhausted.
+func (br *bsonDocReader) next() (doc []byte, offset int64, err error) {
+	startOffset := br.offset
+
+	// Every BSON document begins with a 4-byte little-endian int32 that gives
+	// the total length of the document in bytes, length field included.
+	// io.ReadFull is used instead of Read to guarantee all 4 bytes are returned
+	// even if the underlying Read returns a short count. A clean io.EOF here
+	// (zero bytes read) marks the end of the stream; a partial read surfaces as
+	// io.ErrUnexpectedEOF and is treated as corruption by the caller.
+	var sizeBuf [4]byte
+	if _, err := io.ReadFull(br.r, sizeBuf[:]); err != nil {
+		return nil, 0, err
+	}
+
+	// Decode the 4 bytes as a little-endian int32 (LSB first, as the BSON spec
+	// requires). The result is the total document size in bytes.
+	docSize := int32(sizeBuf[0]) | int32(sizeBuf[1])<<8 | int32(sizeBuf[2])<<16 | int32(sizeBuf[3])<<24
+	if docSize < 5 {
+		// A valid BSON document is at minimum 5 bytes: 4-byte length + 1-byte
+		// null terminator. Anything smaller indicates a corrupt file.
+		return nil, 0, fmt.Errorf("invalid BSON document size %d", docSize)
+	}
+	if docSize > maxBSONDocSize {
+		// Guard against corrupt or malicious files that declare an enormous
+		// document size, which would cause a huge allocation.
+		return nil, 0, fmt.Errorf("BSON document size %d exceeds maximum allowed %d", docSize, maxBSONDocSize)
+	}
+
+	// Allocate a buffer for the complete document and copy the 4 size bytes we
+	// already consumed back into the front of it. bson.Unmarshal expects the
+	// full raw document including the leading length prefix, so we must
+	// reconstruct it before passing the buffer to the decoder.
+	buf := make([]byte, int(docSize))
+	copy(buf[:4], sizeBuf[:])
+	if _, err := io.ReadFull(br.r, buf[4:]); err != nil {
+		return nil, 0, fmt.Errorf("reading BSON document body: %w", err)
+	}
+
+	br.offset += int64(docSize)
+	return buf, startOffset, nil
+}
+
 // readBSONFile reads a concatenated BSON file (as produced by mongodump) and
 // deserializes each document into type T.
 func readBSONFile[T any](filePath string) ([]T, error) {
@@ -34,49 +101,15 @@ func readBSONFile[T any](filePath string) ([]T, error) {
 	}
 	defer f.Close()
 
-	// A mongodump .bson file is a raw stream of back-to-back BSON documents
-	// with no delimiter between them. Each document encodes its own total byte
-	// length in the first 4 bytes, so we use that to frame each read.
+	br := newBSONDocReader(f)
 	var results []T
 	for {
-		// Every BSON document begins with a 4-byte little-endian int32 that
-		// gives the total length of the document in bytes, length field included.
-		// io.ReadFull is used instead of Read to guarantee all 4 bytes are
-		// returned even if the underlying Read returns a short count.
-		var sizeBuf [4]byte
-		_, err := io.ReadFull(f, sizeBuf[:])
+		doc, _, err := br.next()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("reading BSON document size from %s: %w", filePath, err)
-		}
-
-		// Decode the 4 bytes as a little-endian int32 (LSB first, as the BSON
-		// spec requires). The result is the total document size in bytes.
-		docSize := int32(sizeBuf[0]) | int32(sizeBuf[1])<<8 | int32(sizeBuf[2])<<16 | int32(sizeBuf[3])<<24
-		if docSize < 5 {
-			// A valid BSON document is at minimum 5 bytes: 4-byte length + 1-byte
-			// null terminator. Anything smaller indicates a corrupt file.
-			return nil, fmt.Errorf("invalid BSON document size %d in %s", docSize, filePath)
-		}
-		if docSize > maxBSONDocSize {
-			// Guard against corrupt or malicious files that declare an enormous
-			// document size, which would cause a huge allocation.
-			return nil, fmt.Errorf("BSON document size %d exceeds maximum allowed %d in %s", docSize, maxBSONDocSize, filePath)
-		}
-
-		// Allocate a buffer for the complete document and copy the 4 size bytes
-		// we already consumed back into the front of it. bson.Unmarshal expects
-		// the full raw document including the leading length prefix, so we must
-		// reconstruct it before passing the buffer to the decoder.
-		remaining := int(docSize) - 4
-		doc := make([]byte, int(docSize))
-		copy(doc[:4], sizeBuf[:])
-
-		_, err = io.ReadFull(f, doc[4:4+remaining])
-		if err != nil {
-			return nil, fmt.Errorf("reading BSON document body from %s: %w", filePath, err)
+			return nil, fmt.Errorf("reading BSON document from %s: %w", filePath, err)
 		}
 
 		var item T

--- a/services/rocketchat/parse.go
+++ b/services/rocketchat/parse.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// ParsedData holds all data read from a Rocket.Chat mongodump directory.
+// ParsedData holds all data read from a RocketChat mongodump directory.
 type ParsedData struct {
 	Users         []RocketChatUser
 	Rooms         []RocketChatRoom

--- a/services/rocketchat/parse_test.go
+++ b/services/rocketchat/parse_test.go
@@ -1,0 +1,168 @@
+package rocketchat
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalBSONFile serialises a slice of documents into a concatenated BSON file
+// (the format produced by mongodump) and writes it to filePath.
+func marshalBSONFile(t *testing.T, filePath string, docs []any) {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, doc := range docs {
+		b, err := bson.Marshal(doc)
+		require.NoError(t, err)
+		_, err = buf.Write(b)
+		require.NoError(t, err)
+	}
+	err := os.WriteFile(filePath, buf.Bytes(), 0600)
+	require.NoError(t, err)
+}
+
+func TestReadBSONFile(t *testing.T) {
+	t.Run("deserialises single document", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "test.bson")
+
+		expected := RocketChatUser{
+			ID:       "user1",
+			Username: "alice",
+			Name:     "Alice Wonderland",
+			Active:   true,
+			Roles:    []string{"user"},
+			Type:     "user",
+		}
+
+		marshalBSONFile(t, filePath, []any{expected})
+
+		results, err := readBSONFile[RocketChatUser](filePath)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "user1", results[0].ID)
+		assert.Equal(t, "alice", results[0].Username)
+		assert.Equal(t, "Alice Wonderland", results[0].Name)
+		assert.True(t, results[0].Active)
+	})
+
+	t.Run("deserialises multiple documents", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "users.bson")
+
+		docs := []any{
+			RocketChatUser{ID: "u1", Username: "alice"},
+			RocketChatUser{ID: "u2", Username: "bob"},
+			RocketChatUser{ID: "u3", Username: "carol"},
+		}
+		marshalBSONFile(t, filePath, docs)
+
+		results, err := readBSONFile[RocketChatUser](filePath)
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+		assert.Equal(t, "u1", results[0].ID)
+		assert.Equal(t, "u2", results[1].ID)
+		assert.Equal(t, "u3", results[2].ID)
+	})
+
+	t.Run("returns empty slice for empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "empty.bson")
+		require.NoError(t, os.WriteFile(filePath, []byte{}, 0600))
+
+		results, err := readBSONFile[RocketChatUser](filePath)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		_, err := readBSONFile[RocketChatUser]("/does/not/exist.bson")
+		require.Error(t, err)
+	})
+}
+
+func TestParseDump(t *testing.T) {
+	t.Run("parses all required collections", func(t *testing.T) {
+		dir := t.TempDir()
+		logger := log.New()
+		logger.SetOutput(os.Stderr)
+
+		desc := "test room"
+		// Write users.bson
+		marshalBSONFile(t, filepath.Join(dir, "users.bson"), []any{
+			RocketChatUser{ID: "u1", Username: "alice", Active: true},
+			RocketChatUser{ID: "u2", Username: "bob", Active: false},
+		})
+
+		// Write rocketchat_room.bson
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_room.bson"), []any{
+			RocketChatRoom{ID: "r1", Type: "c", Name: "general", Description: &desc},
+		})
+
+		// Write rocketchat_message.bson
+		ts := time.Now()
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_message.bson"), []any{
+			RocketChatMessage{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hello", Timestamp: ts},
+			RocketChatMessage{ID: "m2", RoomID: "r1", User: RCMessageUser{ID: "u2", Username: "bob"}, Message: "world", Timestamp: ts},
+		})
+
+		// Write rocketchat_subscription.bson
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_subscription.bson"), []any{
+			RocketChatSubscription{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+		})
+
+		parsed, err := ParseDump(dir, logger)
+		require.NoError(t, err)
+
+		assert.Len(t, parsed.Users, 2)
+		assert.Len(t, parsed.Rooms, 1)
+		assert.Len(t, parsed.Messages, 2)
+		assert.Len(t, parsed.Subscriptions, 1)
+		assert.Empty(t, parsed.UploadsByID)
+
+		assert.Equal(t, "alice", parsed.Users[0].Username)
+		assert.Equal(t, "general", parsed.Rooms[0].Name)
+	})
+
+	t.Run("parses optional uploads collection when present", func(t *testing.T) {
+		dir := t.TempDir()
+		logger := log.New()
+		logger.SetOutput(os.Stderr)
+
+		marshalBSONFile(t, filepath.Join(dir, "users.bson"), []any{
+			RocketChatUser{ID: "u1", Username: "alice"},
+		})
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_room.bson"), []any{
+			RocketChatRoom{ID: "r1", Type: "c", Name: "general"},
+		})
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_message.bson"), []any{})
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_subscription.bson"), []any{})
+		marshalBSONFile(t, filepath.Join(dir, "rocketchat_uploads.bson"), []any{
+			RocketChatUpload{ID: "up1", Name: "photo.png", Type: "image/png", Complete: true},
+		})
+
+		parsed, err := ParseDump(dir, logger)
+		require.NoError(t, err)
+		assert.Len(t, parsed.UploadsByID, 1)
+		assert.Equal(t, "photo.png", parsed.UploadsByID["up1"].Name)
+	})
+
+	t.Run("returns error when required file missing", func(t *testing.T) {
+		dir := t.TempDir()
+		logger := log.New()
+		// Only write users.bson, omit the rest
+		marshalBSONFile(t, filepath.Join(dir, "users.bson"), []any{})
+
+		_, err := ParseDump(dir, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rocketchat_room.bson")
+	})
+}

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -3,7 +3,6 @@ package rocketchat
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 
@@ -495,6 +494,9 @@ func (t *Transformer) transformSubscriptions(subscriptions []RocketChatSubscript
 		channelByRoomID[ch.Id] = ch
 	}
 
+	channelMemberSets := make(map[string]map[string]struct{}, len(channelByRoomID))
+	userMembershipSets := make(map[string]map[string]struct{}, len(t.Intermediate.UsersById))
+
 	for i := range subscriptions {
 		sub := &subscriptions[i]
 
@@ -523,13 +525,30 @@ func (t *Transformer) transformSubscriptions(subscriptions []RocketChatSubscript
 		}
 
 		// Add to channel Members (by user ID) if not already present.
-		if !slices.Contains(ch.Members, sub.User.ID) {
+		memberSet, ok := channelMemberSets[sub.RoomID]
+		if !ok {
+			memberSet = make(map[string]struct{}, len(ch.Members))
+			for _, id := range ch.Members {
+				memberSet[id] = struct{}{}
+			}
+			channelMemberSets[sub.RoomID] = memberSet
+		}
+		if _, exists := memberSet[sub.User.ID]; !exists {
+			memberSet[sub.User.ID] = struct{}{}
 			ch.Members = append(ch.Members, sub.User.ID)
 		}
 
-		if !slices.ContainsFunc(user.Memberships, func(m intermediate.IntermediateMembership) bool {
-			return m.Name == ch.Name
-		}) {
+		// Add channel to the user's memberships if not already present.
+		membershipSet, ok := userMembershipSets[sub.User.ID]
+		if !ok {
+			membershipSet = make(map[string]struct{}, len(user.Memberships))
+			for _, m := range user.Memberships {
+				membershipSet[m.Name] = struct{}{}
+			}
+			userMembershipSets[sub.User.ID] = membershipSet
+		}
+		if _, exists := membershipSet[ch.Name]; !exists {
+			membershipSet[ch.Name] = struct{}{}
 			user.Memberships = append(user.Memberships, intermediate.IntermediateMembership{Name: ch.Name})
 		}
 	}

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mmetl/services/intermediate"
 )
 
-// Transformer holds all state for a Rocket.Chat → Mattermost transformation.
+// Transformer holds all state for a RocketChat → Mattermost transformation.
 type Transformer struct {
 	intermediate.Exporter // provides TeamName, Intermediate, Logger, and all export methods
 

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -600,6 +600,15 @@ func (t *Transformer) transformMessages(messages []RocketChatMessage, uploadsByI
 
 		post := t.convertMessage(m, uploadsById)
 		if post == nil {
+			// The root was dropped (e.g. authored by a skipped user). Its
+			// thread replies are skipped in the main loop (they carry a
+			// ThreadID) and never reach convertMessage, so account for them
+			// here — otherwise this content is lost silently and undercounted
+			// in the end-of-transform summary.
+			if replies := threadReplies[m.ID]; len(replies) > 0 {
+				t.droppedPostRefs += len(replies)
+				t.Logger.Warnf("Dropping %d thread reply(ies) because their root post %s was skipped", len(replies), m.ID)
+			}
 			continue
 		}
 

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -521,7 +521,13 @@ func (t *Transformer) buildBasePost(m *RocketChatMessage) *intermediate.Intermed
 	// even when the message carries a username that is not in the user collection.
 	username := strings.ToLower(m.User.Username)
 	if m.User.ID != "" {
-		if _, ok := t.Intermediate.UsersById[m.User.ID]; !ok {
+		if user, ok := t.Intermediate.UsersById[m.User.ID]; ok {
+			// Prefer the canonical username from the users collection over the
+			// per-message username, which can be stale if the user was renamed
+			// in RocketChat. This keeps the post's author matching the exported
+			// user line.
+			username = user.Username
+		} else {
 			placeholder := t.createPlaceholderUser(m.User.ID)
 			if username != "" {
 				// Use the username from the message so the post's user field

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -339,6 +339,17 @@ func (t *Transformer) rebuildDMsWithoutSkippedMembers() {
 				continue
 			}
 
+			// dropSkippedMembers filters uid and username arrays independently
+			// when they are not parallel, so a malformed member list can leave
+			// unequal counts here. We can't reliably pair members in that case
+			// (and duplicating a self-DM below would panic), so drop the room.
+			if len(uids) != len(usernames) {
+				t.Logger.Warnf("Dropping direct/group channel %s: mismatched member counts after filtering (%d uids, %d usernames)", ch.Id, len(uids), len(usernames))
+				t.skippedRoomIDs[ch.Id] = true
+				delete(t.directRoomIDToChannel, ch.Id)
+				continue
+			}
+
 			// RC self-DMs are modelled as a direct channel where the same user
 			// appears twice.
 			if len(uids) == 1 {
@@ -433,6 +444,17 @@ func (t *Transformer) transformChannels(rooms []RocketChatRoom) {
 			// If every member was skipped, there is nothing to migrate.
 			if len(uids) == 0 {
 				t.Logger.Warnf("Skipping direct room %s: all members were skipped users", room.ID)
+				t.skippedRoomIDs[room.ID] = true
+				continue
+			}
+
+			// A member list with unequal uid/username counts is malformed (RC
+			// stores them as parallel arrays, and dropSkippedMembers filters them
+			// independently when they are not). We can't reliably pair members,
+			// so drop the room rather than risk dangling references or an
+			// out-of-range panic in the self-DM duplication below.
+			if len(uids) != len(usernames) {
+				t.Logger.Warnf("Skipping direct room %s: mismatched member counts after filtering (%d uids, %d usernames)", room.ID, len(uids), len(usernames))
 				t.skippedRoomIDs[room.ID] = true
 				continue
 			}

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -18,8 +18,8 @@ import (
 type Transformer struct {
 	intermediate.Exporter // provides TeamName, Intermediate, Logger, and all export methods
 
-	// skippedRoomIDs records room IDs that were skipped (encrypted/discussion) so
-	// that messages in those rooms are also skipped.
+	// skippedRoomIDs records room IDs that were skipped (e.g. encrypted or
+	// unknown-type rooms) so that messages in those rooms are also skipped.
 	skippedRoomIDs map[string]bool
 
 	// roomIDToChannelName maps RC room _id → Mattermost channel name (or "" for direct rooms).
@@ -222,6 +222,10 @@ func (t *Transformer) transformChannels(rooms []RocketChatRoom) {
 }
 
 func (t *Transformer) roomToIntermediateChannel(room *RocketChatRoom, chType model.ChannelType) *intermediate.IntermediateChannel {
+	// Capture OriginalName before mutating room.Name below, so an empty name
+	// falls back to the bare room ID rather than the "channel-<id>" slug.
+	originalName := roomOriginalName(room)
+
 	// Handle case of group rooms which are converted to private channels due to exceeding the group DM member limit.
 	if room.Name == "" {
 		t.Logger.Warnf("Room %s has empty name, using ID as fallback", room.ID)
@@ -240,7 +244,7 @@ func (t *Transformer) roomToIntermediateChannel(room *RocketChatRoom, chType mod
 
 	ch := &intermediate.IntermediateChannel{
 		Id:           room.ID,
-		OriginalName: roomOriginalName(room),
+		OriginalName: originalName,
 		Name:         rcConvertChannelName(room.Name, room.ID),
 		DisplayName:  displayName,
 		Purpose:      description,
@@ -272,7 +276,7 @@ func roomOriginalName(room *RocketChatRoom) string {
 	return room.Name
 }
 
-// rcConvertChannelName converts a Rocket.Chat room name to a
+// rcConvertChannelName converts a RocketChat room name to a
 // Mattermost-compatible channel name slug. Spaces and unsupported characters
 // are replaced with hyphens, the result is lowercased, and the room ID is used
 // as a fallback when the slug would otherwise be empty. SanitiseWithPrefix

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -484,6 +484,9 @@ func (t *Transformer) convertMessage(m *RocketChatMessage, uploadsById map[strin
 	// File attachments.
 	if uploadsById != nil {
 		for _, fileRef := range m.Files {
+			if fileRef.TypeGroup == "thumb" {
+				continue
+			}
 			upload, ok := uploadsById[fileRef.ID]
 			if !ok || !upload.Complete {
 				continue

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -116,6 +116,9 @@ func (t *Transformer) Transform(parsed *ParsedData, skipAttachments bool, skipEm
 	t.transformUsers(parsed.Users, skipEmptyEmails, defaultEmailDomain, guestHandling)
 	t.transformChannels(parsed.Rooms)
 	t.transformSubscriptions(parsed.Subscriptions)
+	// Must run after transformSubscriptions, which is what populates
+	// user.Memberships — the signal that decides whether a guest is channel-less.
+	t.skipChannellessGuests()
 	var uploadsForTransform map[string]*RocketChatUpload
 	if !skipAttachments {
 		uploadsForTransform = parsed.UploadsByID
@@ -276,6 +279,91 @@ func (t *Transformer) markUserSkipped(id, username string) {
 	if username != "" {
 		t.skippedUsernames[strings.ToLower(username)] = true
 	}
+}
+
+// skipChannellessGuests drops guest users (in "guest" mode only) that ended up
+// with zero public/private channel memberships. Such a user cannot be
+// represented as a Mattermost guest — every no-channel guest role shape fails
+// the server's isValidGuestRoles and would abort the whole bulk import — and
+// silently promoting them to a full member would grant public-channel access a
+// guest never had. We drop them instead; operators who want channel-less guests
+// kept as regular members can pass --guest-handling=user.
+//
+// This must run after transformSubscriptions, which populates user.Memberships.
+// Because the direct/group channels were already built (in transformChannels)
+// before these users were marked skipped, their DM member lists are re-filtered
+// here so no exported line references a user with no user line.
+func (t *Transformer) skipChannellessGuests() {
+	if !t.EmitGuestRoles {
+		return
+	}
+
+	skipped := 0
+	for id, user := range t.Intermediate.UsersById {
+		if !user.IsGuest || user.IsBot || len(user.Memberships) > 0 {
+			continue
+		}
+		t.Logger.Warnf("Dropping guest user %s: no channel memberships, so they can't be imported as a guest (use --guest-handling=user to keep channel-less guests as regular members)", user.Username)
+		t.markUserSkipped(id, user.Username)
+		delete(t.Intermediate.UsersById, id)
+		skipped++
+	}
+
+	if skipped == 0 {
+		return
+	}
+	t.Logger.Infof("Skipped %d channel-less guest user(s)", skipped)
+
+	t.rebuildDMsWithoutSkippedMembers()
+}
+
+// rebuildDMsWithoutSkippedMembers re-filters the already-built direct and group
+// channels to remove members that were skipped after the channels were created
+// (i.e. channel-less guests). It mirrors the classification logic in
+// transformChannels' direct-room handling: a channel with no remaining members
+// is dropped (and its room recorded so messages are skipped), a single
+// remaining member becomes a self-DM, three or more members stay a group DM,
+// and two members are a direct channel — so a group that shrinks below three is
+// reclassified accordingly.
+func (t *Transformer) rebuildDMsWithoutSkippedMembers() {
+	var directs, groups []*intermediate.IntermediateChannel
+
+	refilter := func(channels []*intermediate.IntermediateChannel) {
+		for _, ch := range channels {
+			uids, usernames := t.dropSkippedMembers(ch.Members, ch.MembersUsernames)
+
+			if len(uids) == 0 {
+				t.Logger.Warnf("Dropping direct/group channel %s: all members were skipped", ch.Id)
+				t.skippedRoomIDs[ch.Id] = true
+				delete(t.directRoomIDToChannel, ch.Id)
+				continue
+			}
+
+			// RC self-DMs are modelled as a direct channel where the same user
+			// appears twice.
+			if len(uids) == 1 {
+				uids = []string{uids[0], uids[0]}
+				usernames = []string{usernames[0], usernames[0]}
+			}
+
+			ch.Members = uids
+			ch.MembersUsernames = usernames
+			if len(uids) >= 3 {
+				ch.Type = model.ChannelTypeGroup
+				groups = append(groups, ch)
+			} else {
+				ch.Type = model.ChannelTypeDirect
+				directs = append(directs, ch)
+			}
+			t.directRoomIDToChannel[ch.Id] = ch
+		}
+	}
+
+	refilter(t.Intermediate.GroupChannels)
+	refilter(t.Intermediate.DirectChannels)
+
+	t.Intermediate.GroupChannels = groups
+	t.Intermediate.DirectChannels = directs
 }
 
 // splitName splits a full name on the first space.

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -1,0 +1,706 @@
+package rocketchat
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/mattermost/mmetl/services/intermediate"
+)
+
+// Transformer holds all state for a Rocket.Chat → Mattermost transformation.
+type Transformer struct {
+	intermediate.Exporter // provides TeamName, Intermediate, Logger, and all export methods
+
+	// skippedRoomIDs records room IDs that were skipped (encrypted/discussion) so
+	// that messages in those rooms are also skipped.
+	skippedRoomIDs map[string]bool
+
+	// roomIDToChannelName maps RC room _id → Mattermost channel name (or "" for direct rooms).
+	roomIDToChannelName map[string]string
+
+	// roomIDToType maps RC room _id → room type string ("c", "p", "d").
+	roomIDToType map[string]string
+
+	// directRoomIDToChannel maps RC direct/group room _id → IntermediateChannel.
+	// Used to look up MembersUsernames in O(1) per message instead of a linear scan.
+	directRoomIDToChannel map[string]*intermediate.IntermediateChannel
+
+	// knownChannels maps lowercase channel name → canonical name, precomputed
+	// after transformChannels so convertChannelMentions avoids rebuilding it
+	// per message.
+	knownChannels map[string]string
+}
+
+// NewTransformer creates a new Transformer for the given team.
+func NewTransformer(teamName string, logger log.FieldLogger) *Transformer {
+	return &Transformer{
+		Exporter: intermediate.Exporter{
+			TeamName:     teamName,
+			Intermediate: &intermediate.Intermediate{},
+			Logger:       logger,
+		},
+		skippedRoomIDs:        make(map[string]bool),
+		roomIDToChannelName:   make(map[string]string),
+		roomIDToType:          make(map[string]string),
+		directRoomIDToChannel: make(map[string]*intermediate.IntermediateChannel),
+		knownChannels:         make(map[string]string),
+	}
+}
+
+// Transform runs all transformation phases against a parsed dump in order:
+// users, channels, subscriptions, then messages.
+// When skipAttachments is true, no attachment paths are written into posts.
+func (t *Transformer) Transform(parsed *ParsedData, skipAttachments bool, skipEmptyEmails bool, defaultEmailDomain string) {
+	t.transformUsers(parsed.Users, skipEmptyEmails, defaultEmailDomain)
+	t.transformChannels(parsed.Rooms)
+	t.transformSubscriptions(parsed.Subscriptions)
+	var uploadsForTransform map[string]*RocketChatUpload
+	if !skipAttachments {
+		uploadsForTransform = parsed.UploadsByID
+	}
+	t.transformMessages(parsed.Messages, uploadsForTransform)
+}
+
+// transformUsers converts RocketChatUser records into IntermediateUser records
+// and stores them in Intermediate.UsersById keyed by RC _id.
+func (t *Transformer) transformUsers(users []RocketChatUser, skipEmptyEmails bool, defaultEmailDomain string) {
+	t.Logger.Info("Transforming users")
+
+	result := make(map[string]*intermediate.IntermediateUser, len(users))
+	for _, u := range users {
+		var deleteAt int64
+		if !u.Active {
+			deleteAt = model.GetMillis()
+		}
+
+		firstName, lastName := splitName(u.Name)
+
+		email := ""
+		if len(u.Emails) > 0 {
+			email = u.Emails[0].Address
+		}
+
+		newUser := &intermediate.IntermediateUser{
+			Id:          u.ID,
+			IsBot:       u.Type == "bot",
+			Username:    strings.ToLower(u.Username),
+			FirstName:   firstName,
+			LastName:    lastName,
+			DisplayName: u.Name,
+			Email:       email,
+			DeleteAt:    deleteAt,
+		}
+
+		if !newUser.IsBot {
+			newUser.Sanitise(t.Logger, defaultEmailDomain, skipEmptyEmails)
+		}
+		result[newUser.Id] = newUser
+		t.Logger.Debugf("transformed user: %s isBot: %t", newUser.Username, newUser.IsBot)
+	}
+
+	t.Intermediate.UsersById = result
+	t.Logger.Infof("Transformed %d users", len(result))
+}
+
+// splitName splits a full name on the first space.
+func splitName(name string) (firstName, lastName string) {
+	idx := strings.Index(name, " ")
+	if idx < 0 {
+		return name, ""
+	}
+	return name[:idx], name[idx+1:]
+}
+
+// createPlaceholderUser creates a deleted placeholder user for a missing RC user.
+func (t *Transformer) createPlaceholderUser(rcUserID string) *intermediate.IntermediateUser {
+	username := strings.ToLower(rcUserID)
+	u := &intermediate.IntermediateUser{
+		Id:        rcUserID,
+		Username:  username,
+		FirstName: "Deleted",
+		LastName:  "User",
+		Email:     fmt.Sprintf("%s@local", username),
+		Password:  model.NewId(),
+		DeleteAt:  model.GetMillis(),
+	}
+	t.Intermediate.UsersById[rcUserID] = u
+	t.Logger.Warnf("Created placeholder user for missing RC user ID: %s", rcUserID)
+	return u
+}
+
+// transformChannels converts RocketChatRoom records into IntermediateChannel records.
+func (t *Transformer) transformChannels(rooms []RocketChatRoom) {
+	t.Logger.Info("Transforming channels")
+
+	for i := range rooms {
+		room := &rooms[i]
+
+		if room.Encrypted {
+			t.Logger.Warnf("Skipping encrypted room: %s", room.Name)
+			t.skippedRoomIDs[room.ID] = true
+			continue
+		}
+
+		t.roomIDToType[room.ID] = room.Type
+
+		switch room.Type {
+		case "c":
+			ch := t.roomToIntermediateChannel(room, model.ChannelTypeOpen)
+			t.Intermediate.PublicChannels = append(t.Intermediate.PublicChannels, ch)
+			t.roomIDToChannelName[room.ID] = ch.Name
+
+		case "p":
+			ch := t.roomToIntermediateChannel(room, model.ChannelTypePrivate)
+			t.Intermediate.PrivateChannels = append(t.Intermediate.PrivateChannels, ch)
+			t.roomIDToChannelName[room.ID] = ch.Name
+
+		case "d":
+			uids := room.UIDs
+			usernames := make([]string, len(room.Usernames))
+			for i, username := range room.Usernames {
+				usernames[i] = strings.ToLower(username)
+			}
+
+			// RC allows self-DMs (1 participant). Mattermost models these as a
+			// direct channel where the same user appears twice.
+			if len(uids) == 1 {
+				uids = []string{uids[0], uids[0]}
+				usernames = []string{usernames[0], usernames[0]}
+			}
+
+			if len(uids) >= 3 && len(uids) <= model.ChannelGroupMaxUsers {
+				ch := t.roomToDirectChannel(room, model.ChannelTypeGroup, uids, usernames)
+				t.Intermediate.GroupChannels = append(t.Intermediate.GroupChannels, ch)
+				// Direct channel names are resolved via member usernames at post time.
+				t.roomIDToChannelName[room.ID] = ""
+				t.directRoomIDToChannel[room.ID] = ch
+			} else if len(uids) > model.ChannelGroupMaxUsers {
+				// Mattermost group messages support at most model.ChannelGroupMaxUsers
+				// members; convert oversized group DMs to private channels.
+				t.Logger.Warnf("Room %s has %d members (>%d), converting group DM to private channel",
+					room.ID, len(uids), model.ChannelGroupMaxUsers)
+				ch := t.roomToIntermediateChannel(room, model.ChannelTypePrivate)
+				t.Intermediate.PrivateChannels = append(t.Intermediate.PrivateChannels, ch)
+				t.roomIDToChannelName[room.ID] = ch.Name
+				t.roomIDToType[room.ID] = "p"
+			} else {
+				ch := t.roomToDirectChannel(room, model.ChannelTypeDirect, uids, usernames)
+				t.Intermediate.DirectChannels = append(t.Intermediate.DirectChannels, ch)
+				// Direct channel names are resolved via member usernames at post time.
+				t.roomIDToChannelName[room.ID] = ""
+				t.directRoomIDToChannel[room.ID] = ch
+			}
+
+		default:
+			t.Logger.Warnf("Skipping room with unknown type %q: %s", room.Type, room.Name)
+			t.skippedRoomIDs[room.ID] = true
+		}
+	}
+
+	// Precompute the lowercase-name → canonical-name lookup used by
+	// convertChannelMentions so that it isn't rebuilt for every message.
+	t.knownChannels = make(map[string]string, len(t.roomIDToChannelName))
+	for _, name := range t.roomIDToChannelName {
+		if name != "" {
+			t.knownChannels[strings.ToLower(name)] = name
+		}
+	}
+
+	t.Logger.Infof("Transformed %d public, %d private, %d group, %d direct channels",
+		len(t.Intermediate.PublicChannels),
+		len(t.Intermediate.PrivateChannels),
+		len(t.Intermediate.GroupChannels),
+		len(t.Intermediate.DirectChannels),
+	)
+}
+
+func (t *Transformer) roomToIntermediateChannel(room *RocketChatRoom, chType model.ChannelType) *intermediate.IntermediateChannel {
+	// Handle case of group rooms which are converted to private channels due to exceeding the group DM member limit.
+	if room.Name == "" {
+		t.Logger.Warnf("Room %s has empty name, using ID as fallback", room.ID)
+		room.Name = "channel-" + room.ID
+	}
+
+	displayName := room.FName
+	if displayName == "" {
+		displayName = room.Name
+	}
+
+	description := ""
+	if room.Description != nil {
+		description = *room.Description
+	}
+
+	ch := &intermediate.IntermediateChannel{
+		Id:           room.ID,
+		OriginalName: roomOriginalName(room),
+		Name:         rcConvertChannelName(room.Name, room.ID),
+		DisplayName:  displayName,
+		Purpose:      description,
+		Header:       room.Topic,
+		Type:         chType,
+	}
+	ch.SanitiseWithPrefix(t.Logger, "rocketchat-channel-")
+	return ch
+}
+
+func (t *Transformer) roomToDirectChannel(room *RocketChatRoom, chType model.ChannelType, uids, usernames []string) *intermediate.IntermediateChannel {
+	ch := &intermediate.IntermediateChannel{
+		Id:               room.ID,
+		OriginalName:     roomOriginalName(room),
+		Members:          uids,
+		MembersUsernames: usernames,
+		Type:             chType,
+	}
+	return ch
+}
+
+// roomOriginalName returns the room's Name if non-empty, falling back to its
+// ID. This mirrors the Slack getOriginalName pattern and ensures OriginalName
+// is always a meaningful, non-empty identifier.
+func roomOriginalName(room *RocketChatRoom) string {
+	if room.Name == "" {
+		return room.ID
+	}
+	return room.Name
+}
+
+// rcConvertChannelName converts a Rocket.Chat room name to a
+// Mattermost-compatible channel name slug. Spaces and unsupported characters
+// are replaced with hyphens, the result is lowercased, and the room ID is used
+// as a fallback when the slug would otherwise be empty. SanitiseWithPrefix
+// further trims and validates the result.
+func rcConvertChannelName(name, id string) string {
+	var sb strings.Builder
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			sb.WriteRune(r)
+		default:
+			// Replace spaces and any other invalid character with a hyphen.
+			sb.WriteRune('-')
+		}
+	}
+	slug := strings.Trim(sb.String(), "-_")
+	if slug == "" {
+		return strings.ToLower(id)
+	}
+	return slug
+}
+
+// transformSubscriptions uses subscription records to populate channel member lists
+// for public and private channels, and user membership lists.
+func (t *Transformer) transformSubscriptions(subscriptions []RocketChatSubscription) {
+	t.Logger.Info("Transforming subscriptions")
+
+	// Build a room-id → channel index for public + private channels.
+	channelByRoomID := make(map[string]*intermediate.IntermediateChannel, len(t.Intermediate.PublicChannels)+len(t.Intermediate.PrivateChannels))
+	for _, ch := range t.Intermediate.PublicChannels {
+		channelByRoomID[ch.Id] = ch
+	}
+	for _, ch := range t.Intermediate.PrivateChannels {
+		channelByRoomID[ch.Id] = ch
+	}
+
+	for i := range subscriptions {
+		sub := &subscriptions[i]
+
+		ch, ok := channelByRoomID[sub.RoomID]
+		if !ok {
+			// Subscription to a DM/group/skipped room — not relevant here.
+			continue
+		}
+
+		user, ok := t.Intermediate.UsersById[sub.User.ID]
+		if !ok {
+			t.Logger.Warnf("Subscription references unknown user %s (room %s), skipping", sub.User.ID, sub.RoomID)
+			continue
+		}
+
+		// Bots don't need channel or team memberships.
+		if user.IsBot {
+			continue
+		}
+
+		// Add to channel Members (by user ID) if not already present.
+		if !slices.Contains(ch.Members, sub.User.ID) {
+			ch.Members = append(ch.Members, sub.User.ID)
+		}
+
+		if !slices.ContainsFunc(user.Memberships, func(m intermediate.IntermediateMembership) bool {
+			return m.Name == ch.Name
+		}) {
+			user.Memberships = append(user.Memberships, intermediate.IntermediateMembership{Name: ch.Name})
+		}
+	}
+}
+
+// systemMessageTypeMap maps RC system message types to Mattermost post types.
+// Types not listed here are skipped.
+var systemMessageTypeMap = map[string]string{
+	"uj": "system_join_channel",
+	"ul": "system_leave_channel",
+	"au": "system_add_to_channel",
+	"ru": "system_remove_from_channel",
+}
+
+// skippedSystemMessageTypes is the set of RC system message types that produce no post.
+var skippedSystemMessageTypes = map[string]bool{
+	"r":                         true,
+	"message_pinned":            true,
+	"discussion-created":        true,
+	"user-muted":                true,
+	"subscription-role-added":   true,
+	"room_changed_privacy":      true,
+	"room_changed_topic":        true,
+	"room_changed_description":  true,
+	"room_changed_announcement": true,
+	"room_changed_avatar":       true,
+	"user-unmuted":              true,
+	"subscription-role-removed": true,
+}
+
+// transformMessages converts RC messages into IntermediatePost records.
+func (t *Transformer) transformMessages(messages []RocketChatMessage, uploadsById map[string]*RocketChatUpload) {
+	t.Logger.Info("Transforming messages")
+
+	// Sort messages by timestamp for deterministic output and to ensure root
+	// posts are always processed before their replies.
+	sort.Slice(messages, func(i, j int) bool {
+		return messages[i].Timestamp.Before(messages[j].Timestamp)
+	})
+
+	// First pass: build thread map — tmid → list of reply messages.
+	threadReplies := make(map[string][]*RocketChatMessage)
+	for i := range messages {
+		m := &messages[i]
+		if m.ThreadID != "" {
+			threadReplies[m.ThreadID] = append(threadReplies[m.ThreadID], m)
+		}
+	}
+
+	// Second pass: process root messages (those without a tmid).
+	// Track timestamps globally to avoid duplicates that cause import failures.
+	// This is more conservative than per-channel (Mattermost only requires
+	// unique timestamps within a channel), but keeps the logic simple.
+	timestamps := make(map[int64]bool)
+	var posts []*intermediate.IntermediatePost
+	for i := range messages {
+		m := &messages[i]
+
+		// Skip thread replies — they will be attached to their root post.
+		if m.ThreadID != "" {
+			continue
+		}
+
+		// Skip messages in skipped rooms.
+		if t.skippedRoomIDs[m.RoomID] {
+			continue
+		}
+
+		post := t.convertMessage(m, uploadsById)
+		if post == nil {
+			continue
+		}
+
+		// Deduplicate timestamps: increment until unique.
+		for timestamps[post.CreateAt] {
+			post.CreateAt++
+		}
+		timestamps[post.CreateAt] = true
+
+		// Attach thread replies with timestamp deduplication.
+		for _, reply := range threadReplies[m.ID] {
+			replyPost := t.convertMessage(reply, uploadsById)
+			if replyPost != nil {
+				for timestamps[replyPost.CreateAt] {
+					replyPost.CreateAt++
+				}
+				timestamps[replyPost.CreateAt] = true
+				post.Replies = append(post.Replies, replyPost)
+			}
+		}
+
+		// Split oversized root messages into continuation thread replies.
+		intermediate.SplitPostIntoThread(post)
+
+		// Split any oversized replies, deduplicate timestamps, and sort replies.
+		intermediate.SplitOversizedReplies(post)
+
+		posts = append(posts, post)
+	}
+
+	t.Intermediate.Posts = posts
+	t.Logger.Infof("Transformed %d posts", len(posts))
+}
+
+// convertMessage converts a single RocketChatMessage to an IntermediatePost.
+// Returns nil if the message should be skipped.
+func (t *Transformer) convertMessage(m *RocketChatMessage, uploadsById map[string]*RocketChatUpload) *intermediate.IntermediatePost {
+	// Handle system messages.
+	if m.Type != "" {
+		if skippedSystemMessageTypes[m.Type] {
+			return nil
+		}
+		mmType, ok := systemMessageTypeMap[m.Type]
+		if !ok {
+			t.Logger.Debugf("Skipping unsupported system message type %q in room %s", m.Type, m.RoomID)
+			return nil
+		}
+
+		// System messages are modelled as regular posts with a type set.
+		post := t.buildBasePost(m)
+		if post == nil {
+			return nil
+		}
+		post.Type = mmType
+		return post
+	}
+
+	post := t.buildBasePost(m)
+	if post == nil {
+		return nil
+	}
+
+	// Convert #channel-name references to Mattermost ~channel-name format.
+	// Uses the structured channels list on the message when available, then
+	// falls back to scanning the text for any remaining #word tokens.
+	post.Message = t.convertChannelMentions(post.Message, m.Channels)
+
+	// NOTE: oversized messages are split into thread continuations by
+	// transformMessages after all replies are assembled, rather than
+	// truncated here, to avoid data loss.
+
+	// Reactions.
+	post.Reactions = t.convertReactions(m)
+
+	// File attachments.
+	if uploadsById != nil {
+		for _, fileRef := range m.Files {
+			upload, ok := uploadsById[fileRef.ID]
+			if !ok || !upload.Complete {
+				continue
+			}
+			// If the message has no text but the upload has a description
+			// (caption typed by the user when uploading), use it as the post message.
+			if post.Message == "" && upload.Description != "" {
+				post.Message = upload.Description
+			}
+			// Apply NFC normalization before sanitizing, matching the logic in
+			// ExtractAttachments, so the path embedded in the JSONL matches the
+			// filename that will be created on disk.
+			sanitizedName := sanitizeFilename(norm.NFC.String(upload.Name))
+			attachPath := fmt.Sprintf("bulk-export-attachments/%s_%s", sanitizeFilename(upload.ID), sanitizedName)
+			post.Attachments = append(post.Attachments, attachPath)
+		}
+	}
+
+	return post
+}
+
+// buildBasePost constructs a base IntermediatePost from a message, resolving
+// user and channel references. Returns nil if the post should be skipped.
+func (t *Transformer) buildBasePost(m *RocketChatMessage) *intermediate.IntermediatePost {
+	// Resolve user.
+	// Always check UsersById and create a placeholder when the user ID is absent.
+	// This ensures every post's author has a corresponding user line in the JSONL,
+	// even when the message carries a username that is not in the user collection.
+	username := strings.ToLower(m.User.Username)
+	if m.User.ID != "" {
+		if _, ok := t.Intermediate.UsersById[m.User.ID]; !ok {
+			placeholder := t.createPlaceholderUser(m.User.ID)
+			if username != "" {
+				// Use the username from the message so the post's user field
+				// matches the placeholder user line we'll export.
+				placeholder.Username = username
+				placeholder.Email = fmt.Sprintf("%s@local", username)
+			} else {
+				username = placeholder.Username
+			}
+		}
+	}
+	if username == "" {
+		if user := t.Intermediate.UsersById[m.User.ID]; user != nil {
+			username = user.Username
+		}
+	}
+
+	// Resolve channel.
+	roomType := t.roomIDToType[m.RoomID]
+	isDirect := roomType == "d"
+
+	var channelName string
+	var channelMembers []string
+
+	if isDirect {
+		// For direct posts, channel name is empty; members are resolved from the
+		// precomputed directRoomIDToChannel map (O(1) instead of linear scan).
+		channelName = ""
+		if ch, ok := t.directRoomIDToChannel[m.RoomID]; ok {
+			channelMembers = ch.MembersUsernames
+		} else {
+			// Fallback: linear scan for callers (e.g. unit tests) that populate
+			// Intermediate.DirectChannels / GroupChannels directly without going
+			// through transformChannels, which normally builds the map.
+			for _, ch := range t.Intermediate.DirectChannels {
+				if ch.Id == m.RoomID {
+					channelMembers = ch.MembersUsernames
+					break
+				}
+			}
+			if channelMembers == nil {
+				for _, ch := range t.Intermediate.GroupChannels {
+					if ch.Id == m.RoomID {
+						channelMembers = ch.MembersUsernames
+						break
+					}
+				}
+			}
+		}
+	} else {
+		name, ok := t.roomIDToChannelName[m.RoomID]
+		if !ok {
+			t.Logger.Debugf("Message %s references unknown room %s, skipping", m.ID, m.RoomID)
+			return nil
+		}
+		channelName = name
+	}
+
+	createAt := m.Timestamp.UnixMilli()
+	if createAt <= 0 {
+		createAt = model.GetMillis()
+	}
+
+	return &intermediate.IntermediatePost{
+		User:           username,
+		Channel:        channelName,
+		Message:        m.Message,
+		CreateAt:       createAt,
+		IsDirect:       isDirect,
+		ChannelMembers: channelMembers,
+	}
+}
+
+// convertReactions converts RC reaction map to IntermediateReaction slice.
+func (t *Transformer) convertReactions(m *RocketChatMessage) []*intermediate.IntermediateReaction {
+	if len(m.Reactions) == 0 {
+		return nil
+	}
+
+	var reactions []*intermediate.IntermediateReaction
+	baseTs := m.Timestamp.UnixMilli()
+	counter := int64(0)
+
+	for emojiCode, info := range m.Reactions {
+		// Strip surrounding colons: ":smile:" → "smile"
+		emojiName := strings.Trim(emojiCode, ":")
+
+		// Strip skin-tone suffixes: "thumbsup::skin-tone-3" → "thumbsup"
+		if idx := strings.Index(emojiName, "::"); idx >= 0 {
+			emojiName = emojiName[:idx]
+		}
+
+		for _, username := range info.Usernames {
+			counter++
+			reactions = append(reactions, &intermediate.IntermediateReaction{
+				User:      strings.ToLower(username),
+				EmojiName: emojiName,
+				CreateAt:  baseTs + counter,
+			})
+		}
+	}
+	return reactions
+}
+
+// channelMentionRe matches a #word token that could be a RC channel reference.
+// RC channel names are lowercase alphanumeric with hyphens and underscores.
+// We also allow uppercase and dots so we catch display names before lowercasing.
+var channelMentionRe = regexp.MustCompile(`#([A-Za-z0-9._-]+)`)
+
+// convertChannelMentions rewrites #channel-name tokens in text to the
+// Mattermost format ~channel-name, or strips the leading '#' when the name
+// does not correspond to a known channel (to avoid creating spurious hashtags).
+//
+// RC provides a structured `channels` array on each message listing the
+// channels explicitly referenced. We use that first (O(1) lookups), then apply
+// a regex pass for any remaining #word tokens in the text.
+func (t *Transformer) convertChannelMentions(text string, refs []RCChannelRef) string {
+	if !strings.Contains(text, "#") {
+		return text
+	}
+
+	// Use the precomputed knownChannels map (built once at end of transformChannels).
+	// If it is empty — which happens when unit tests set roomIDToChannelName
+	// directly without going through transformChannels — rebuild lazily from
+	// roomIDToChannelName and cache the result for subsequent calls.
+	knownChannels := t.knownChannels
+	if len(knownChannels) == 0 && len(t.roomIDToChannelName) > 0 {
+		knownChannels = make(map[string]string, len(t.roomIDToChannelName))
+		for _, name := range t.roomIDToChannelName {
+			if name != "" {
+				knownChannels[strings.ToLower(name)] = name
+			}
+		}
+		t.knownChannels = knownChannels
+	}
+
+	// Index the structured refs by lowercase name and fname for fast lookup.
+	// RC's `channels` array gives us the exact names the sender intended.
+	refByName := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if ref.Name != "" {
+			refByName[strings.ToLower(ref.Name)] = ref.Name
+		}
+		if ref.FName != "" {
+			refByName[strings.ToLower(ref.FName)] = ref.Name // fname → canonical name
+		}
+	}
+
+	return channelMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		// match is the full "#word"; extract just the word part.
+		word := match[1:] // strip leading '#'
+		lower := strings.ToLower(word)
+
+		// 1. Check if it matches a channel from the structured refs list.
+		//    Then verify that canonical name exists in our known channels.
+		if canonicalName, ok := refByName[lower]; ok {
+			mmName := strings.ToLower(canonicalName)
+			if _, known := knownChannels[mmName]; known {
+				return "~" + mmName
+			}
+		}
+
+		// 2. Check directly against known channel names.
+		if _, known := knownChannels[lower]; known {
+			return "~" + lower
+		}
+
+		// 3. Not a known channel — strip '#' to prevent MM hashtag indexing.
+		return word
+	})
+}
+
+// sanitizeFilename returns a safe filename by replacing non-alphanumeric
+// characters (other than '.', '-', '_') with underscores.
+func sanitizeFilename(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}

--- a/services/rocketchat/transformer.go
+++ b/services/rocketchat/transformer.go
@@ -36,6 +36,57 @@ type Transformer struct {
 	// after transformChannels so convertChannelMentions avoids rebuilding it
 	// per message.
 	knownChannels map[string]string
+
+	// skippedUserIDs / skippedUsernames record users that were dropped during
+	// transformUsers (unsupported RC types, or guests under --guest-handling=skip)
+	// so that every later stage can drop channel/DM memberships, posts, and
+	// reactions referencing them, leaving no dangling references in the export.
+	skippedUserIDs   map[string]bool
+	skippedUsernames map[string]bool
+
+	// droppedPostRefs / droppedMembershipRefs count references removed because
+	// they pointed at a skipped user, for the end-of-transform summary log.
+	droppedPostRefs       int
+	droppedMembershipRefs int
+}
+
+// Guest handling modes for the --guest-handling flag.
+const (
+	// GuestHandlingGuest migrates RC guests as Mattermost guest accounts.
+	GuestHandlingGuest = "guest"
+	// GuestHandlingUser migrates RC guests as regular Mattermost users.
+	GuestHandlingUser = "user"
+	// GuestHandlingSkip drops RC guests entirely.
+	GuestHandlingSkip = "skip"
+)
+
+// ValidateGuestHandling returns an error if the given guest-handling mode is not
+// one of the supported values.
+func ValidateGuestHandling(mode string) error {
+	switch mode {
+	case GuestHandlingGuest, GuestHandlingUser, GuestHandlingSkip:
+		return nil
+	default:
+		return fmt.Errorf("invalid --guest-handling value %q: must be one of %q, %q, or %q",
+			mode, GuestHandlingGuest, GuestHandlingUser, GuestHandlingSkip)
+	}
+}
+
+// rolesContainGuest reports whether the RC roles slice contains the "guest"
+// role (case-insensitive).
+func rolesContainGuest(roles []string) bool {
+	for _, r := range roles {
+		if strings.EqualFold(r, "guest") {
+			return true
+		}
+	}
+	return false
+}
+
+// isSkippedUser reports whether the given RC user ID was dropped in
+// transformUsers.
+func (t *Transformer) isSkippedUser(id string) bool {
+	return id != "" && t.skippedUserIDs[id]
 }
 
 // NewTransformer creates a new Transformer for the given team.
@@ -51,14 +102,19 @@ func NewTransformer(teamName string, logger log.FieldLogger) *Transformer {
 		roomIDToType:          make(map[string]string),
 		directRoomIDToChannel: make(map[string]*intermediate.IntermediateChannel),
 		knownChannels:         make(map[string]string),
+		skippedUserIDs:        make(map[string]bool),
+		skippedUsernames:      make(map[string]bool),
 	}
 }
 
 // Transform runs all transformation phases against a parsed dump in order:
 // users, channels, subscriptions, then messages.
 // When skipAttachments is true, no attachment paths are written into posts.
-func (t *Transformer) Transform(parsed *ParsedData, skipAttachments bool, skipEmptyEmails bool, defaultEmailDomain string) {
-	t.transformUsers(parsed.Users, skipEmptyEmails, defaultEmailDomain)
+func (t *Transformer) Transform(parsed *ParsedData, skipAttachments bool, skipEmptyEmails bool, defaultEmailDomain string, guestHandling string) {
+	// Guests are exported with Mattermost guest roles only in "guest" mode.
+	t.EmitGuestRoles = guestHandling == GuestHandlingGuest
+
+	t.transformUsers(parsed.Users, skipEmptyEmails, defaultEmailDomain, guestHandling)
 	t.transformChannels(parsed.Rooms)
 	t.transformSubscriptions(parsed.Subscriptions)
 	var uploadsForTransform map[string]*RocketChatUpload
@@ -66,15 +122,54 @@ func (t *Transformer) Transform(parsed *ParsedData, skipAttachments bool, skipEm
 		uploadsForTransform = parsed.UploadsByID
 	}
 	t.transformMessages(parsed.Messages, uploadsForTransform)
+
+	if t.droppedPostRefs > 0 || t.droppedMembershipRefs > 0 {
+		t.Logger.Infof("Dropped %d posts and %d channel/DM memberships referencing skipped users",
+			t.droppedPostRefs, t.droppedMembershipRefs)
+	}
 }
 
 // transformUsers converts RocketChatUser records into IntermediateUser records
 // and stores them in Intermediate.UsersById keyed by RC _id.
-func (t *Transformer) transformUsers(users []RocketChatUser, skipEmptyEmails bool, defaultEmailDomain string) {
+func (t *Transformer) transformUsers(users []RocketChatUser, skipEmptyEmails bool, defaultEmailDomain string, guestHandling string) {
 	t.Logger.Info("Transforming users")
 
 	result := make(map[string]*intermediate.IntermediateUser, len(users))
+	// unsupportedByType counts users dropped because their RC type is neither
+	// "user" nor "bot" (e.g. "app", "unknown", or empty), broken down by type
+	// for the summary log.
+	unsupportedByType := make(map[string]int)
+	guestCount := 0
+	guestsSkipped := 0
 	for _, u := range users {
+		// Only real people (type "user") and bots (type "bot") are migrated.
+		// Everything else — "app" (marketplace/app-owned accounts like
+		// rocket.cat), "unknown", empty, etc. — is skipped and recorded so that
+		// downstream stages drop any memberships, posts, and reactions that
+		// reference it.
+		isBot := u.Type == "bot"
+		if u.Type != "user" && !isBot {
+			typeLabel := u.Type
+			if typeLabel == "" {
+				typeLabel = "empty"
+			}
+			unsupportedByType[typeLabel]++
+			t.markUserSkipped(u.ID, u.Username)
+			continue
+		}
+
+		// A guest is a type "user" whose roles include "guest"; bots are never
+		// guests.
+		isGuest := !isBot && rolesContainGuest(u.Roles)
+		if isGuest {
+			guestCount++
+			if guestHandling == GuestHandlingSkip {
+				guestsSkipped++
+				t.markUserSkipped(u.ID, u.Username)
+				continue
+			}
+		}
+
 		var deleteAt int64
 		if !u.Active {
 			deleteAt = model.GetMillis()
@@ -89,7 +184,8 @@ func (t *Transformer) transformUsers(users []RocketChatUser, skipEmptyEmails boo
 
 		newUser := &intermediate.IntermediateUser{
 			Id:          u.ID,
-			IsBot:       u.Type == "bot",
+			IsBot:       isBot,
+			IsGuest:     isGuest,
 			Username:    strings.ToLower(u.Username),
 			FirstName:   firstName,
 			LastName:    lastName,
@@ -102,11 +198,85 @@ func (t *Transformer) transformUsers(users []RocketChatUser, skipEmptyEmails boo
 			newUser.Sanitise(t.Logger, defaultEmailDomain, skipEmptyEmails)
 		}
 		result[newUser.Id] = newUser
-		t.Logger.Debugf("transformed user: %s isBot: %t", newUser.Username, newUser.IsBot)
+		t.Logger.Debugf("transformed user: %s isBot: %t isGuest: %t", newUser.Username, newUser.IsBot, newUser.IsGuest)
 	}
 
 	t.Intermediate.UsersById = result
+
+	if len(unsupportedByType) > 0 {
+		total := 0
+		parts := make([]string, 0, len(unsupportedByType))
+		// Sort the type labels for deterministic log output.
+		labels := make([]string, 0, len(unsupportedByType))
+		for label := range unsupportedByType {
+			labels = append(labels, label)
+		}
+		sort.Strings(labels)
+		for _, label := range labels {
+			total += unsupportedByType[label]
+			parts = append(parts, fmt.Sprintf("%s=%d", label, unsupportedByType[label]))
+		}
+		t.Logger.Infof("Skipped %d users of unsupported types (%s)", total, strings.Join(parts, ", "))
+	}
+
+	switch guestHandling {
+	case GuestHandlingGuest:
+		t.Logger.Infof("Detected %d guest users; mode=guest (migrating as MM guests)", guestCount)
+	case GuestHandlingUser:
+		t.Logger.Infof("Detected %d guest users; mode=user (migrating as regular users)", guestCount)
+	case GuestHandlingSkip:
+		t.Logger.Infof("Detected %d guest users; mode=skip (skipping %d guest users)", guestCount, guestsSkipped)
+	}
+
 	t.Logger.Infof("Transformed %d users", len(result))
+}
+
+// dropSkippedMembers returns the given parallel uid/username slices with any
+// skipped users removed, counting each removal as a dropped membership. The two
+// slices are only filtered together when they are the same length (RC stores
+// them as parallel arrays); otherwise they are filtered independently by ID and
+// username respectively.
+func (t *Transformer) dropSkippedMembers(uids, usernames []string) (outUIDs, outUsernames []string) {
+	if len(uids) == len(usernames) {
+		outUIDs = make([]string, 0, len(uids))
+		outUsernames = make([]string, 0, len(usernames))
+		for i, uid := range uids {
+			if t.skippedUserIDs[uid] || t.skippedUsernames[usernames[i]] {
+				t.droppedMembershipRefs++
+				continue
+			}
+			outUIDs = append(outUIDs, uid)
+			outUsernames = append(outUsernames, usernames[i])
+		}
+		return outUIDs, outUsernames
+	}
+
+	for _, uid := range uids {
+		if t.skippedUserIDs[uid] {
+			t.droppedMembershipRefs++
+			continue
+		}
+		outUIDs = append(outUIDs, uid)
+	}
+	for _, username := range usernames {
+		if t.skippedUsernames[username] {
+			t.droppedMembershipRefs++
+			continue
+		}
+		outUsernames = append(outUsernames, username)
+	}
+	return outUIDs, outUsernames
+}
+
+// markUserSkipped records a user (by ID and username) as skipped so downstream
+// stages drop everything referencing them.
+func (t *Transformer) markUserSkipped(id, username string) {
+	if id != "" {
+		t.skippedUserIDs[id] = true
+	}
+	if username != "" {
+		t.skippedUsernames[strings.ToLower(username)] = true
+	}
 }
 
 // splitName splits a full name on the first space.
@@ -166,6 +336,18 @@ func (t *Transformer) transformChannels(rooms []RocketChatRoom) {
 			usernames := make([]string, len(room.Usernames))
 			for i, username := range room.Usernames {
 				usernames[i] = strings.ToLower(username)
+			}
+
+			// Drop skipped users (unsupported types / skipped guests) from the
+			// DM member list so we never export a direct/group channel that
+			// references a user with no corresponding user line.
+			uids, usernames = t.dropSkippedMembers(uids, usernames)
+
+			// If every member was skipped, there is nothing to migrate.
+			if len(uids) == 0 {
+				t.Logger.Warnf("Skipping direct room %s: all members were skipped users", room.ID)
+				t.skippedRoomIDs[room.ID] = true
+				continue
 			}
 
 			// RC allows self-DMs (1 participant). Mattermost models these as a
@@ -322,6 +504,13 @@ func (t *Transformer) transformSubscriptions(subscriptions []RocketChatSubscript
 			continue
 		}
 
+		// Drop memberships of users we deliberately skipped, quietly (they are
+		// expected to be absent), counting them for the summary log.
+		if t.isSkippedUser(sub.User.ID) {
+			t.droppedMembershipRefs++
+			continue
+		}
+
 		user, ok := t.Intermediate.UsersById[sub.User.ID]
 		if !ok {
 			t.Logger.Warnf("Subscription references unknown user %s (room %s), skipping", sub.User.ID, sub.RoomID)
@@ -448,6 +637,14 @@ func (t *Transformer) transformMessages(messages []RocketChatMessage, uploadsByI
 // convertMessage converts a single RocketChatMessage to an IntermediatePost.
 // Returns nil if the message should be skipped.
 func (t *Transformer) convertMessage(m *RocketChatMessage, uploadsById map[string]*RocketChatUpload) *intermediate.IntermediatePost {
+	// Drop posts authored by a skipped user (unsupported type / skipped guest)
+	// before any placeholder user is created for them, so the export never
+	// references a user with no user line.
+	if t.isSkippedUser(m.User.ID) || t.skippedUsernames[strings.ToLower(m.User.Username)] {
+		t.droppedPostRefs++
+		return nil
+	}
+
 	// Handle system messages.
 	if m.Type != "" {
 		if skippedSystemMessageTypes[m.Type] {
@@ -621,9 +818,15 @@ func (t *Transformer) convertReactions(m *RocketChatMessage) []*intermediate.Int
 		}
 
 		for _, username := range info.Usernames {
+			lower := strings.ToLower(username)
+			// Skip reactions by skipped users so they don't reference a
+			// non-existent user line.
+			if t.skippedUsernames[lower] {
+				continue
+			}
 			counter++
 			reactions = append(reactions, &intermediate.IntermediateReaction{
-				User:      strings.ToLower(username),
+				User:      lower,
 				EmojiName: emojiName,
 				CreateAt:  baseTs + counter,
 			})

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -1,0 +1,725 @@
+package rocketchat
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mmetl/services/intermediate"
+)
+
+func newLogger() log.FieldLogger {
+	l := log.New()
+	l.SetOutput(os.Stderr)
+	return l
+}
+
+// ---------------------------------------------------------------------------
+// User transformation tests
+// ---------------------------------------------------------------------------
+
+func TestTransformUsers(t *testing.T) {
+	t.Run("basic user mapping", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{
+				ID:       "u1",
+				Username: "Alice",
+				Name:     "Alice Wonderland",
+				Emails:   []RCEmail{{Address: "alice@example.com", Verified: true}},
+				Active:   true,
+				Roles:    []string{"user"},
+				Type:     "user",
+			},
+		}
+
+		tr.transformUsers(users, false, "")
+
+		require.Len(t, tr.Intermediate.UsersById, 1)
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.Equal(t, "u1", u.Id)
+		assert.Equal(t, "alice", u.Username) // lowercased
+		assert.Equal(t, "Alice", u.FirstName)
+		assert.Equal(t, "Wonderland", u.LastName)
+		assert.Equal(t, "alice@example.com", u.Email)
+		assert.Zero(t, u.DeleteAt)
+	})
+
+	t.Run("name splitting on first space", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "bob", Name: "Bob James Smith", Emails: []RCEmail{{Address: "b@b.com"}}, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "")
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.Equal(t, "Bob", u.FirstName)
+		assert.Equal(t, "James Smith", u.LastName)
+	})
+
+	t.Run("admin role mapping", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "admin", Name: "Admin User", Emails: []RCEmail{{Address: "admin@example.com"}}, Active: true, Roles: []string{"admin"}, Type: "user"},
+		}
+		tr.transformUsers(users, false, "")
+		// User should be transformed (role mapping is informational — not stored in IntermediateUser itself)
+		require.NotNil(t, tr.Intermediate.UsersById["u1"])
+	})
+
+	t.Run("inactive user sets DeleteAt", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "inactive", Name: "Inactive User", Emails: []RCEmail{{Address: "i@i.com"}}, Active: false, Type: "user"},
+		}
+		tr.transformUsers(users, false, "")
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.NotZero(t, u.DeleteAt)
+	})
+
+	t.Run("missing email with defaultEmailDomain", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "noemail", Name: "No Email", Emails: nil, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "example.org")
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.Equal(t, "noemail@example.org", u.Email)
+	})
+
+	t.Run("missing email with skipEmptyEmails", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "noemail", Name: "No Email", Emails: nil, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, true, "")
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.Equal(t, "", u.Email)
+	})
+
+	t.Run("bot user is imported as bot", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "b1", Username: "bot", Name: "My Bot", Type: "bot", Active: true},
+			{ID: "u1", Username: "human", Name: "Human User", Emails: []RCEmail{{Address: "h@h.com"}}, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "")
+		assert.Len(t, tr.Intermediate.UsersById, 2)
+
+		bot := tr.Intermediate.UsersById["b1"]
+		require.NotNil(t, bot)
+		assert.True(t, bot.IsBot)
+		assert.Equal(t, "bot", bot.Username)
+		assert.Equal(t, "My Bot", bot.DisplayName)
+		assert.Equal(t, "", bot.Email)
+		assert.Equal(t, "", bot.Password)
+		assert.Equal(t, int64(0), bot.DeleteAt)
+
+		human := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, human)
+		assert.False(t, human.IsBot)
+	})
+
+	t.Run("inactive bot user sets DeleteAt", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "b1", Username: "bot", Name: "My Bot", Type: "bot", Active: false},
+		}
+		tr.transformUsers(users, false, "")
+		bot := tr.Intermediate.UsersById["b1"]
+		require.NotNil(t, bot)
+		assert.True(t, bot.IsBot)
+		assert.Greater(t, bot.DeleteAt, int64(0))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Channel transformation tests
+// ---------------------------------------------------------------------------
+
+func TestTransformChannels(t *testing.T) {
+	desc := "a channel"
+
+	t.Run("public channel type c", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "general", FName: "General", Description: &desc},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PublicChannels, 1)
+		ch := tr.Intermediate.PublicChannels[0]
+		assert.Equal(t, "general", ch.Name)
+		assert.Equal(t, "General", ch.DisplayName)
+		assert.Equal(t, desc, ch.Purpose)
+	})
+
+	t.Run("private channel type p", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "p", Name: "secret"},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PrivateChannels, 1)
+	})
+
+	t.Run("direct channel type d with 2 users", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		// Users must be pre-populated (TransformChannels runs after TransformUsers).
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+			"u2": {Id: "u2", Username: "bob"},
+		}
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", UIDs: []string{"u1", "u2"}, Usernames: []string{"alice", "bob"}},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		assert.Equal(t, []string{"alice", "bob"}, tr.Intermediate.DirectChannels[0].MembersUsernames)
+	})
+
+	t.Run("group channel type d with 3+ users", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+			"u2": {Id: "u2", Username: "bob"},
+			"u3": {Id: "u3", Username: "carol"},
+		}
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", UIDs: []string{"u1", "u2", "u3"}, Usernames: []string{"alice", "bob", "carol"}},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.GroupChannels, 1)
+		assert.Equal(t, []string{"alice", "bob", "carol"}, tr.Intermediate.GroupChannels[0].MembersUsernames)
+	})
+
+	t.Run("direct channel with unknown member is included without a placeholder user", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+			// "bot1" / "rocket.cat" is intentionally absent.
+		}
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", UIDs: []string{"u1", "bot1"}, Usernames: []string{"alice", "rocket.cat"}},
+		}
+		tr.transformChannels(rooms)
+
+		// Room must be imported, not dropped.
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		assert.False(t, tr.skippedRoomIDs["r1"])
+
+		// transformChannels does not create placeholder users for unknown
+		// members; placeholders are created lazily during message transformation
+		// (buildBasePost). Both usernames still appear in the channel.
+		assert.Equal(t, []string{"alice", "rocket.cat"}, tr.Intermediate.DirectChannels[0].MembersUsernames)
+	})
+
+	t.Run("single-member DM is expanded to a self-DM", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", UIDs: []string{"u1"}, Usernames: []string{"alice"}},
+		}
+		tr.transformChannels(rooms)
+
+		// RC allows self-DMs (1 participant); Mattermost models these as a direct
+		// channel where the same user appears twice, so the room is kept.
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		assert.False(t, tr.skippedRoomIDs["r1"])
+		assert.Equal(t, []string{"alice", "alice"}, tr.Intermediate.DirectChannels[0].MembersUsernames)
+	})
+
+	t.Run("empty room name falls back to ID for OriginalName", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "room-id-123", Type: "c", Name: ""},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PublicChannels, 1)
+		assert.Equal(t, "room-id-123", tr.Intermediate.PublicChannels[0].OriginalName)
+	})
+
+	t.Run("room name with spaces is slugified", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "General Discussion"},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PublicChannels, 1)
+		assert.Equal(t, "general-discussion", tr.Intermediate.PublicChannels[0].Name)
+	})
+
+	t.Run("group DM at exactly ChannelGroupMaxUsers members stays as group", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		uids := make([]string, model.ChannelGroupMaxUsers)
+		usernames := make([]string, model.ChannelGroupMaxUsers)
+		users := make(map[string]*intermediate.IntermediateUser, model.ChannelGroupMaxUsers)
+		for i := 0; i < model.ChannelGroupMaxUsers; i++ {
+			uid := fmt.Sprintf("u%d", i+1)
+			username := fmt.Sprintf("user%d", i+1)
+			users[uid] = &intermediate.IntermediateUser{Id: uid, Username: username}
+			uids[i] = uid
+			usernames[i] = username
+		}
+		tr.Intermediate.UsersById = users
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", UIDs: uids, Usernames: usernames},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.GroupChannels, 1)
+		assert.Empty(t, tr.Intermediate.PrivateChannels)
+	})
+
+	t.Run("group DM exceeding ChannelGroupMaxUsers converts to private channel", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		count := model.ChannelGroupMaxUsers + 1
+		uids := make([]string, count)
+		usernames := make([]string, count)
+		users := make(map[string]*intermediate.IntermediateUser, count)
+		for i := 0; i < count; i++ {
+			uid := fmt.Sprintf("u%d", i+1)
+			username := fmt.Sprintf("user%d", i+1)
+			users[uid] = &intermediate.IntermediateUser{Id: uid, Username: username}
+			uids[i] = uid
+			usernames[i] = username
+		}
+		tr.Intermediate.UsersById = users
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "d", Name: "big-group", UIDs: uids, Usernames: usernames},
+		}
+		tr.transformChannels(rooms)
+		assert.Empty(t, tr.Intermediate.GroupChannels)
+		require.Len(t, tr.Intermediate.PrivateChannels, 1)
+	})
+
+	t.Run("encrypted room is skipped", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "encrypted-room", Encrypted: true},
+		}
+		tr.transformChannels(rooms)
+		assert.Empty(t, tr.Intermediate.PublicChannels)
+		assert.True(t, tr.skippedRoomIDs["r1"])
+	})
+
+	t.Run("discussion room (prid set) is skipped", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "p", Name: "discussion", ParentRID: "parent-room-id"},
+		}
+		tr.transformChannels(rooms)
+		assert.Empty(t, tr.Intermediate.PrivateChannels)
+		assert.True(t, tr.skippedRoomIDs["r1"])
+	})
+
+	t.Run("null description handled", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "nodesc", Description: nil},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PublicChannels, 1)
+		assert.Equal(t, "", tr.Intermediate.PublicChannels[0].Purpose)
+	})
+
+	t.Run("name sanitization", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		rooms := []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "My-Channel-Name"},
+		}
+		tr.transformChannels(rooms)
+		require.Len(t, tr.Intermediate.PublicChannels, 1)
+		// Name should be lowercased
+		assert.Equal(t, "my-channel-name", tr.Intermediate.PublicChannels[0].Name)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Subscription → Membership tests
+// ---------------------------------------------------------------------------
+
+func TestTransformSubscriptions(t *testing.T) {
+	t.Run("user added to channel members", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.Intermediate.PublicChannels = []*intermediate.IntermediateChannel{
+			{Id: "r1", Name: "general"},
+		}
+		subs := []RocketChatSubscription{
+			{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+		}
+		tr.transformSubscriptions(subs)
+		assert.Contains(t, tr.Intermediate.PublicChannels[0].Members, "u1")
+		require.Len(t, tr.Intermediate.UsersById["u1"].Memberships, 1)
+		assert.Equal(t, "general", tr.Intermediate.UsersById["u1"].Memberships[0].Name)
+	})
+
+	t.Run("skip on missing user", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{}
+		tr.Intermediate.PublicChannels = []*intermediate.IntermediateChannel{
+			{Id: "r1", Name: "general"},
+		}
+		subs := []RocketChatSubscription{
+			{RoomID: "r1", User: RCMessageUser{ID: "unknown"}},
+		}
+		tr.transformSubscriptions(subs)
+		assert.Empty(t, tr.Intermediate.PublicChannels[0].Members)
+	})
+
+	t.Run("skip on missing channel (DM room)", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		// No public/private channels — subscription is for a DM
+		subs := []RocketChatSubscription{
+			{RoomID: "dm-room", User: RCMessageUser{ID: "u1"}},
+		}
+		tr.transformSubscriptions(subs) // should not panic
+		assert.Empty(t, tr.Intermediate.UsersById["u1"].Memberships)
+	})
+
+	t.Run("no duplicate members", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.Intermediate.PublicChannels = []*intermediate.IntermediateChannel{
+			{Id: "r1", Name: "general"},
+		}
+		subs := []RocketChatSubscription{
+			{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+			{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+		}
+		tr.transformSubscriptions(subs)
+		assert.Len(t, tr.Intermediate.PublicChannels[0].Members, 1)
+		assert.Len(t, tr.Intermediate.UsersById["u1"].Memberships, 1)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Message transformation tests
+// ---------------------------------------------------------------------------
+
+func TestTransformMessages(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("regular message conversion", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "Hello!", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		p := tr.Intermediate.Posts[0]
+		assert.Equal(t, "alice", p.User)
+		assert.Equal(t, "general", p.Channel)
+		assert.Equal(t, "Hello!", p.Message)
+		assert.Equal(t, now.UnixMilli(), p.CreateAt)
+		assert.False(t, p.IsDirect)
+	})
+
+	t.Run("thread assembly - root gets replies", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+			"u2": {Id: "u2", Username: "bob"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		root := RocketChatMessage{
+			ID: "root", RoomID: "r1",
+			User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "Root",
+			Timestamp: now, ThreadCount: 1,
+		}
+		reply := RocketChatMessage{
+			ID: "reply", RoomID: "r1",
+			User: RCMessageUser{ID: "u2", Username: "bob"}, Message: "Reply",
+			Timestamp: now.Add(time.Second), ThreadID: "root",
+		}
+		tr.transformMessages([]RocketChatMessage{root, reply}, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		assert.Equal(t, "Root", tr.Intermediate.Posts[0].Message)
+		require.Len(t, tr.Intermediate.Posts[0].Replies, 1)
+		assert.Equal(t, "Reply", tr.Intermediate.Posts[0].Replies[0].Message)
+	})
+
+	t.Run("reaction conversion - colon stripping", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		messages := []RocketChatMessage{
+			{
+				ID: "m1", RoomID: "r1",
+				User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hi",
+				Timestamp: now,
+				Reactions: map[string]RCReactionInfo{
+					":smile:":    {Usernames: []string{"alice", "bob"}},
+					":thumbsup:": {Usernames: []string{"carol"}},
+				},
+			},
+		}
+		tr.transformMessages(messages, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		p := tr.Intermediate.Posts[0]
+		require.Len(t, p.Reactions, 3)
+		emojiNames := make(map[string]bool)
+		for _, r := range p.Reactions {
+			emojiNames[r.EmojiName] = true
+		}
+		assert.True(t, emojiNames["smile"])
+		assert.True(t, emojiNames["thumbsup"])
+	})
+
+	t.Run("system message mapping - uj → system_join_channel", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Type: "uj", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		assert.Equal(t, "system_join_channel", tr.Intermediate.Posts[0].Type)
+	})
+
+	t.Run("system message skip - message_pinned", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Type: "message_pinned", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		assert.Empty(t, tr.Intermediate.Posts)
+	})
+
+	t.Run("system message skip - discussion-created", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{}
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Type: "discussion-created", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		assert.Empty(t, tr.Intermediate.Posts)
+	})
+
+	t.Run("message in skipped room is skipped", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.skippedRoomIDs["r1"] = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hello", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		assert.Empty(t, tr.Intermediate.Posts)
+	})
+
+	t.Run("DM message - IsDirect and ChannelMembers set", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.Intermediate.DirectChannels = []*intermediate.IntermediateChannel{
+			{Id: "dm1", MembersUsernames: []string{"alice", "bob"}},
+		}
+		tr.roomIDToType["dm1"] = "d"
+		tr.roomIDToChannelName["dm1"] = ""
+
+		messages := []RocketChatMessage{
+			{ID: "m1", RoomID: "dm1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hey", Timestamp: now},
+		}
+		tr.transformMessages(messages, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		p := tr.Intermediate.Posts[0]
+		assert.True(t, p.IsDirect)
+		assert.Equal(t, []string{"alice", "bob"}, p.ChannelMembers)
+	})
+
+	t.Run("file attachment mapping", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		uploads := map[string]*RocketChatUpload{
+			"file1": {ID: "file1", Name: "photo.jpg", Complete: true},
+		}
+		messages := []RocketChatMessage{
+			{
+				ID: "m1", RoomID: "r1",
+				User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "see this",
+				Timestamp: now,
+				Files:     []RCFileRef{{ID: "file1", Name: "photo.jpg"}},
+			},
+		}
+		tr.transformMessages(messages, uploads)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		require.Len(t, tr.Intermediate.Posts[0].Attachments, 1)
+		assert.Equal(t, "bulk-export-attachments/file1_photo.jpg", tr.Intermediate.Posts[0].Attachments[0])
+	})
+
+	t.Run("file attachment with caption uses upload description as message", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		uploads := map[string]*RocketChatUpload{
+			"file1": {ID: "file1", Name: "test-simple.txt", Complete: true, Description: "texter"},
+		}
+		messages := []RocketChatMessage{
+			{
+				ID: "m1", RoomID: "r1",
+				User:      RCMessageUser{ID: "u1", Username: "alice"},
+				Message:   "", // RC sets msg="" when file is uploaded with a caption
+				Timestamp: now,
+				Files:     []RCFileRef{{ID: "file1", Name: "test-simple.txt"}},
+			},
+		}
+		tr.transformMessages(messages, uploads)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		p := tr.Intermediate.Posts[0]
+		assert.Equal(t, "texter", p.Message)
+		require.Len(t, p.Attachments, 1)
+		assert.Equal(t, "bulk-export-attachments/file1_test-simple.txt", p.Attachments[0])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Channel mention conversion tests
+// ---------------------------------------------------------------------------
+
+func TestConvertChannelMentions(t *testing.T) {
+	makeTransformerWithChannels := func(channelNames ...string) *Transformer {
+		tr := NewTransformer("test", newLogger())
+		for _, name := range channelNames {
+			// roomIDToChannelName maps roomID → MM channel name (lowercase).
+			// Use name as room ID for simplicity.
+			tr.roomIDToChannelName[name] = name
+		}
+		return tr
+	}
+
+	t.Run("known channel reference converted to tilde format", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general", "random")
+		result := tr.convertChannelMentions("check out #general for updates", nil)
+		assert.Equal(t, "check out ~general for updates", result)
+	})
+
+	t.Run("unknown channel reference has hash stripped", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general")
+		result := tr.convertChannelMentions("use #somehashtag for this topic", nil)
+		assert.Equal(t, "use somehashtag for this topic", result)
+	})
+
+	t.Run("multiple references in one message", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general", "random")
+		result := tr.convertChannelMentions("see #general and #random and #notachannel", nil)
+		assert.Equal(t, "see ~general and ~random and notachannel", result)
+	})
+
+	t.Run("structured refs used for lookup", func(t *testing.T) {
+		tr := makeTransformerWithChannels("my-channel")
+		refs := []RCChannelRef{
+			{ID: "r1", Name: "my-channel", FName: "My Channel"},
+		}
+		// RC may store "#my-channel" or display name variant in text
+		result := tr.convertChannelMentions("join #my-channel now", refs)
+		assert.Equal(t, "join ~my-channel now", result)
+	})
+
+	t.Run("no hash in message returns unchanged", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general")
+		result := tr.convertChannelMentions("hello world", nil)
+		assert.Equal(t, "hello world", result)
+	})
+
+	t.Run("channel mention case-insensitive match", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general")
+		// RC may emit "#General" with capital letter
+		result := tr.convertChannelMentions("see #General for info", nil)
+		assert.Equal(t, "see ~general for info", result)
+	})
+
+	t.Run("channel mention at start of message", func(t *testing.T) {
+		tr := makeTransformerWithChannels("announcements")
+		result := tr.convertChannelMentions("#announcements is the place", nil)
+		assert.Equal(t, "~announcements is the place", result)
+	})
+
+	t.Run("channel mention at end of message", func(t *testing.T) {
+		tr := makeTransformerWithChannels("general")
+		result := tr.convertChannelMentions("post in #general", nil)
+		assert.Equal(t, "post in ~general", result)
+	})
+
+	t.Run("integration: channel mention converted in TransformMessages", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+		tr.roomIDToChannelName["r2"] = "random"
+
+		messages := []RocketChatMessage{
+			{
+				ID:      "m1",
+				RoomID:  "r1",
+				User:    RCMessageUser{ID: "u1", Username: "alice"},
+				Message: "check #general and #unknown-tag",
+				Channels: []RCChannelRef{
+					{ID: "r1", Name: "general"},
+				},
+				Timestamp: time.Now(),
+			},
+		}
+		tr.transformMessages(messages, nil)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		assert.Equal(t, "check ~general and unknown-tag", tr.Intermediate.Posts[0].Message)
+	})
+}

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -1,6 +1,7 @@
 package rocketchat
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"testing"
@@ -39,7 +40,7 @@ func TestTransformUsers(t *testing.T) {
 			},
 		}
 
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 
 		require.Len(t, tr.Intermediate.UsersById, 1)
 		u := tr.Intermediate.UsersById["u1"]
@@ -57,7 +58,7 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "u1", Username: "bob", Name: "Bob James Smith", Emails: []RCEmail{{Address: "b@b.com"}}, Active: true, Type: "user"},
 		}
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 		u := tr.Intermediate.UsersById["u1"]
 		require.NotNil(t, u)
 		assert.Equal(t, "Bob", u.FirstName)
@@ -69,7 +70,7 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "u1", Username: "admin", Name: "Admin User", Emails: []RCEmail{{Address: "admin@example.com"}}, Active: true, Roles: []string{"admin"}, Type: "user"},
 		}
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 		// User should be transformed (role mapping is informational — not stored in IntermediateUser itself)
 		require.NotNil(t, tr.Intermediate.UsersById["u1"])
 	})
@@ -79,7 +80,7 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "u1", Username: "inactive", Name: "Inactive User", Emails: []RCEmail{{Address: "i@i.com"}}, Active: false, Type: "user"},
 		}
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 		u := tr.Intermediate.UsersById["u1"]
 		require.NotNil(t, u)
 		assert.NotZero(t, u.DeleteAt)
@@ -90,7 +91,7 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "u1", Username: "noemail", Name: "No Email", Emails: nil, Active: true, Type: "user"},
 		}
-		tr.transformUsers(users, false, "example.org")
+		tr.transformUsers(users, false, "example.org", GuestHandlingUser)
 		u := tr.Intermediate.UsersById["u1"]
 		require.NotNil(t, u)
 		assert.Equal(t, "noemail@example.org", u.Email)
@@ -101,7 +102,7 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "u1", Username: "noemail", Name: "No Email", Emails: nil, Active: true, Type: "user"},
 		}
-		tr.transformUsers(users, true, "")
+		tr.transformUsers(users, true, "", GuestHandlingUser)
 		u := tr.Intermediate.UsersById["u1"]
 		require.NotNil(t, u)
 		assert.Equal(t, "", u.Email)
@@ -113,7 +114,7 @@ func TestTransformUsers(t *testing.T) {
 			{ID: "b1", Username: "bot", Name: "My Bot", Type: "bot", Active: true},
 			{ID: "u1", Username: "human", Name: "Human User", Emails: []RCEmail{{Address: "h@h.com"}}, Active: true, Type: "user"},
 		}
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 		assert.Len(t, tr.Intermediate.UsersById, 2)
 
 		bot := tr.Intermediate.UsersById["b1"]
@@ -135,11 +136,112 @@ func TestTransformUsers(t *testing.T) {
 		users := []RocketChatUser{
 			{ID: "b1", Username: "bot", Name: "My Bot", Type: "bot", Active: false},
 		}
-		tr.transformUsers(users, false, "")
+		tr.transformUsers(users, false, "", GuestHandlingUser)
 		bot := tr.Intermediate.UsersById["b1"]
 		require.NotNil(t, bot)
 		assert.True(t, bot.IsBot)
 		assert.Greater(t, bot.DeleteAt, int64(0))
+	})
+
+	t.Run("app-type user is skipped", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "app1", Username: "rocket.cat", Name: "Rocket Cat", Type: "app", Active: true},
+			{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingUser)
+		require.Len(t, tr.Intermediate.UsersById, 1)
+		assert.Nil(t, tr.Intermediate.UsersById["app1"])
+		assert.NotNil(t, tr.Intermediate.UsersById["u1"])
+		assert.True(t, tr.skippedUserIDs["app1"])
+		assert.True(t, tr.skippedUsernames["rocket.cat"])
+	})
+
+	t.Run("unknown-type and empty-type users are skipped", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "x1", Username: "mystery", Name: "Mystery", Type: "unknown", Active: true},
+			{ID: "x2", Username: "blank", Name: "Blank", Type: "", Active: true},
+			{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingUser)
+		require.Len(t, tr.Intermediate.UsersById, 1)
+		assert.NotNil(t, tr.Intermediate.UsersById["u1"])
+		assert.True(t, tr.skippedUserIDs["x1"])
+		assert.True(t, tr.skippedUserIDs["x2"])
+	})
+
+	t.Run("guest role sets IsGuest", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"user", "guest"}, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingGuest)
+		u := tr.Intermediate.UsersById["g1"]
+		require.NotNil(t, u)
+		assert.True(t, u.IsGuest)
+		assert.False(t, u.IsBot)
+	})
+
+	t.Run("guest detection is case-insensitive", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"Guest"}, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingGuest)
+		u := tr.Intermediate.UsersById["g1"]
+		require.NotNil(t, u)
+		assert.True(t, u.IsGuest)
+	})
+
+	t.Run("regular user roles do not set IsGuest", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Roles: []string{"user", "admin"}, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingGuest)
+		u := tr.Intermediate.UsersById["u1"]
+		require.NotNil(t, u)
+		assert.False(t, u.IsGuest)
+	})
+
+	t.Run("bot with guest role is never a guest", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "b1", Username: "bot", Name: "My Bot", Type: "bot", Active: true, Roles: []string{"guest"}},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingGuest)
+		bot := tr.Intermediate.UsersById["b1"]
+		require.NotNil(t, bot)
+		assert.True(t, bot.IsBot)
+		assert.False(t, bot.IsGuest)
+	})
+
+	t.Run("guest-handling skip drops the guest user", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+			{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingSkip)
+		require.Len(t, tr.Intermediate.UsersById, 1)
+		assert.Nil(t, tr.Intermediate.UsersById["g1"])
+		assert.NotNil(t, tr.Intermediate.UsersById["u1"])
+		assert.True(t, tr.skippedUserIDs["g1"])
+		assert.True(t, tr.skippedUsernames["guesty"])
+	})
+
+	t.Run("guest-handling user keeps guest as flagged user", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		users := []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+		}
+		tr.transformUsers(users, false, "", GuestHandlingUser)
+		u := tr.Intermediate.UsersById["g1"]
+		require.NotNil(t, u)
+		// IsGuest reflects detection regardless of mode; the export mode decides
+		// whether guest roles are actually emitted.
+		assert.True(t, u.IsGuest)
 	})
 }
 
@@ -741,4 +843,172 @@ func TestConvertChannelMentions(t *testing.T) {
 		require.Len(t, tr.Intermediate.Posts, 1)
 		assert.Equal(t, "check ~general and unknown-tag", tr.Intermediate.Posts[0].Message)
 	})
+}
+
+// ---------------------------------------------------------------------------
+// Guest handling tests
+// ---------------------------------------------------------------------------
+
+func TestValidateGuestHandling(t *testing.T) {
+	for _, mode := range []string{GuestHandlingGuest, GuestHandlingUser, GuestHandlingSkip} {
+		assert.NoError(t, ValidateGuestHandling(mode))
+	}
+	for _, mode := range []string{"", "guests", "USER", "drop", "invalid"} {
+		assert.Error(t, ValidateGuestHandling(mode), "expected error for %q", mode)
+	}
+}
+
+// exportUserRoles runs a guest user through the full pipeline in the given mode
+// and returns the exported user line's system role, team role, and channel role
+// (empty strings when the user was not exported at all).
+func exportUserRoles(t *testing.T, mode string) (systemRole, teamRole, channelRole string, exported bool) {
+	t.Helper()
+	tr := NewTransformer("myteam", newLogger())
+	parsed := &ParsedData{
+		Users: []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+		},
+		Rooms: []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "general"},
+		},
+		Subscriptions: []RocketChatSubscription{
+			{RoomID: "r1", User: RCMessageUser{ID: "g1", Username: "guesty"}},
+		},
+	}
+	tr.Transform(parsed, true, false, "", mode)
+
+	var buf bytes.Buffer
+	require.NoError(t, tr.ExportUsers(&buf, ""))
+	lines := readLines(t, &buf)
+
+	for _, line := range lines {
+		if line["type"] != "user" {
+			continue
+		}
+		user := line["user"].(map[string]any)
+		if user["username"] != "guesty" {
+			continue
+		}
+		exported = true
+		systemRole, _ = user["roles"].(string)
+		teams := user["teams"].([]any)
+		team := teams[0].(map[string]any)
+		teamRole, _ = team["roles"].(string)
+		channels := team["channels"].([]any)
+		require.NotEmpty(t, channels)
+		ch := channels[0].(map[string]any)
+		channelRole, _ = ch["roles"].(string)
+	}
+	return systemRole, teamRole, channelRole, exported
+}
+
+func TestGuestExportRoleMapping(t *testing.T) {
+	t.Run("mode guest emits guest roles", func(t *testing.T) {
+		systemRole, teamRole, channelRole, exported := exportUserRoles(t, GuestHandlingGuest)
+		require.True(t, exported)
+		assert.Equal(t, model.SystemGuestRoleId, systemRole)
+		assert.Equal(t, model.TeamGuestRoleId, teamRole)
+		assert.Equal(t, model.ChannelGuestRoleId, channelRole)
+	})
+
+	t.Run("mode user emits regular user roles", func(t *testing.T) {
+		systemRole, teamRole, channelRole, exported := exportUserRoles(t, GuestHandlingUser)
+		require.True(t, exported)
+		assert.Equal(t, model.SystemUserRoleId, systemRole)
+		assert.Equal(t, model.TeamUserRoleId, teamRole)
+		assert.Equal(t, model.ChannelUserRoleId, channelRole)
+	})
+
+	t.Run("mode skip omits the guest user entirely", func(t *testing.T) {
+		_, _, _, exported := exportUserRoles(t, GuestHandlingSkip)
+		assert.False(t, exported)
+	})
+}
+
+func TestSkippedUsersReferentialIntegrity(t *testing.T) {
+	// Build a dump where an "app" user (rocket.cat) participates in a public
+	// channel, a DM with a real user, authors a post, and reacts to a message.
+	// After the transform, nothing may reference rocket.cat.
+	newDump := func() *ParsedData {
+		now := time.Now().UTC()
+		return &ParsedData{
+			Users: []RocketChatUser{
+				{ID: "app1", Username: "rocket.cat", Name: "Rocket Cat", Type: "app", Active: true},
+				{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+			},
+			Rooms: []RocketChatRoom{
+				{ID: "r1", Type: "c", Name: "general"},
+				{ID: "dm1", Type: "d", UIDs: []string{"u1", "app1"}, Usernames: []string{"alice", "rocket.cat"}},
+			},
+			Subscriptions: []RocketChatSubscription{
+				{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+				{RoomID: "r1", User: RCMessageUser{ID: "app1", Username: "rocket.cat"}},
+			},
+			Messages: []RocketChatMessage{
+				{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hi", Timestamp: now,
+					Reactions: map[string]RCReactionInfo{":wave:": {Usernames: []string{"rocket.cat"}}}},
+				{ID: "m2", RoomID: "r1", User: RCMessageUser{ID: "app1", Username: "rocket.cat"}, Message: "beep boop", Timestamp: now.Add(time.Second)},
+			},
+		}
+	}
+
+	tr := NewTransformer("myteam", newLogger())
+	tr.Transform(newDump(), true, false, "", GuestHandlingUser)
+
+	// rocket.cat must not be exported, not even as a placeholder.
+	assert.Nil(t, tr.Intermediate.UsersById["app1"])
+	assert.Len(t, tr.Intermediate.UsersById, 1)
+	assert.NotNil(t, tr.Intermediate.UsersById["u1"])
+
+	// No public-channel membership references rocket.cat.
+	require.Len(t, tr.Intermediate.PublicChannels, 1)
+	assert.NotContains(t, tr.Intermediate.PublicChannels[0].Members, "app1")
+
+	// The DM must not reference rocket.cat; with only alice left it becomes a
+	// self-DM rather than a dangling reference.
+	require.Len(t, tr.Intermediate.DirectChannels, 1)
+	for _, name := range tr.Intermediate.DirectChannels[0].MembersUsernames {
+		assert.NotEqual(t, "rocket.cat", name)
+	}
+
+	// Only alice's post survives, and no reaction references rocket.cat.
+	require.Len(t, tr.Intermediate.Posts, 1)
+	assert.Equal(t, "alice", tr.Intermediate.Posts[0].User)
+	for _, r := range tr.Intermediate.Posts[0].Reactions {
+		assert.NotEqual(t, "rocket.cat", r.User)
+	}
+	assert.Positive(t, tr.droppedPostRefs)
+}
+
+func TestGuestSkipReferentialIntegrity(t *testing.T) {
+	now := time.Now().UTC()
+	parsed := &ParsedData{
+		Users: []RocketChatUser{
+			{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+			{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+		},
+		Rooms: []RocketChatRoom{
+			{ID: "r1", Type: "c", Name: "general"},
+		},
+		Subscriptions: []RocketChatSubscription{
+			{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+			{RoomID: "r1", User: RCMessageUser{ID: "g1", Username: "guesty"}},
+		},
+		Messages: []RocketChatMessage{
+			{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "g1", Username: "guesty"}, Message: "hello from guest", Timestamp: now},
+			{ID: "m2", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hi", Timestamp: now.Add(time.Second)},
+		},
+	}
+
+	tr := NewTransformer("myteam", newLogger())
+	tr.Transform(parsed, true, false, "", GuestHandlingSkip)
+
+	// The guest is dropped along with its post and membership.
+	assert.Nil(t, tr.Intermediate.UsersById["g1"])
+	require.Len(t, tr.Intermediate.PublicChannels, 1)
+	assert.NotContains(t, tr.Intermediate.PublicChannels[0].Members, "g1")
+	require.Len(t, tr.Intermediate.Posts, 1)
+	assert.Equal(t, "alice", tr.Intermediate.Posts[0].User)
+	assert.Positive(t, tr.droppedPostRefs)
+	assert.Positive(t, tr.droppedMembershipRefs)
 }

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/app/imports"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -957,6 +958,171 @@ func TestGuestExportRoleMapping(t *testing.T) {
 	t.Run("mode skip omits the guest user entirely", func(t *testing.T) {
 		_, _, _, exported := exportUserRoles(t, GuestHandlingSkip)
 		assert.False(t, exported)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Channel-less guest handling tests
+// ---------------------------------------------------------------------------
+
+func TestSkipChannellessGuests(t *testing.T) {
+	t.Run("guest mode drops guests with no memberships, keeps the rest", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"g1": {Id: "g1", Username: "guesty", IsGuest: true},
+			"g2": {Id: "g2", Username: "keeper", IsGuest: true, Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+		}
+
+		tr.skipChannellessGuests()
+
+		assert.Nil(t, tr.Intermediate.UsersById["g1"], "channel-less guest should be dropped")
+		assert.True(t, tr.skippedUserIDs["g1"])
+		assert.True(t, tr.skippedUsernames["guesty"])
+		assert.NotNil(t, tr.Intermediate.UsersById["g2"], "guest with a membership stays a guest")
+		assert.NotNil(t, tr.Intermediate.UsersById["u1"])
+	})
+
+	t.Run("user mode (EmitGuestRoles false) is a no-op", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = false
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"g1": {Id: "g1", Username: "guesty", IsGuest: true},
+		}
+
+		tr.skipChannellessGuests()
+
+		assert.NotNil(t, tr.Intermediate.UsersById["g1"], "channel-less guests are only dropped in guest mode")
+		assert.False(t, tr.skippedUserIDs["g1"])
+	})
+
+	t.Run("channel-less guest in a DM collapses it to a self-DM", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"g1": {Id: "g1", Username: "guesty", IsGuest: true},
+		}
+		dm := &intermediate.IntermediateChannel{
+			Id: "dm1", Type: model.ChannelTypeDirect,
+			Members: []string{"u1", "g1"}, MembersUsernames: []string{"alice", "guesty"},
+		}
+		tr.Intermediate.DirectChannels = []*intermediate.IntermediateChannel{dm}
+		tr.directRoomIDToChannel["dm1"] = dm
+
+		tr.skipChannellessGuests()
+
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		assert.Equal(t, []string{"alice", "alice"}, tr.Intermediate.DirectChannels[0].MembersUsernames)
+		assert.NotContains(t, tr.Intermediate.DirectChannels[0].MembersUsernames, "guesty")
+	})
+
+	t.Run("group DM losing a channel-less guest is reclassified to a direct channel", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"u2": {Id: "u2", Username: "bob", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"g1": {Id: "g1", Username: "guesty", IsGuest: true},
+		}
+		gm := &intermediate.IntermediateChannel{
+			Id: "gm1", Type: model.ChannelTypeGroup,
+			Members: []string{"u1", "u2", "g1"}, MembersUsernames: []string{"alice", "bob", "guesty"},
+		}
+		tr.Intermediate.GroupChannels = []*intermediate.IntermediateChannel{gm}
+		tr.directRoomIDToChannel["gm1"] = gm
+
+		tr.skipChannellessGuests()
+
+		assert.Empty(t, tr.Intermediate.GroupChannels)
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		assert.Equal(t, []string{"alice", "bob"}, tr.Intermediate.DirectChannels[0].MembersUsernames)
+		assert.Equal(t, model.ChannelTypeDirect, tr.Intermediate.DirectChannels[0].Type)
+	})
+
+	t.Run("DM between only channel-less guests is dropped entirely", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"g1": {Id: "g1", Username: "guesty1", IsGuest: true},
+			"g2": {Id: "g2", Username: "guesty2", IsGuest: true},
+		}
+		dm := &intermediate.IntermediateChannel{
+			Id: "dm1", Type: model.ChannelTypeDirect,
+			Members: []string{"g1", "g2"}, MembersUsernames: []string{"guesty1", "guesty2"},
+		}
+		tr.Intermediate.DirectChannels = []*intermediate.IntermediateChannel{dm}
+		tr.directRoomIDToChannel["dm1"] = dm
+
+		tr.skipChannellessGuests()
+
+		assert.Empty(t, tr.Intermediate.DirectChannels)
+		assert.True(t, tr.skippedRoomIDs["dm1"], "room must be recorded so its messages are skipped")
+		_, stillMapped := tr.directRoomIDToChannel["dm1"]
+		assert.False(t, stillMapped)
+	})
+}
+
+// TestChannellessGuestEndToEnd runs a full transform where a guest exists only
+// in a DM (no channel subscription). In guest mode they must be dropped with no
+// dangling references; in user mode they are kept as a regular member.
+func TestChannellessGuestEndToEnd(t *testing.T) {
+	newDump := func() *ParsedData {
+		now := time.Now().UTC()
+		return &ParsedData{
+			Users: []RocketChatUser{
+				{ID: "u1", Username: "alice", Name: "Alice", Emails: []RCEmail{{Address: "a@a.com"}}, Active: true, Type: "user"},
+				{ID: "k1", Username: "keeper", Name: "Keeper Guest", Emails: []RCEmail{{Address: "k@k.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+				{ID: "g1", Username: "guesty", Name: "Guest User", Emails: []RCEmail{{Address: "g@g.com"}}, Active: true, Roles: []string{"guest"}, Type: "user"},
+			},
+			Rooms: []RocketChatRoom{
+				{ID: "r1", Type: "c", Name: "general"},
+				{ID: "dm1", Type: "d", UIDs: []string{"u1", "g1"}, Usernames: []string{"alice", "guesty"}},
+			},
+			// guesty has no subscription to r1, so ends up channel-less; keeper does.
+			Subscriptions: []RocketChatSubscription{
+				{RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}},
+				{RoomID: "r1", User: RCMessageUser{ID: "k1", Username: "keeper"}},
+			},
+			Messages: []RocketChatMessage{
+				{ID: "m1", RoomID: "r1", User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "hi", Timestamp: now},
+				{ID: "m2", RoomID: "dm1", User: RCMessageUser{ID: "g1", Username: "guesty"}, Message: "secret", Timestamp: now.Add(time.Second)},
+			},
+		}
+	}
+
+	t.Run("guest mode drops the channel-less guest and their DM post", func(t *testing.T) {
+		tr := NewTransformer("myteam", newLogger())
+		tr.Transform(newDump(), true, false, "", GuestHandlingGuest)
+
+		assert.Nil(t, tr.Intermediate.UsersById["g1"], "channel-less guest dropped")
+		require.NotNil(t, tr.Intermediate.UsersById["k1"], "guest with a channel membership kept")
+		assert.True(t, tr.Intermediate.UsersById["k1"].IsGuest)
+		require.NotNil(t, tr.Intermediate.UsersById["u1"])
+
+		// The DM collapses to alice's self-DM; nothing references guesty.
+		require.Len(t, tr.Intermediate.DirectChannels, 1)
+		for _, name := range tr.Intermediate.DirectChannels[0].MembersUsernames {
+			assert.NotEqual(t, "guesty", name)
+		}
+
+		// guesty's DM post is dropped; only alice's channel post remains.
+		for _, p := range tr.Intermediate.Posts {
+			assert.NotEqual(t, "guesty", p.User)
+		}
+
+		// The exported guest line for keeper must satisfy the server's validator.
+		line := intermediate.GetImportLineFromUser(tr.Intermediate.UsersById["k1"], "myteam", tr.EmitGuestRoles)
+		assert.Equal(t, model.SystemGuestRoleId, *line.User.Roles)
+		require.Nil(t, imports.ValidateUserImportData(line.User))
+	})
+
+	t.Run("user mode keeps the channel-less guest as a regular member", func(t *testing.T) {
+		tr := NewTransformer("myteam", newLogger())
+		tr.Transform(newDump(), true, false, "", GuestHandlingUser)
+
+		require.NotNil(t, tr.Intermediate.UsersById["g1"], "in user mode channel-less guests are kept")
 	})
 }
 

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -313,16 +313,6 @@ func TestTransformChannels(t *testing.T) {
 		assert.True(t, tr.skippedRoomIDs["r1"])
 	})
 
-	t.Run("discussion room (prid set) is skipped", func(t *testing.T) {
-		tr := NewTransformer("test", newLogger())
-		rooms := []RocketChatRoom{
-			{ID: "r1", Type: "p", Name: "discussion", ParentRID: "parent-room-id"},
-		}
-		tr.transformChannels(rooms)
-		assert.Empty(t, tr.Intermediate.PrivateChannels)
-		assert.True(t, tr.skippedRoomIDs["r1"])
-	})
-
 	t.Run("null description handled", func(t *testing.T) {
 		tr := NewTransformer("test", newLogger())
 		rooms := []RocketChatRoom{

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -600,6 +600,35 @@ func TestTransformMessages(t *testing.T) {
 		assert.Equal(t, "bulk-export-attachments/file1_photo.jpg", tr.Intermediate.Posts[0].Attachments[0])
 	})
 
+	t.Run("thumbnail file ref is skipped to avoid duplicate images", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+
+		uploads := map[string]*RocketChatUpload{
+			"img1":   {ID: "img1", Name: "white-wolf.jpg", Complete: true},
+			"thumb1": {ID: "thumb1", Name: "thumb-white-wolf.jpg", Complete: true},
+		}
+		messages := []RocketChatMessage{
+			{
+				ID: "m1", RoomID: "r1",
+				User: RCMessageUser{ID: "u1", Username: "alice"}, Message: "chart",
+				Timestamp: now,
+				Files: []RCFileRef{
+					{ID: "img1", Name: "white-wolf.jpg", TypeGroup: "image"},
+					{ID: "thumb1", Name: "thumb-white-wolf.jpg", TypeGroup: "thumb"},
+				},
+			},
+		}
+		tr.transformMessages(messages, uploads)
+		require.Len(t, tr.Intermediate.Posts, 1)
+		require.Len(t, tr.Intermediate.Posts[0].Attachments, 1)
+		assert.Equal(t, "bulk-export-attachments/img1_white-wolf.jpg", tr.Intermediate.Posts[0].Attachments[0])
+	})
+
 	t.Run("file attachment with caption uses upload description as message", func(t *testing.T) {
 		tr := NewTransformer("test", newLogger())
 		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -1062,6 +1062,46 @@ func TestSkipChannellessGuests(t *testing.T) {
 		_, stillMapped := tr.directRoomIDToChannel["dm1"]
 		assert.False(t, stillMapped)
 	})
+
+	t.Run("malformed DM with mismatched member arrays is dropped without panicking", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.EmitGuestRoles = true
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u1": {Id: "u1", Username: "alice", Memberships: []intermediate.IntermediateMembership{{Name: "general"}}},
+			"g1": {Id: "g1", Username: "guesty", IsGuest: true},
+		}
+		// Two uids but a single username: after the channel-less guest g1/guesty
+		// is filtered out, dropSkippedMembers leaves one uid and zero usernames,
+		// which used to panic on the self-DM duplication.
+		dm := &intermediate.IntermediateChannel{
+			Id: "dm1", Type: model.ChannelTypeDirect,
+			Members: []string{"u1", "g1"}, MembersUsernames: []string{"guesty"},
+		}
+		tr.Intermediate.DirectChannels = []*intermediate.IntermediateChannel{dm}
+		tr.directRoomIDToChannel["dm1"] = dm
+
+		assert.NotPanics(t, func() { tr.skipChannellessGuests() })
+		assert.Empty(t, tr.Intermediate.DirectChannels)
+		assert.True(t, tr.skippedRoomIDs["dm1"])
+	})
+}
+
+func TestTransformChannelsMalformedDirectRoom(t *testing.T) {
+	// A direct room whose uid/username arrays have different lengths is malformed;
+	// once skipped users are filtered out it can collapse to one uid and zero
+	// usernames, which must be dropped rather than panic on the self-DM path.
+	tr := NewTransformer("test", newLogger())
+	tr.markUserSkipped("u2", "")
+	tr.skippedUsernames["ghost"] = true
+
+	rooms := []RocketChatRoom{
+		{ID: "dm1", Type: "d", UIDs: []string{"u1", "u2"}, Usernames: []string{"ghost"}},
+	}
+
+	assert.NotPanics(t, func() { tr.transformChannels(rooms) })
+	assert.Empty(t, tr.Intermediate.DirectChannels)
+	assert.Empty(t, tr.Intermediate.GroupChannels)
+	assert.True(t, tr.skippedRoomIDs["dm1"])
 }
 
 // TestChannellessGuestEndToEnd runs a full transform where a guest exists only

--- a/services/rocketchat/transformer_test.go
+++ b/services/rocketchat/transformer_test.go
@@ -557,6 +557,41 @@ func TestTransformMessages(t *testing.T) {
 		assert.Equal(t, "Reply", tr.Intermediate.Posts[0].Replies[0].Message)
 	})
 
+	t.Run("thread assembly - skipped root drops replies and counts them", func(t *testing.T) {
+		tr := NewTransformer("test", newLogger())
+		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{
+			"u2": {Id: "u2", Username: "bob"},
+		}
+		tr.roomIDToType["r1"] = "c"
+		tr.roomIDToChannelName["r1"] = "general"
+		// The root's author is a skipped user (e.g. a guest under
+		// GuestHandlingSkip), so convertMessage returns nil for the root.
+		tr.skippedUsernames["guesty"] = true
+
+		root := RocketChatMessage{
+			ID: "root", RoomID: "r1",
+			User: RCMessageUser{ID: "u1", Username: "guesty"}, Message: "Root",
+			Timestamp: now, ThreadCount: 2,
+		}
+		reply1 := RocketChatMessage{
+			ID: "reply1", RoomID: "r1",
+			User: RCMessageUser{ID: "u2", Username: "bob"}, Message: "Reply 1",
+			Timestamp: now.Add(time.Second), ThreadID: "root",
+		}
+		reply2 := RocketChatMessage{
+			ID: "reply2", RoomID: "r1",
+			User: RCMessageUser{ID: "u2", Username: "bob"}, Message: "Reply 2",
+			Timestamp: now.Add(2 * time.Second), ThreadID: "root",
+		}
+		tr.transformMessages([]RocketChatMessage{root, reply1, reply2}, nil)
+
+		// The whole thread is dropped, but the lost replies must be counted so
+		// the loss is visible in the end-of-transform summary: 1 root (skipped
+		// user) + 2 orphaned replies.
+		assert.Empty(t, tr.Intermediate.Posts)
+		assert.Equal(t, 3, tr.droppedPostRefs)
+	})
+
 	t.Run("reaction conversion - colon stripping", func(t *testing.T) {
 		tr := NewTransformer("test", newLogger())
 		tr.Intermediate.UsersById = map[string]*intermediate.IntermediateUser{

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -606,7 +606,7 @@ func TestGetImportLineFromUser(t *testing.T) {
 			},
 		}
 
-		line := intermediate.GetImportLineFromUser(user, "myteam")
+		line := intermediate.GetImportLineFromUser(user, "myteam", false)
 
 		assert.Equal(t, "user", line.Type)
 		require.NotNil(t, line.User)
@@ -638,7 +638,7 @@ func TestGetImportLineFromUser(t *testing.T) {
 			},
 		}
 
-		line := intermediate.GetImportLineFromUser(user, "myteam")
+		line := intermediate.GetImportLineFromUser(user, "myteam", false)
 
 		channels := *(*line.User.Teams)[0].Channels
 		require.Len(t, channels, 1)
@@ -656,7 +656,7 @@ func TestGetImportLineFromUser(t *testing.T) {
 			},
 		}
 
-		line := intermediate.GetImportLineFromUser(user, "myteam")
+		line := intermediate.GetImportLineFromUser(user, "myteam", false)
 
 		channels := *(*line.User.Teams)[0].Channels
 		require.Len(t, channels, 1)
@@ -671,7 +671,7 @@ func TestGetImportLineFromUser(t *testing.T) {
 			Email:    "charlie@example.com",
 		}
 
-		line := intermediate.GetImportLineFromUser(user, "myteam")
+		line := intermediate.GetImportLineFromUser(user, "myteam", false)
 
 		require.NotNil(t, line.User.Teams)
 		team := (*line.User.Teams)[0]

--- a/services/slack/export_test.go
+++ b/services/slack/export_test.go
@@ -691,7 +691,7 @@ func TestGetImportLineFromDirectChannel(t *testing.T) {
 			LastPostAt:       1704099999000,
 		}
 
-		line := intermediate.GetImportLineFromDirectChannel("myteam", channel)
+		line := intermediate.GetImportLineFromDirectChannel("myteam", channel, nil)
 
 		assert.Equal(t, "direct_channel", line.Type)
 		require.NotNil(t, line.DirectChannel)
@@ -716,7 +716,7 @@ func TestGetImportLineFromDirectChannel(t *testing.T) {
 			Created:          1704067200,
 		}
 
-		line := intermediate.GetImportLineFromDirectChannel("myteam", channel)
+		line := intermediate.GetImportLineFromDirectChannel("myteam", channel, nil)
 
 		require.Len(t, line.DirectChannel.Participants, 2)
 		assert.Equal(t, int64(1704067200000), *line.DirectChannel.Participants[0].LastViewedAt)
@@ -736,7 +736,7 @@ func TestGetImportLineFromDirectChannel(t *testing.T) {
 			Created:          0, // absent (Slack DM placeholders are normalized to 0 upstream)
 		}
 
-		line := intermediate.GetImportLineFromDirectChannel("myteam", channel)
+		line := intermediate.GetImportLineFromDirectChannel("myteam", channel, nil)
 
 		require.Len(t, line.DirectChannel.Participants, 2)
 		assert.Equal(t, fixedTime.UnixMilli(), *line.DirectChannel.Participants[0].LastViewedAt)

--- a/services/slack/intermediate.go
+++ b/services/slack/intermediate.go
@@ -42,7 +42,7 @@ func normalizeSlackCreated(created int64) int64 {
 }
 
 // The intermediate representation now lives in the shared services/intermediate
-// package so it can be reused across import sources (Slack, Rocket.Chat, ...).
+// package so it can be reused across import sources (Slack, RocketChat, ...).
 // These aliases keep the Slack transform code below unchanged. Methods such as
 // CreatedMillis and Sanitise are defined on the canonical types in that package.
 type (


### PR DESCRIPTION
## Summary

Adds **Rocket.Chat → Mattermost** migration support to `mmetl`, built on top of the shared source-agnostic intermediate representation introduced in #93 (now on `master`).

Related docs PR - https://github.com/mattermost/docs/pull/9084

## What's included

- **Core service** (`services/rocketchat/`): parse, transform, and export a Rocket.Chat export into the shared intermediate representation
  - `parse.go` — read Rocket.Chat export files
  - `transformer.go` — map users/channels/messages/threads into the intermediate model
  - `intermediate.go` — bridge into the shared `services/intermediate` package
  - `attachments.go` / `gridfs.go` — attachment + GridFS file handling
  - `check.go` — validation of a produced import file
- **CLI commands** (`commands/`): `mmetl transform rocketchat` and `mmetl check rocketchat`
- **Docs**: regenerated `docs/cli/*.md`, updated `README.md` and `AGENTS.md`
- **Tests**: unit tests across the service plus a Docker-backed e2e test (`transform_rocketchat_e2e_test.go`) that spins up real Mattermost + Postgres and imports the output
