### PR TITLE
fix: create per-team directories before writing in grid-transform (MM-69731)

### DIFF
--- a/commands/grid_transform.go
+++ b/commands/grid_transform.go
@@ -47,7 +47,7 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	logger := log.New()
 	logFile, err := os.OpenFile("grid-transform-slack.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
-		logger.WithError(err).Error("error creating zip reader")
+		logger.WithError(err).Error("error creating log file")
 		return err
 	}
 	defer logFile.Close()

--- a/commands/grid_transform.go
+++ b/commands/grid_transform.go
@@ -104,7 +104,7 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	err = slackTransformer.ExtractDirectory(zipReader)
 	if err != nil {
 		logger.WithError(err).Error("error extracting zip file")
-		return nil
+		return err
 	}
 
 	slackExport, err := slackTransformer.ParseGridSlackExportFile(zipReader)

--- a/commands/grid_transform.go
+++ b/commands/grid_transform.go
@@ -47,7 +47,7 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	logger := log.New()
 	logFile, err := os.OpenFile("grid-transform-slack.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
-		logger.Error("error creating zip reader: %w", err)
+		logger.WithError(err).Error("error creating zip reader")
 		return err
 	}
 	defer logFile.Close()
@@ -63,20 +63,20 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	// input file
 	fileReader, err := os.Open(inputFilePath)
 	if err != nil {
-		logger.Error("error opening input file: %w", err)
+		logger.WithError(err).Error("error opening input file")
 		return err
 	}
 	defer fileReader.Close()
 
 	zipFileInfo, err := fileReader.Stat()
 	if err != nil {
-		logger.Error("error getting file info: %w", err)
+		logger.WithError(err).Error("error getting file info")
 		return err
 	}
 
 	zipReader, err := zip.NewReader(fileReader, zipFileInfo.Size())
 	if err != nil || zipReader.File == nil {
-		logger.Error("error reading zip file %w", err)
+		logger.WithError(err).Error("error reading zip file")
 		return err
 	}
 
@@ -84,7 +84,7 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	slackTransformer := slack_grid.NewGridTransformer(logger)
 	teamMapFile, err := os.Open(teamMap)
 	if err != nil {
-		logger.Error("error parsing teams.json: %w", err)
+		logger.WithError(err).Error("error opening teams.json")
 		return err
 	}
 	defer teamMapFile.Close()
@@ -92,7 +92,7 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	teamMapDecoder := json.NewDecoder(teamMapFile)
 	err = teamMapDecoder.Decode(&slackTransformer.Teams)
 	if err != nil {
-		logger.Error("error parsing teams.json: %w", err)
+		logger.WithError(err).Error("error parsing teams.json")
 		return err
 	}
 
@@ -103,13 +103,13 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 
 	err = slackTransformer.ExtractDirectory(zipReader)
 	if err != nil {
-		logger.Error("error extracting zip file. error:", err)
+		logger.WithError(err).Error("error extracting zip file")
 		return nil
 	}
 
 	slackExport, err := slackTransformer.ParseGridSlackExportFile(zipReader)
 	if err != nil {
-		logger.Error("error parsing slack export: %w", err)
+		logger.WithError(err).Error("error parsing slack export")
 		return err
 	}
 
@@ -126,14 +126,14 @@ func gridTransformCmdF(cmd *cobra.Command, args []string) error {
 	for _, ct := range channelTypes {
 		err = slackTransformer.HandleMovingChannels(ct.channels, ct.fileType)
 		if err != nil {
-			logger.Errorf("Error moving %v channels: %v", ct.fileType, err)
+			logger.WithError(err).WithField("channel_type", ct.fileType).Error("error moving channels")
 			return err
 		}
 	}
 
 	err = slackTransformer.ZipTeamDirectories()
 	if err != nil {
-		logger.Error("error zipping team directories", err)
+		logger.WithError(err).Error("error zipping team directories")
 		return err
 	}
 

--- a/services/slack_grid/extract.go
+++ b/services/slack_grid/extract.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const DefaultDirPath = "tmp/slack_grid"
@@ -57,7 +58,7 @@ func (t *GridTransformer) ExtractDirectory(zipReader *zip.Reader) error {
 	}
 	t.pwd = pwd
 	t.dirPath = filepath.Join(pwd, DefaultDirPath)
-	t.Logger.Infof("Extracting to %s", t.dirPath)
+	t.Logger.WithField("path", t.dirPath).Info("Extracting to directory")
 
 	yes, err := t.dirHasContent(t.dirPath)
 	if err != nil {
@@ -65,7 +66,7 @@ func (t *GridTransformer) ExtractDirectory(zipReader *zip.Reader) error {
 	}
 
 	if yes {
-		t.Logger.Infof("content exists in the directory %s. Skipping extraction.", t.dirPath)
+		t.Logger.WithField("path", t.dirPath).Info("content already exists in the directory. Skipping extraction.")
 		return nil
 	}
 
@@ -108,7 +109,10 @@ func (t *GridTransformer) ExtractDirectory(zipReader *zip.Reader) error {
 		outFile.Close()
 		rc.Close()
 		if i%1000 == 0 || i == totalFiles-1 {
-			t.Logger.Infof("Extracting file %d of %d", i, totalFiles)
+			t.Logger.WithFields(log.Fields{
+				"file":  i,
+				"total": totalFiles,
+			}).Info("Extracting file")
 		}
 		if err != nil {
 			return errors.Wrap(err, "error copying files")
@@ -130,7 +134,7 @@ func (t *GridTransformer) ZipTeamDirectories() error {
 
 	teams, err := t.readDir(teamsDir)
 
-	t.Logger.Infof("Zipping %v team directories...", len(teams))
+	t.Logger.WithField("count", len(teams)).Info("Zipping team directories")
 
 	if err != nil {
 		return errors.Wrap(err, "error reading teams directory")
@@ -141,7 +145,10 @@ func (t *GridTransformer) ZipTeamDirectories() error {
 		teamPath := filepath.Join(t.dirPath, "teams", team.Name())
 		teamZipPath := filepath.Join(t.pwd, team.Name()+".zip")
 
-		t.Logger.Infof("Zipping %s to %s", teamPath, teamZipPath)
+		t.Logger.WithFields(log.Fields{
+			"source": teamPath,
+			"target": teamZipPath,
+		}).Info("Zipping team directory")
 
 		err := ZipDir(teamPath, teamZipPath)
 		if err != nil {

--- a/services/slack_grid/extract.go
+++ b/services/slack_grid/extract.go
@@ -121,8 +121,14 @@ func (t *GridTransformer) ExtractDirectory(zipReader *zip.Reader) error {
 
 func (t *GridTransformer) ZipTeamDirectories() error {
 	// zip the directories under /teams
+	teamsDir := filepath.Join(t.dirPath, "teams")
 
-	teams, err := t.readDir(filepath.Join(t.dirPath, "teams"))
+	if _, err := os.Stat(teamsDir); os.IsNotExist(err) {
+		t.Logger.Warn("no teams directory found. No channels were moved to a team.")
+		return nil
+	}
+
+	teams, err := t.readDir(teamsDir)
 
 	t.Logger.Infof("Zipping %v team directories...", len(teams))
 

--- a/services/slack_grid/extract_test.go
+++ b/services/slack_grid/extract_test.go
@@ -53,3 +53,21 @@ func TestExtractDirectory(t *testing.T) {
 		t.Fatalf("Extracted file does not exist")
 	}
 }
+
+// TestZipTeamDirectories_NoTeamsDir covers the case where no channels were
+// ever moved into a team directory, so "teams/" was never created. Prior to
+// the fix, this made ZipTeamDirectories fail with "error reading teams
+// directory" instead of completing with nothing to zip.
+func TestZipTeamDirectories_NoTeamsDir(t *testing.T) {
+	dir := createTestDir(t)
+	defer os.RemoveAll(dir)
+
+	tf := NewGridTransformer(logrus.New())
+	tf.dirPath = dir
+	tf.pwd = dir
+
+	err := tf.ZipTeamDirectories()
+	if err != nil {
+		t.Fatalf("expected no error when teams directory does not exist, got: %v", err)
+	}
+}

--- a/services/slack_grid/parse.go
+++ b/services/slack_grid/parse.go
@@ -290,6 +290,10 @@ func (t *GridTransformer) performChannelMove(channelType ChannelFiles, channel C
 func (t *GridTransformer) appendChannelToTeamChannelsFile(channelType ChannelFiles, channel ChannelsToMove) error {
 	path := filepath.Join(t.dirPath, "teams", channel.TeamName, string(channelType)+".json")
 
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return errors.Wrap(err, "error creating team directory")
+	}
+
 	// Read the existing channels
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -380,6 +384,10 @@ func channelHasBeenMoved(channel slack.SlackChannel, channelsToMove []ChannelsTo
 }
 
 func moveDirectory(source string, destination string) error {
+	if err := os.MkdirAll(filepath.Dir(destination), os.ModePerm); err != nil {
+		return errors.Wrap(err, "error creating destination directory")
+	}
+
 	err := os.Rename(source, destination)
 	if err != nil {
 		return err

--- a/services/slack_grid/parse.go
+++ b/services/slack_grid/parse.go
@@ -130,17 +130,20 @@ func (t *GridTransformer) ParseGridSlackExportFile(zipReader *zip.Reader) (*Grid
 // Any channels that do not have a valid mapping in the teams.json file or no team ID found are skipped.
 
 func (t *GridTransformer) HandleMovingChannels(slackChannels []slack.SlackChannel, channelType ChannelFiles) error {
-	t.Logger.Infof("Unzipped slack export path being used: %v", t.dirPath)
+	t.Logger.WithField("path", t.dirPath).Info("Unzipped slack export path being used")
 
 	itemsInDir, err := t.readDir(t.dirPath)
-	t.Logger.Debugf("Found %v items in directory.", len(itemsInDir))
+	t.Logger.WithField("count", len(itemsInDir)).Debug("Found items in directory")
 
 	if err != nil {
 		return errors.Wrap(err, "error reading directory")
 	}
 
 	totalChannels := len(slackChannels)
-	t.Logger.Debugf("Found %v %v. Looking for team IDs. \n", totalChannels, channelType)
+	t.Logger.WithFields(log.Fields{
+		"count":        totalChannels,
+		"channel_type": channelType,
+	}).Debug("Looking for team IDs")
 
 	channelsToMove, err := t.getChannelsToMove(slackChannels, itemsInDir, channelType)
 	if err != nil {
@@ -162,22 +165,35 @@ func (t *GridTransformer) getChannelsToMove(slackChannels []slack.SlackChannel, 
 
 		teamID, err := t.findTeamIDForChannel(channel, itemsInDir, channelType)
 		if err != nil {
-			t.Logger.Errorf("error finding team ID for channel: %v", err.Error())
+			t.Logger.WithError(err).WithFields(log.Fields{
+				"channel":    channel.Name,
+				"channel_id": channel.Id,
+			}).Error("error finding team ID for channel")
 			continue
 		}
 
 		if teamID == "" {
-			t.Logger.Errorf(ErrFindingTeamID, channel.Name, channel.Id)
+			t.Logger.WithFields(log.Fields{
+				"channel":    channel.Name,
+				"channel_id": channel.Id,
+			}).Error("could not find team ID for channel")
 			continue
 		}
 
 		moveChannel, err := t.createMoveChannel(channel, teamID, channelType)
 		if err != nil {
-			t.Logger.Errorf("error creating move channel: %v", err.Error())
+			t.Logger.WithError(err).WithFields(log.Fields{
+				"channel":    channel.Name,
+				"channel_id": channel.Id,
+			}).Error("error creating move channel")
 			continue
 		}
 
-		t.Logger.Debugf("Found channel to move.  %v", moveChannel)
+		t.Logger.WithFields(log.Fields{
+			"channel":   moveChannel.Path,
+			"team_name": moveChannel.TeamName,
+			"team_id":   moveChannel.TeamID,
+		}).Debug("Found channel to move")
 		channelsToMove = append(channelsToMove, moveChannel)
 	}
 
@@ -228,11 +244,18 @@ func (t *GridTransformer) parseChannel(file *zip.File, channelType model.Channel
 
 func (t *GridTransformer) moveChannels(channelsToMove []ChannelsToMove, channelType ChannelFiles) error {
 	totalChannels := len(channelsToMove)
-	t.Logger.Infof("Moving %v channels. \n", totalChannels)
+	t.Logger.WithFields(log.Fields{
+		"count":        totalChannels,
+		"channel_type": channelType,
+	}).Info("Moving channels")
 
 	for i, channel := range channelsToMove {
 		if totalChannels > 100 && i%100 == 0 {
-			t.Logger.Infof("Performing %v of %v %v moves \n", i+100, totalChannels, channelType)
+			t.Logger.WithFields(log.Fields{
+				"completed":    i + 100,
+				"total":        totalChannels,
+				"channel_type": channelType,
+			}).Info("Performing channel moves")
 		}
 
 		err := t.performChannelMove(channelType, channel, channelsToMove, i)
@@ -241,7 +264,10 @@ func (t *GridTransformer) moveChannels(channelsToMove []ChannelsToMove, channelT
 		}
 	}
 
-	t.Logger.Infof("Moved %v %v \n", totalChannels, channelType)
+	t.Logger.WithFields(log.Fields{
+		"count":        totalChannels,
+		"channel_type": channelType,
+	}).Info("Moved channels")
 	return nil
 }
 
@@ -259,13 +285,12 @@ func (t *GridTransformer) performChannelMove(channelType ChannelFiles, channel C
 		return errors.Errorf(ErrFindingTeamName, channel.Path)
 	}
 
-	t.Logger.Debugf(
-		"Moving channel %v to team %v. channel ID: %v, team ID: %v",
-		channel.Path,
-		channel.TeamName,
-		channel.TeamID,
-		channel.SlackChannel.Id,
-	)
+	t.Logger.WithFields(log.Fields{
+		"channel":    channel.Path,
+		"channel_id": channel.SlackChannel.Id,
+		"team_name":  channel.TeamName,
+		"team_id":    channel.TeamID,
+	}).Debug("Moving channel to team")
 
 	currentDir := filepath.Join(t.dirPath, channel.Path)
 	newDir := filepath.Join(t.dirPath, "teams", channel.TeamName, channel.Path)

--- a/services/slack_grid/parse_test.go
+++ b/services/slack_grid/parse_test.go
@@ -67,8 +67,12 @@ func TestParseGridSlackExportFile(t *testing.T) {
 	marshalAndWriteToZipFile(zipWriter, "channels.json", channels, t)
 	marshalAndWriteToZipFile(zipWriter, "groups.json", channels, t)
 
+	// the export must already contain a folder for each team named in teams.json.
+	_, err := zipWriter.Create("teams/team1/")
+	assert.NoError(t, err)
+
 	// Close the zip writer
-	err := zipWriter.Close()
+	err = zipWriter.Close()
 	assert.NoError(t, err)
 
 	// Create a new zip reader

--- a/services/slack_grid/parse_test.go
+++ b/services/slack_grid/parse_test.go
@@ -245,6 +245,28 @@ func TestAppendChannelToChannelsToMove(t *testing.T) {
 	}
 }
 
+// TestAppendChannelToChannelsToMove_TeamDirDoesNotExist covers appending to a
+// team's channels file when the "teams/<team name>" directory does not
+// already exist, e.g. when a channel move failed but the append is still
+// attempted, or the append runs before any directory has been created.
+func TestAppendChannelToChannelsToMove_TeamDirDoesNotExist(t *testing.T) {
+	bt := setupGridTransformer(t)
+
+	teamName := "team1"
+
+	channel := ChannelsToMove{SlackChannel: slack.SlackChannel{Id: "1"}, TeamName: teamName}
+	err := bt.appendChannelToTeamChannelsFile(ChannelFilePublic, channel)
+	if err != nil {
+		t.Fatalf("error appending channel to team channels file %v", err)
+	}
+
+	teamUpdatedChannels := readChannelsFile(filepath.Join(bt.dirPath, "teams", teamName, string(ChannelFilePublic)+".json"), t)
+
+	if len(teamUpdatedChannels) != 1 || teamUpdatedChannels[0].Id != "1" {
+		t.Fatalf("channel was not appended. Channels found: %v", teamUpdatedChannels)
+	}
+}
+
 func TestHandleMovingChannels(t *testing.T) {
 	bt := setupGridTransformer(t)
 
@@ -262,6 +284,44 @@ func TestHandleMovingChannels(t *testing.T) {
 	)
 
 	// creating a channel with a single post in it that we can move.
+	writeToFileInTestDir(channelPath, "posts.json",
+		marshalJSON([]Post{{Team: "team1"}}, t),
+		t,
+	)
+
+	slackChannel := []slack.SlackChannel{
+		{Id: "channel1", Name: "channel1"},
+	}
+	err := bt.HandleMovingChannels(slackChannel, ChannelFilePublic)
+
+	if err != nil {
+		t.Fatalf("error moving channel %v", err)
+	}
+
+	channels := readChannelsFile(teamPath+"/channels.json", t)
+
+	if len(channels) != len(slackChannel) {
+		t.Fatal("channel was not moved. Channel IDs in team path are: ", channels)
+	}
+}
+
+// TestHandleMovingChannels_TeamDirDoesNotExist covers moving the very first
+// channel for a team, where the "teams/<team name>" directory does not
+// already exist. This reproduces a customer report where grid-transform
+// failed because the team directory named after teams.json's team name was
+// never created ahead of the move.
+func TestHandleMovingChannels_TeamDirDoesNotExist(t *testing.T) {
+	bt := setupGridTransformer(t)
+
+	bt.Teams = map[string]string{
+		"team1": "team1",
+	}
+
+	teamPath := filepath.Join(bt.dirPath, "teams", "team1")
+	channelPath := filepath.Join(bt.dirPath, "channel1")
+
+	// creating a channel with a single post in it that we can move, without
+	// pre-creating the destination team directory.
 	writeToFileInTestDir(channelPath, "posts.json",
 		marshalJSON([]Post{{Team: "team1"}}, t),
 		t,

--- a/services/slack_grid/precheck.go
+++ b/services/slack_grid/precheck.go
@@ -71,6 +71,16 @@ func (t *GridTransformer) checkForDuplicateTeamNames() bool {
 func (t *GridTransformer) checkTeamFoldersExist(zipReader *zip.Reader) bool {
 	valid := true
 	for teamID, teamName := range t.Teams {
+		// Reject unsafe team names that could escape the export tree
+		if strings.Contains(teamName, "..") || strings.ContainsAny(teamName, "/\\") {
+			t.Logger.WithFields(log.Fields{
+				"team_name": teamName,
+				"team_id":   teamID,
+			}).Error("invalid team name contains path separators or traversal segments")
+			valid = false
+			continue
+		}
+
 		prefix := "teams/" + teamName + "/"
 		found := false
 		for _, file := range zipReader.File {

--- a/services/slack_grid/precheck.go
+++ b/services/slack_grid/precheck.go
@@ -2,6 +2,10 @@ package slack_grid
 
 import (
 	"archive/zip"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func (t *GridTransformer) GridPreCheck(zipReader *zip.Reader) bool {
@@ -22,6 +26,67 @@ func (t *GridTransformer) GridPreCheck(zipReader *zip.Reader) bool {
 	if len(t.Teams) == 0 {
 		t.Logger.Error("no teams found in teams.json")
 		valid = false
+	}
+
+	if !t.checkForDuplicateTeamNames() {
+		valid = false
+	}
+
+	if !t.checkTeamFoldersExist(zipReader) {
+		valid = false
+	}
+
+	return valid
+}
+
+// checkForDuplicateTeamNames ensures every team ID in teams.json maps to a
+// distinct name. Without this, channels for teams sharing the same name
+// would be silently merged into the same "teams/<name>/" output directory
+// and zip file.
+func (t *GridTransformer) checkForDuplicateTeamNames() bool {
+	teamIDsByName := make(map[string][]string)
+	for teamID, teamName := range t.Teams {
+		teamIDsByName[teamName] = append(teamIDsByName[teamName], teamID)
+	}
+
+	valid := true
+	for teamName, teamIDs := range teamIDsByName {
+		if len(teamIDs) > 1 {
+			sort.Strings(teamIDs)
+			t.Logger.WithFields(log.Fields{
+				"team_name": teamName,
+				"team_ids":  teamIDs,
+			}).Error("team name in teams.json is used for multiple team IDs")
+			valid = false
+		}
+	}
+
+	return valid
+}
+
+// checkTeamFoldersExist ensures every team name in teams.json has a
+// corresponding "teams/<name>/" folder in the export archive. teams.json
+// names must match the folders Slack already put in the export, not
+// arbitrary display names.
+func (t *GridTransformer) checkTeamFoldersExist(zipReader *zip.Reader) bool {
+	valid := true
+	for teamID, teamName := range t.Teams {
+		prefix := "teams/" + teamName + "/"
+		found := false
+		for _, file := range zipReader.File {
+			if strings.HasPrefix(file.Name, prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Logger.WithFields(log.Fields{
+				"team_name": teamName,
+				"team_id":   teamID,
+				"path":      prefix,
+			}).Error("folder not found for team in the export archive")
+			valid = false
+		}
 	}
 
 	return valid

--- a/services/slack_grid/precheck.go
+++ b/services/slack_grid/precheck.go
@@ -69,6 +69,15 @@ func (t *GridTransformer) checkForDuplicateTeamNames() bool {
 // names must match the folders Slack already put in the export, not
 // arbitrary display names.
 func (t *GridTransformer) checkTeamFoldersExist(zipReader *zip.Reader) bool {
+	existingTeamFolders := make(map[string]bool)
+	for _, file := range zipReader.File {
+		if rest, ok := strings.CutPrefix(file.Name, "teams/"); ok {
+			if idx := strings.Index(rest, "/"); idx >= 0 {
+				existingTeamFolders[rest[:idx]] = true
+			}
+		}
+	}
+
 	valid := true
 	for teamID, teamName := range t.Teams {
 		// Reject unsafe team names that could escape the export tree
@@ -81,19 +90,11 @@ func (t *GridTransformer) checkTeamFoldersExist(zipReader *zip.Reader) bool {
 			continue
 		}
 
-		prefix := "teams/" + teamName + "/"
-		found := false
-		for _, file := range zipReader.File {
-			if strings.HasPrefix(file.Name, prefix) {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !existingTeamFolders[teamName] {
 			t.Logger.WithFields(log.Fields{
 				"team_name": teamName,
 				"team_id":   teamID,
-				"path":      prefix,
+				"path":      "teams/" + teamName + "/",
 			}).Error("folder not found for team in the export archive")
 			valid = false
 		}

--- a/services/slack_grid/precheck_test.go
+++ b/services/slack_grid/precheck_test.go
@@ -1,0 +1,72 @@
+package slack_grid
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+
+	"github.com/mattermost/mmetl/services/slack"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// buildGridZip creates a minimal valid grid export zip, plus a "teams/<name>/"
+// folder entry for each name given in teamFolders.
+func buildGridZip(t *testing.T, teamFolders []string) *zip.Reader {
+	zipData := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(zipData)
+
+	marshalAndWriteToZipFile(zipWriter, "channels.json", []slack.SlackChannel{}, t)
+	marshalAndWriteToZipFile(zipWriter, "groups.json", []slack.SlackChannel{}, t)
+	marshalAndWriteToZipFile(zipWriter, "dms.json", []slack.SlackChannel{}, t)
+	marshalAndWriteToZipFile(zipWriter, "mpims.json", []slack.SlackChannel{}, t)
+
+	for _, teamFolder := range teamFolders {
+		_, err := zipWriter.Create("teams/" + teamFolder + "/")
+		assert.NoError(t, err)
+	}
+
+	err := zipWriter.Close()
+	assert.NoError(t, err)
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipData.Bytes()), int64(zipData.Len()))
+	assert.NoError(t, err)
+
+	return zipReader
+}
+
+func TestGridPreCheck_Valid(t *testing.T) {
+	gt := NewGridTransformer(logrus.New())
+	gt.Teams = map[string]string{
+		"team1": "acme",
+		"team2": "widgets-inc",
+	}
+
+	zipReader := buildGridZip(t, []string{"acme", "widgets-inc"})
+
+	assert.True(t, gt.GridPreCheck(zipReader))
+}
+
+func TestGridPreCheck_DuplicateTeamNames(t *testing.T) {
+	gt := NewGridTransformer(logrus.New())
+	gt.Teams = map[string]string{
+		"team1": "acme",
+		"team2": "acme",
+	}
+
+	zipReader := buildGridZip(t, []string{"acme"})
+
+	assert.False(t, gt.GridPreCheck(zipReader))
+}
+
+func TestGridPreCheck_MissingTeamFolder(t *testing.T) {
+	gt := NewGridTransformer(logrus.New())
+	gt.Teams = map[string]string{
+		"team1": "acme",
+	}
+
+	// export only contains a folder for a different team name.
+	zipReader := buildGridZip(t, []string{"widgets-inc"})
+
+	assert.False(t, gt.GridPreCheck(zipReader))
+}


### PR DESCRIPTION
## Summary
- `grid-transform` never created the `teams/<team name>/` output directory before moving channels or appending to team channel files, so it failed with "no such file or directory" on the first channel moved for a team (`os.Rename`/`os.WriteFile` require the destination's parent to already exist). `ZipTeamDirectories` also errored if no channels were ever moved (missing `teams/` entirely).
- Added `GridPreCheck` validations: reject `teams.json` files with duplicate team names (which would silently merge two teams' channels into one output), and reject team names with no matching `teams/<name>/` folder already present in the export archive.
- Converted all grid-transform logging (command + `slack_grid` service) to structured fields (`WithField`/`WithFields`/`WithError`) instead of formatted strings; this also fixed a few `logger.Error("...: %w", err)` calls that silently dropped the error since `Error()` doesn't interpolate format verbs, and a mislabeled log message caught by CodeRabbit review.

## Test plan
- [x] `make check-style` — 0 issues
- [x] `make test` — full suite passes
- [x] New regression tests added: `TestHandleMovingChannels_TeamDirDoesNotExist`, `TestAppendChannelToChannelsToMove_TeamDirDoesNotExist`, `TestZipTeamDirectories_NoTeamsDir`, `TestGridPreCheck_Valid`, `TestGridPreCheck_DuplicateTeamNames`, `TestGridPreCheck_MissingTeamFolder`
- [x] CodeRabbit CLI review run; one finding addressed

https://mattermost.atlassian.net/browse/MM-69731