### PR TITLE
feat: align Confluence CSV export with Docs v2 contract

### DIFF
--- a/commands/transform.go
+++ b/commands/transform.go
@@ -69,11 +69,10 @@ func init() {
 	TransformSlackCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the Slack export contains bot users.")
 
 	// Confluence command flags
-	TransformConfluenceCmd.Flags().StringP("team", "t", "", "the target team in Mattermost")
+	TransformConfluenceCmd.Flags().StringP("team", "t", "", "advisory destination team recorded in the bundle; the Docs import request selects the actual target team")
 	if err := TransformConfluenceCmd.MarkFlagRequired("team"); err != nil {
 		panic(err)
 	}
-	TransformConfluenceCmd.Flags().StringP("channel", "c", "", "deprecated and ignored in v2: the Space's backing channel is resolved at import time")
 	TransformConfluenceCmd.Flags().StringP("file", "f", "", "the Confluence export file (ZIP) to transform")
 	if err := TransformConfluenceCmd.MarkFlagRequired("file"); err != nil {
 		panic(err)
@@ -209,7 +208,6 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 
 func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	team, _ := cmd.Flags().GetString("team")
-	channel, _ := cmd.Flags().GetString("channel")
 	inputFilePath, _ := cmd.Flags().GetString("file")
 	outputFilePath, _ := cmd.Flags().GetString("output")
 	bundlePath, _ := cmd.Flags().GetString("bundle")
@@ -226,13 +224,10 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	failOnRestricted, _ := cmd.Flags().GetBool("fail-on-restricted")
 	debug, _ := cmd.Flags().GetBool("debug")
 
-	// Normalize team and channel names to lowercase, as Mattermost expects.
+	// Normalize the team name to lowercase, as Mattermost expects. This is
+	// advisory metadata recorded in the bundle; the Docs import request selects
+	// the actual target team.
 	team = strings.ToLower(team)
-	channel = strings.ToLower(channel)
-
-	if channel != "" {
-		fmt.Println("Note: --channel is deprecated and ignored in v2; the Space's backing channel is resolved at import time.")
-	}
 
 	// When --bundle is set, stage the JSONL, manifest, and data/ into a temp dir
 	// and zip it into one self-contained archive. Otherwise keep loose files.
@@ -314,7 +309,7 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create transformer
-	confluenceTransformer := confluence.NewTransformer(team, channel, logger, config)
+	confluenceTransformer := confluence.NewTransformer(team, logger, config)
 	confluenceTransformer.ExportFile = inputFilePath
 
 	// Load user mapping if provided
@@ -335,7 +330,7 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run pre-flight validation
-	validator := confluence.NewValidator(team, channel)
+	validator := confluence.NewValidator(team)
 	validator.RequireUserMapping = requireUserMapping
 	validator.FailOnRestricted = failOnRestricted
 	if mattermostURL != "" && mattermostToken != "" {

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -12,10 +12,16 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mmetl/services/confluence"
 	"github.com/mattermost/mmetl/services/slack"
 )
 
-const attachmentsInternal = "bulk-export-attachments"
+const (
+	// slackAttachmentsDir is the subdirectory for Slack attachments.
+	slackAttachmentsDir = "bulk-export-attachments"
+	// confluenceAttachmentsDir matches the Mattermost bulk import expected path (model.ExportDataDir).
+	confluenceAttachmentsDir = "data"
+)
 
 var TransformCmd = &cobra.Command{
 	Use:   "transform",
@@ -29,6 +35,15 @@ var TransformSlackCmd = &cobra.Command{
 	Example: "  transform slack --team myteam --file my_export.zip --output mm_export.json",
 	Args:    cobra.NoArgs,
 	RunE:    transformSlackCmdF,
+}
+
+var TransformConfluenceCmd = &cobra.Command{
+	Use:     "confluence",
+	Short:   "Transforms a Confluence export.",
+	Long:    "Transforms a Confluence Cloud CSV space export into a Mattermost Wiki/Pages JSONL file.",
+	Example: "  transform confluence --team myteam --channel docs --file confluence-export.zip --output wiki-import.jsonl",
+	Args:    cobra.NoArgs,
+	RunE:    transformConfluenceCmdF,
 }
 
 func init() {
@@ -51,8 +66,35 @@ func init() {
 	TransformSlackCmd.Flags().Bool("debug", false, "Whether to show debug logs or not")
 	TransformSlackCmd.Flags().String("bot-owner", "", "Username of the Mattermost user who will own all imported bots. Required if the Slack export contains bot users.")
 
+	// Confluence command flags
+	TransformConfluenceCmd.Flags().StringP("team", "t", "", "the target team in Mattermost")
+	if err := TransformConfluenceCmd.MarkFlagRequired("team"); err != nil {
+		panic(err)
+	}
+	TransformConfluenceCmd.Flags().StringP("channel", "c", "", "the target channel in Mattermost for the wikis")
+	if err := TransformConfluenceCmd.MarkFlagRequired("channel"); err != nil {
+		panic(err)
+	}
+	TransformConfluenceCmd.Flags().StringP("file", "f", "", "the Confluence export file (ZIP) to transform")
+	if err := TransformConfluenceCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
+	TransformConfluenceCmd.Flags().StringP("output", "o", "wiki-import.jsonl", "the output JSONL file path")
+	TransformConfluenceCmd.Flags().StringP("attachments-dir", "d", "data", "the path for extracted attachments")
+	TransformConfluenceCmd.Flags().StringP("user-mapping", "u", "", "CSV file mapping Confluence users to Mattermost users")
+	TransformConfluenceCmd.Flags().String("fallback-user", "", "Mattermost username to use for unmapped Confluence users")
+	TransformConfluenceCmd.Flags().BoolP("skip-attachments", "a", false, "skip extracting attachments")
+	TransformConfluenceCmd.Flags().Int("max-depth", 10, "maximum page hierarchy depth (deeper pages are flattened)")
+	TransformConfluenceCmd.Flags().Bool("dry-run", false, "validate without writing output files")
+	TransformConfluenceCmd.Flags().Bool("validate-only", false, "only run pre-flight validation, do not transform")
+	TransformConfluenceCmd.Flags().String("mattermost-url", "", "Mattermost server URL for validation (optional)")
+	TransformConfluenceCmd.Flags().String("mattermost-token", "", "Mattermost auth token for validation (optional)")
+	TransformConfluenceCmd.Flags().Bool("create-channel", false, "include channel creation in JSONL output (for new channels)")
+	TransformConfluenceCmd.Flags().Bool("debug", false, "enable debug logging")
+
 	TransformCmd.AddCommand(
 		TransformSlackCmd,
+		TransformConfluenceCmd,
 	)
 
 	RootCmd.AddCommand(
@@ -85,7 +127,7 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	// attachments dir
-	attachmentsFullDir := path.Join(attachmentsDir, attachmentsInternal)
+	attachmentsFullDir := path.Join(attachmentsDir, slackAttachmentsDir)
 
 	if !skipAttachments {
 		if fileInfo, err := os.Stat(attachmentsFullDir); os.IsNotExist(err) {
@@ -160,6 +202,201 @@ func transformSlackCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	slackTransformer.Logger.Info("Transformation succeeded!")
+
+	return nil
+}
+
+func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
+	team, _ := cmd.Flags().GetString("team")
+	channel, _ := cmd.Flags().GetString("channel")
+	inputFilePath, _ := cmd.Flags().GetString("file")
+	outputFilePath, _ := cmd.Flags().GetString("output")
+	attachmentsDir, _ := cmd.Flags().GetString("attachments-dir")
+	userMappingPath, _ := cmd.Flags().GetString("user-mapping")
+	fallbackUser, _ := cmd.Flags().GetString("fallback-user")
+	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
+	maxDepth, _ := cmd.Flags().GetInt("max-depth")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	validateOnly, _ := cmd.Flags().GetBool("validate-only")
+	mattermostURL, _ := cmd.Flags().GetString("mattermost-url")
+	mattermostToken, _ := cmd.Flags().GetString("mattermost-token")
+	createChannel, _ := cmd.Flags().GetBool("create-channel")
+	debug, _ := cmd.Flags().GetBool("debug")
+
+	// Normalize team and channel names to lowercase, as Mattermost expects.
+	team = strings.ToLower(team)
+	channel = strings.ToLower(channel)
+
+	// Validate output file
+	if !dryRun {
+		if fileInfo, err := os.Stat(outputFilePath); err != nil && !os.IsNotExist(err) {
+			return err
+		} else if err == nil && fileInfo.IsDir() {
+			return fmt.Errorf("output file \"%s\" is a directory", outputFilePath)
+		}
+	}
+
+	// Prepare attachments directory
+	attachmentsFullDir := path.Join(attachmentsDir, confluenceAttachmentsDir)
+	if !skipAttachments && !dryRun {
+		if fileInfo, err := os.Stat(attachmentsFullDir); os.IsNotExist(err) {
+			if createErr := os.MkdirAll(attachmentsFullDir, 0755); createErr != nil {
+				return createErr
+			}
+		} else if err != nil {
+			return err
+		} else if !fileInfo.IsDir() {
+			return fmt.Errorf("file \"%s\" is not a directory", attachmentsDir)
+		}
+	}
+
+	// Open input file
+	fileReader, err := os.Open(inputFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open input file: %w", err)
+	}
+	defer fileReader.Close()
+
+	zipFileInfo, err := fileReader.Stat()
+	if err != nil {
+		return err
+	}
+
+	zipReader, err := zip.NewReader(fileReader, zipFileInfo.Size())
+	if err != nil || zipReader.File == nil {
+		return fmt.Errorf("failed to read ZIP file: %w", err)
+	}
+
+	// Set up logger
+	logger := log.New()
+	logFile, err := os.OpenFile("transform-confluence.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	logger.SetOutput(logFile)
+	logger.SetFormatter(customLogFormatter)
+	logger.SetReportCaller(true)
+
+	if debug {
+		logger.Level = log.DebugLevel
+		logger.Info("Debug mode enabled")
+	}
+
+	// Create transformer config
+	config := &confluence.TransformConfig{
+		SkipAttachments:   skipAttachments,
+		AttachmentsDir:    attachmentsFullDir,
+		MaxDepth:          maxDepth,
+		DryRun:            dryRun,
+		AutoCreateChannel: createChannel,
+	}
+
+	// Create transformer
+	confluenceTransformer := confluence.NewTransformer(team, channel, logger, config)
+	confluenceTransformer.ExportFile = inputFilePath
+
+	// Load user mapping if provided
+	if userMappingPath != "" {
+		userMapper, mapErr := confluence.NewUserMapper(userMappingPath, fallbackUser)
+		if mapErr != nil {
+			return fmt.Errorf("failed to load user mapping: %w", mapErr)
+		}
+		confluenceTransformer.UserMapper = userMapper
+		logger.Infof("Loaded %d user mappings (by account ID), %d email mappings", userMapper.GetMappingCount(), userMapper.GetEmailMappingCount())
+	}
+
+	// Parse export
+	logger.Info("Parsing Confluence export...")
+	export, err := confluenceTransformer.ParseConfluenceExport(zipReader)
+	if err != nil {
+		return fmt.Errorf("failed to parse Confluence export: %w", err)
+	}
+
+	// Run pre-flight validation
+	validator := confluence.NewValidator(team, channel)
+	if mattermostURL != "" && mattermostToken != "" {
+		validator.SetServerConfig(mattermostURL, mattermostToken)
+	}
+
+	validationResult := validator.ValidateAll(cmd.Context(), zipReader, export, confluenceTransformer.UserMapper)
+
+	// Print validation results
+	if len(validationResult.Warnings) > 0 {
+		fmt.Println("Validation warnings:")
+		for _, warning := range validationResult.Warnings {
+			fmt.Printf("  ⚠️  %s\n", warning)
+		}
+	}
+	if len(validationResult.Errors) > 0 {
+		fmt.Println("Validation errors:")
+		for _, validationErr := range validationResult.Errors {
+			fmt.Printf("  ❌ %s\n", validationErr)
+		}
+	}
+
+	if !validationResult.Valid {
+		return fmt.Errorf("pre-flight validation failed")
+	}
+
+	if validateOnly {
+		fmt.Println("✅ Pre-flight validation passed")
+		fmt.Printf("  Pages: %d\n", len(export.Pages))
+		fmt.Printf("  Comments: %d\n", len(export.Comments))
+		fmt.Printf("  Users in export: %d\n", len(export.Users))
+		return nil
+	}
+
+	// Extract attachments from ZIP before transform so paths are updated
+	if !skipAttachments && !dryRun {
+		logger.Info("Extracting attachments...")
+		if extractErr := confluenceTransformer.ExtractAttachments(zipReader, export); extractErr != nil {
+			return fmt.Errorf("attachment extraction failed: %w", extractErr)
+		}
+	}
+
+	// Transform
+	logger.Info("Transforming content...")
+	if err = confluenceTransformer.Transform(export); err != nil {
+		return fmt.Errorf("transformation failed: %w", err)
+	}
+
+	// Export (unless dry run)
+	if dryRun {
+		logger.Info("Dry run complete - no output written")
+		fmt.Printf("Dry run complete: %d wikis, %d pages, %d comments would be exported\n",
+			len(confluenceTransformer.Intermediate.Wikis),
+			len(confluenceTransformer.Intermediate.Pages),
+			len(confluenceTransformer.Intermediate.Comments))
+		return nil
+	}
+
+	logger.Info("Writing JSONL output...")
+	if err = confluenceTransformer.ExportWithManifest(outputFilePath, export); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	manifestPath := strings.TrimSuffix(outputFilePath, ".jsonl") + "-manifest.json"
+	logger.Info("Transformation succeeded!")
+	fmt.Printf("Successfully transformed Confluence export to %s\n", outputFilePath)
+	fmt.Printf("  Wikis: %d\n", len(confluenceTransformer.Intermediate.Wikis))
+	fmt.Printf("  Pages: %d\n", len(confluenceTransformer.Intermediate.Pages))
+	fmt.Printf("  Comments: %d\n", len(confluenceTransformer.Intermediate.Comments))
+	fmt.Printf("  Attachments: %d\n", confluenceTransformer.Stats.AttachmentCount)
+	if confluenceTransformer.Stats.AttachmentsExtracted > 0 {
+		fmt.Printf("  Attachments extracted: %d\n", confluenceTransformer.Stats.AttachmentsExtracted)
+	}
+	if confluenceTransformer.Stats.AttachmentsSkipped > 0 {
+		fmt.Printf("  Attachments skipped: %d\n", confluenceTransformer.Stats.AttachmentsSkipped)
+	}
+	fmt.Printf("  Manifest: %s\n", manifestPath)
+	if confluenceTransformer.Stats.UsersUnmapped > 0 {
+		fmt.Printf("  Warning: %d users could not be mapped\n", confluenceTransformer.Stats.UsersUnmapped)
+	}
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  1. Create import ZIP: cd %s && zip -r ../import.zip .\n", attachmentsDir)
+	fmt.Printf("  2. mmctl import upload import.zip\n")
+	fmt.Printf("  3. mmctl import process <import_id>\n")
 
 	return nil
 }

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -42,8 +42,8 @@ var TransformSlackCmd = &cobra.Command{
 var TransformConfluenceCmd = &cobra.Command{
 	Use:     "confluence",
 	Short:   "Transforms a Confluence export.",
-	Long:    "Transforms a Confluence Cloud CSV space export into a Mattermost Wiki/Pages JSONL file.",
-	Example: "  transform confluence --team myteam --channel docs --file confluence-export.zip --output wiki-import.jsonl",
+	Long:    "Transforms a Confluence Cloud CSV space export into a Mattermost Docs (Spaces/Pages) import bundle.",
+	Example: "  transform confluence --team myteam --file confluence-export.zip --bundle import.zip",
 	Args:    cobra.NoArgs,
 	RunE:    transformConfluenceCmdF,
 }
@@ -421,9 +421,7 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 		if confluenceTransformer.Stats.UsersUnmapped > 0 {
 			fmt.Printf("  Warning: %d users could not be mapped\n", confluenceTransformer.Stats.UsersUnmapped)
 		}
-		fmt.Printf("\nNext steps:\n")
-		fmt.Printf("  1. mmctl import upload %s\n", bundlePath)
-		fmt.Printf("  2. mmctl import process <import_id>\n")
+		printImporterNotice()
 		return nil
 	}
 
@@ -443,29 +441,44 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	if confluenceTransformer.Stats.UsersUnmapped > 0 {
 		fmt.Printf("  Warning: %d users could not be mapped\n", confluenceTransformer.Stats.UsersUnmapped)
 	}
-	fmt.Printf("\nNext steps:\n")
-	fmt.Printf("  Simplest: re-run with --bundle import.zip to get a ready-to-upload archive.\n")
-	fmt.Printf("  Or build the archive manually (the JSONL must sit at the archive root):\n")
-	fmt.Printf("    zip -r import.zip %s %s\n", outputFilePath, path.Join(attachmentsDir, confluenceAttachmentsDir))
-	fmt.Printf("  Then: mmctl import upload import.zip && mmctl import process <import_id>\n")
+	fmt.Printf("\nTip: re-run with --bundle <out.zip> to produce a single self-contained archive\n")
+	fmt.Printf("(import.jsonl at the archive root, plus import-manifest.json and data/).\n")
+	printImporterNotice()
 
 	return nil
 }
 
+// printImporterNotice explains that the emitted bundle uses the Docs v2 import
+// contract, for which no importer yet exists. In particular, Mattermost bulk
+// import (mmctl import) only accepts the v1 format and rejects these line types,
+// so we must not tell users to upload the bundle with it.
+func printImporterNotice() {
+	fmt.Printf("\nImportant: this output uses the Mattermost Docs (Spaces/Pages) v2 import\n")
+	fmt.Printf("contract. The Docs-plugin importer for it is not available yet, and\n")
+	fmt.Printf("Mattermost bulk import (mmctl import) does NOT accept this format. Do not\n")
+	fmt.Printf("upload this output via mmctl import; keep it until the Docs importer lands.\n")
+}
+
 // zipDir writes every file under srcDir into a zip archive at destPath, using
 // paths relative to srcDir so the archive contains import.jsonl,
-// import-manifest.json, and data/ at its root.
-func zipDir(srcDir, destPath string) error {
+// import-manifest.json, and data/ at its root. Each input file is closed as it
+// is written (no per-file defers accumulating across a large walk), and the zip
+// writer's Close — which flushes the central directory — is checked so a
+// finalization failure is not reported as success.
+func zipDir(srcDir, destPath string) (err error) {
 	out, err := os.Create(destPath)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	zw := zip.NewWriter(out)
-	defer zw.Close()
 
-	return filepath.Walk(srcDir, func(p string, info os.FileInfo, walkErr error) error {
+	walkErr := filepath.Walk(srcDir, func(p string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -484,10 +497,17 @@ func zipDir(srcDir, destPath string) error {
 		if openErr != nil {
 			return openErr
 		}
-		defer f.Close()
 		_, copyErr := io.Copy(w, f)
+		if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+			copyErr = closeErr
+		}
 		return copyErr
 	})
+	if walkErr != nil {
+		_ = zw.Close()
+		return walkErr
+	}
+	return zw.Close()
 }
 
 var customLogFormatter = &log.JSONFormatter{

--- a/commands/transform.go
+++ b/commands/transform.go
@@ -3,8 +3,10 @@ package commands
 import (
 	"archive/zip"
 	"fmt"
+	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -71,25 +73,24 @@ func init() {
 	if err := TransformConfluenceCmd.MarkFlagRequired("team"); err != nil {
 		panic(err)
 	}
-	TransformConfluenceCmd.Flags().StringP("channel", "c", "", "the target channel in Mattermost for the wikis")
-	if err := TransformConfluenceCmd.MarkFlagRequired("channel"); err != nil {
-		panic(err)
-	}
+	TransformConfluenceCmd.Flags().StringP("channel", "c", "", "deprecated and ignored in v2: the Space's backing channel is resolved at import time")
 	TransformConfluenceCmd.Flags().StringP("file", "f", "", "the Confluence export file (ZIP) to transform")
 	if err := TransformConfluenceCmd.MarkFlagRequired("file"); err != nil {
 		panic(err)
 	}
-	TransformConfluenceCmd.Flags().StringP("output", "o", "wiki-import.jsonl", "the output JSONL file path")
+	TransformConfluenceCmd.Flags().StringP("output", "o", "import.jsonl", "the output JSONL file path")
+	TransformConfluenceCmd.Flags().String("bundle", "", "write a single self-contained import archive (zip) at this path instead of loose files")
 	TransformConfluenceCmd.Flags().StringP("attachments-dir", "d", "data", "the path for extracted attachments")
 	TransformConfluenceCmd.Flags().StringP("user-mapping", "u", "", "CSV file mapping Confluence users to Mattermost users")
 	TransformConfluenceCmd.Flags().String("fallback-user", "", "Mattermost username to use for unmapped Confluence users")
+	TransformConfluenceCmd.Flags().Bool("require-user-mapping", false, "fail if any Confluence author is not mapped to a Mattermost user")
 	TransformConfluenceCmd.Flags().BoolP("skip-attachments", "a", false, "skip extracting attachments")
 	TransformConfluenceCmd.Flags().Int("max-depth", 10, "maximum page hierarchy depth (deeper pages are flattened)")
 	TransformConfluenceCmd.Flags().Bool("dry-run", false, "validate without writing output files")
 	TransformConfluenceCmd.Flags().Bool("validate-only", false, "only run pre-flight validation, do not transform")
 	TransformConfluenceCmd.Flags().String("mattermost-url", "", "Mattermost server URL for validation (optional)")
 	TransformConfluenceCmd.Flags().String("mattermost-token", "", "Mattermost auth token for validation (optional)")
-	TransformConfluenceCmd.Flags().Bool("create-channel", false, "include channel creation in JSONL output (for new channels)")
+	TransformConfluenceCmd.Flags().Bool("fail-on-restricted", false, "fail if any page has a View restriction (not preserved on import)")
 	TransformConfluenceCmd.Flags().Bool("debug", false, "enable debug logging")
 
 	TransformCmd.AddCommand(
@@ -211,21 +212,42 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	channel, _ := cmd.Flags().GetString("channel")
 	inputFilePath, _ := cmd.Flags().GetString("file")
 	outputFilePath, _ := cmd.Flags().GetString("output")
+	bundlePath, _ := cmd.Flags().GetString("bundle")
 	attachmentsDir, _ := cmd.Flags().GetString("attachments-dir")
 	userMappingPath, _ := cmd.Flags().GetString("user-mapping")
 	fallbackUser, _ := cmd.Flags().GetString("fallback-user")
+	requireUserMapping, _ := cmd.Flags().GetBool("require-user-mapping")
 	skipAttachments, _ := cmd.Flags().GetBool("skip-attachments")
 	maxDepth, _ := cmd.Flags().GetInt("max-depth")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	validateOnly, _ := cmd.Flags().GetBool("validate-only")
 	mattermostURL, _ := cmd.Flags().GetString("mattermost-url")
 	mattermostToken, _ := cmd.Flags().GetString("mattermost-token")
-	createChannel, _ := cmd.Flags().GetBool("create-channel")
+	failOnRestricted, _ := cmd.Flags().GetBool("fail-on-restricted")
 	debug, _ := cmd.Flags().GetBool("debug")
 
 	// Normalize team and channel names to lowercase, as Mattermost expects.
 	team = strings.ToLower(team)
 	channel = strings.ToLower(channel)
+
+	if channel != "" {
+		fmt.Println("Note: --channel is deprecated and ignored in v2; the Space's backing channel is resolved at import time.")
+	}
+
+	// When --bundle is set, stage the JSONL, manifest, and data/ into a temp dir
+	// and zip it into one self-contained archive. Otherwise keep loose files.
+	bundling := bundlePath != "" && !dryRun && !validateOnly
+	var stagingDir string
+	if bundling {
+		var mkErr error
+		stagingDir, mkErr = os.MkdirTemp("", "mmetl-confluence-bundle-")
+		if mkErr != nil {
+			return fmt.Errorf("failed to create staging dir: %w", mkErr)
+		}
+		defer os.RemoveAll(stagingDir)
+		outputFilePath = path.Join(stagingDir, "import.jsonl")
+		attachmentsDir = stagingDir
+	}
 
 	// Validate output file
 	if !dryRun {
@@ -285,11 +307,10 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 
 	// Create transformer config
 	config := &confluence.TransformConfig{
-		SkipAttachments:   skipAttachments,
-		AttachmentsDir:    attachmentsFullDir,
-		MaxDepth:          maxDepth,
-		DryRun:            dryRun,
-		AutoCreateChannel: createChannel,
+		SkipAttachments: skipAttachments,
+		AttachmentsDir:  attachmentsFullDir,
+		MaxDepth:        maxDepth,
+		DryRun:          dryRun,
 	}
 
 	// Create transformer
@@ -315,6 +336,8 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 
 	// Run pre-flight validation
 	validator := confluence.NewValidator(team, channel)
+	validator.RequireUserMapping = requireUserMapping
+	validator.FailOnRestricted = failOnRestricted
 	if mattermostURL != "" && mattermostToken != "" {
 		validator.SetServerConfig(mattermostURL, mattermostToken)
 	}
@@ -361,11 +384,16 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("transformation failed: %w", err)
 	}
 
+	spaceCount := 0
+	if confluenceTransformer.Intermediate.Space != nil {
+		spaceCount = 1
+	}
+
 	// Export (unless dry run)
 	if dryRun {
 		logger.Info("Dry run complete - no output written")
-		fmt.Printf("Dry run complete: %d wikis, %d pages, %d comments would be exported\n",
-			len(confluenceTransformer.Intermediate.Wikis),
+		fmt.Printf("Dry run complete: %d spaces, %d pages, %d comments would be exported\n",
+			spaceCount,
 			len(confluenceTransformer.Intermediate.Pages),
 			len(confluenceTransformer.Intermediate.Comments))
 		return nil
@@ -377,9 +405,31 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	manifestPath := strings.TrimSuffix(outputFilePath, ".jsonl") + "-manifest.json"
+
+	// When bundling, zip the staging dir (import.jsonl + import-manifest.json +
+	// data/) into the single archive and report that instead of loose files.
+	if bundling {
+		if zipErr := zipDir(stagingDir, bundlePath); zipErr != nil {
+			return fmt.Errorf("failed to write bundle: %w", zipErr)
+		}
+		logger.Info("Transformation succeeded!")
+		fmt.Printf("Successfully transformed Confluence export to bundle %s\n", bundlePath)
+		fmt.Printf("  Spaces: %d\n", spaceCount)
+		fmt.Printf("  Pages: %d\n", len(confluenceTransformer.Intermediate.Pages))
+		fmt.Printf("  Comments: %d\n", len(confluenceTransformer.Intermediate.Comments))
+		fmt.Printf("  Attachments: %d\n", confluenceTransformer.Stats.AttachmentCount)
+		if confluenceTransformer.Stats.UsersUnmapped > 0 {
+			fmt.Printf("  Warning: %d users could not be mapped\n", confluenceTransformer.Stats.UsersUnmapped)
+		}
+		fmt.Printf("\nNext steps:\n")
+		fmt.Printf("  1. mmctl import upload %s\n", bundlePath)
+		fmt.Printf("  2. mmctl import process <import_id>\n")
+		return nil
+	}
+
 	logger.Info("Transformation succeeded!")
 	fmt.Printf("Successfully transformed Confluence export to %s\n", outputFilePath)
-	fmt.Printf("  Wikis: %d\n", len(confluenceTransformer.Intermediate.Wikis))
+	fmt.Printf("  Spaces: %d\n", spaceCount)
 	fmt.Printf("  Pages: %d\n", len(confluenceTransformer.Intermediate.Pages))
 	fmt.Printf("  Comments: %d\n", len(confluenceTransformer.Intermediate.Comments))
 	fmt.Printf("  Attachments: %d\n", confluenceTransformer.Stats.AttachmentCount)
@@ -394,11 +444,50 @@ func transformConfluenceCmdF(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Warning: %d users could not be mapped\n", confluenceTransformer.Stats.UsersUnmapped)
 	}
 	fmt.Printf("\nNext steps:\n")
-	fmt.Printf("  1. Create import ZIP: cd %s && zip -r ../import.zip .\n", attachmentsDir)
-	fmt.Printf("  2. mmctl import upload import.zip\n")
-	fmt.Printf("  3. mmctl import process <import_id>\n")
+	fmt.Printf("  Simplest: re-run with --bundle import.zip to get a ready-to-upload archive.\n")
+	fmt.Printf("  Or build the archive manually (the JSONL must sit at the archive root):\n")
+	fmt.Printf("    zip -r import.zip %s %s\n", outputFilePath, path.Join(attachmentsDir, confluenceAttachmentsDir))
+	fmt.Printf("  Then: mmctl import upload import.zip && mmctl import process <import_id>\n")
 
 	return nil
+}
+
+// zipDir writes every file under srcDir into a zip archive at destPath, using
+// paths relative to srcDir so the archive contains import.jsonl,
+// import-manifest.json, and data/ at its root.
+func zipDir(srcDir, destPath string) error {
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	zw := zip.NewWriter(out)
+	defer zw.Close()
+
+	return filepath.Walk(srcDir, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcDir, p)
+		if relErr != nil {
+			return relErr
+		}
+		w, createErr := zw.Create(filepath.ToSlash(rel))
+		if createErr != nil {
+			return createErr
+		}
+		f, openErr := os.Open(p)
+		if openErr != nil {
+			return openErr
+		}
+		defer f.Close()
+		_, copyErr := io.Copy(w, f)
+		return copyErr
+	})
 }
 
 var customLogFormatter = &log.JSONFormatter{

--- a/commands/transform_confluence_test.go
+++ b/commands/transform_confluence_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransformConfluence_NoChannelFlag proves the Confluence command no longer
+// exposes a --channel flag. The Space's backing channel is created and owned by
+// the Docs importer; mmetl never names it.
+func TestTransformConfluence_NoChannelFlag(t *testing.T) {
+	flags := TransformConfluenceCmd.Flags()
+
+	assert.Nil(t, flags.Lookup("channel"), "--channel must not be registered on transform confluence")
+	assert.Nil(t, flags.ShorthandLookup("c"), "-c (channel shorthand) must not be registered on transform confluence")
+
+	// --team remains, and its help makes the advisory semantics explicit.
+	team := flags.Lookup("team")
+	require.NotNil(t, team, "--team must remain registered")
+	assert.Contains(t, team.Usage, "advisory", "--team help must describe it as advisory metadata")
+}

--- a/docs/cli/mmetl_transform.md
+++ b/docs/cli/mmetl_transform.md
@@ -17,5 +17,6 @@ Transforms export files into Mattermost import files
 ### SEE ALSO
 
 * [mmetl](mmetl.md)	 - ETL tool to transform the export files from different providers to be compatible with Mattermost.
+* [mmetl transform confluence](mmetl_transform_confluence.md)	 - Transforms a Confluence export.
 * [mmetl transform slack](mmetl_transform_slack.md)	 - Transforms a Slack export.
 

--- a/docs/cli/mmetl_transform_confluence.md
+++ b/docs/cli/mmetl_transform_confluence.md
@@ -26,17 +26,19 @@ mmetl transform confluence [flags]
 
 ```
   -d, --attachments-dir string    the path for extracted attachments (default "data")
-  -c, --channel string            the target channel in Mattermost for the wikis
-      --create-channel            include channel creation in JSONL output (for new channels)
+      --bundle string             write a single self-contained import archive (zip) at this path instead of loose files
+  -c, --channel string            deprecated and ignored in v2: the Space's backing channel is resolved at import time
       --debug                     enable debug logging
       --dry-run                   validate without writing output files
+      --fail-on-restricted        fail if any page has a View restriction (not preserved on import)
       --fallback-user string      Mattermost username to use for unmapped Confluence users
   -f, --file string               the Confluence export file (ZIP) to transform
   -h, --help                      help for confluence
       --mattermost-token string   Mattermost auth token for validation (optional)
       --mattermost-url string     Mattermost server URL for validation (optional)
       --max-depth int             maximum page hierarchy depth (deeper pages are flattened) (default 10)
-  -o, --output string             the output JSONL file path (default "wiki-import.jsonl")
+  -o, --output string             the output JSONL file path (default "import.jsonl")
+      --require-user-mapping      fail if any Confluence author is not mapped to a Mattermost user
   -a, --skip-attachments          skip extracting attachments
   -t, --team string               the target team in Mattermost
   -u, --user-mapping string       CSV file mapping Confluence users to Mattermost users

--- a/docs/cli/mmetl_transform_confluence.md
+++ b/docs/cli/mmetl_transform_confluence.md
@@ -10,7 +10,7 @@ Transforms a Confluence export.
 
 ### Synopsis
 
-Transforms a Confluence Cloud CSV space export into a Mattermost Wiki/Pages JSONL file.
+Transforms a Confluence Cloud CSV space export into a Mattermost Docs (Spaces/Pages) import bundle.
 
 ```
 mmetl transform confluence [flags]
@@ -19,7 +19,7 @@ mmetl transform confluence [flags]
 ### Examples
 
 ```
-  transform confluence --team myteam --channel docs --file confluence-export.zip --output wiki-import.jsonl
+  transform confluence --team myteam --file confluence-export.zip --bundle import.zip
 ```
 
 ### Options

--- a/docs/cli/mmetl_transform_confluence.md
+++ b/docs/cli/mmetl_transform_confluence.md
@@ -1,0 +1,49 @@
+---
+title: "mmetl transform confluence"
+slug: "mmetl_transform_confluence"
+description: "CLI reference for mmetl transform confluence"
+---
+
+## mmetl transform confluence
+
+Transforms a Confluence export.
+
+### Synopsis
+
+Transforms a Confluence Cloud CSV space export into a Mattermost Wiki/Pages JSONL file.
+
+```
+mmetl transform confluence [flags]
+```
+
+### Examples
+
+```
+  transform confluence --team myteam --channel docs --file confluence-export.zip --output wiki-import.jsonl
+```
+
+### Options
+
+```
+  -d, --attachments-dir string    the path for extracted attachments (default "data")
+  -c, --channel string            the target channel in Mattermost for the wikis
+      --create-channel            include channel creation in JSONL output (for new channels)
+      --debug                     enable debug logging
+      --dry-run                   validate without writing output files
+      --fallback-user string      Mattermost username to use for unmapped Confluence users
+  -f, --file string               the Confluence export file (ZIP) to transform
+  -h, --help                      help for confluence
+      --mattermost-token string   Mattermost auth token for validation (optional)
+      --mattermost-url string     Mattermost server URL for validation (optional)
+      --max-depth int             maximum page hierarchy depth (deeper pages are flattened) (default 10)
+  -o, --output string             the output JSONL file path (default "wiki-import.jsonl")
+  -a, --skip-attachments          skip extracting attachments
+  -t, --team string               the target team in Mattermost
+  -u, --user-mapping string       CSV file mapping Confluence users to Mattermost users
+      --validate-only             only run pre-flight validation, do not transform
+```
+
+### SEE ALSO
+
+* [mmetl transform](mmetl_transform.md)	 - Transforms export files into Mattermost import files
+

--- a/docs/cli/mmetl_transform_confluence.md
+++ b/docs/cli/mmetl_transform_confluence.md
@@ -27,7 +27,6 @@ mmetl transform confluence [flags]
 ```
   -d, --attachments-dir string    the path for extracted attachments (default "data")
       --bundle string             write a single self-contained import archive (zip) at this path instead of loose files
-  -c, --channel string            deprecated and ignored in v2: the Space's backing channel is resolved at import time
       --debug                     enable debug logging
       --dry-run                   validate without writing output files
       --fail-on-restricted        fail if any page has a View restriction (not preserved on import)
@@ -40,7 +39,7 @@ mmetl transform confluence [flags]
   -o, --output string             the output JSONL file path (default "import.jsonl")
       --require-user-mapping      fail if any Confluence author is not mapped to a Mattermost user
   -a, --skip-attachments          skip extracting attachments
-  -t, --team string               the target team in Mattermost
+  -t, --team string               advisory destination team recorded in the bundle; the Docs import request selects the actual target team
   -u, --user-mapping string       CSV file mapping Confluence users to Mattermost users
       --validate-only             only run pre-flight validation, do not transform
 ```

--- a/docs/confluence-jsonl-contract.md
+++ b/docs/confluence-jsonl-contract.md
@@ -29,6 +29,22 @@ never globally — so IDs cannot collide across Confluence instances.
 One bundle = one Space. A CSV export always covers a single space; a multi-space
 export is rejected at transform time.
 
+## Target team (advisory)
+
+The `team` values carried by the bundle — `target.team` in the manifest and the
+`team` field on `space`, `page`, and `resolve_space_placeholders` lines — are
+**advisory destination metadata** recorded for audit. They reflect
+producer/operator intent only.
+
+The **import request's target team is authoritative**: the Docs importer selects
+the actual destination team and must never route an import from the bundle
+value. A mismatch between the bundle `team` and the requested team is recorded
+as a warning/audit detail, not an error, and does not redirect the import.
+
+The bundle never carries or selects the Space backing channel. The Docs plugin
+creates and owns the Space's `ChannelTypeSpace` backing channel in the requested
+team at import time; there is no channel field in the JSONL or the manifest.
+
 ## Line types
 
 Lines are newline-delimited JSON objects, each with a `type`. They appear in
@@ -90,6 +106,22 @@ time from the import request.
 ```
 
 `is_resolved` is omitted when false.
+
+`page_comment` records are consumed downstream as **Mattermost posts in the
+Space's `ChannelTypeSpace` backing channel**, not as plugin-owned comment rows:
+
+- A top-level Confluence page comment (no
+  `parent_comment_import_source_id`) becomes a **root post** carrying the local
+  Docs page ID and source metadata in its props.
+- A reply resolves its `parent_comment_import_source_id` through the import
+  job's comment mapping and is created in the corresponding Mattermost thread.
+  This is how replies/threads are reconstructed.
+- `page_import_source_id` ties every comment to its owning page;
+  `confluence_author_account_id` (in props) carries attribution; and the inline
+  anchor/resolved metadata is preserved in props.
+
+mmetl does not create, identify, discover, or validate the Space backing
+channel — the Docs importer owns it.
 
 ### `resolve_space_placeholders`
 

--- a/docs/confluence-jsonl-contract.md
+++ b/docs/confluence-jsonl-contract.md
@@ -1,0 +1,117 @@
+# Confluence → Mattermost Docs JSONL contract (v2)
+
+`mmetl transform confluence` emits a JSONL bundle for the Mattermost Docs
+(Spaces/Pages) importer. This document describes the **v2** contract. There is
+no shipped consumer of an earlier version, so no backward-compatibility shim
+exists.
+
+## Bundle layout
+
+With `--bundle <out.zip>` the tool produces one self-contained archive:
+
+```text
+import.jsonl
+import-manifest.json
+data/<page-id>/<attachment>
+```
+
+Without `--bundle`, the same files are written loose (`--output` for the JSONL,
+`--attachments-dir` for `data/`, and `<output>-manifest.json` alongside).
+
+## Source namespace
+
+Entity source IDs (numeric page IDs, space keys) are **bare** and interpreted
+within the bundle's source namespace. The namespace is carried **once**, on the
+`version` line, and mirrored in the manifest (`source.organization_id`,
+`source.space_key`). Importers must scope every source-ID lookup to the job —
+never globally — so IDs cannot collide across Confluence instances.
+
+One bundle = one Space. A CSV export always covers a single space; a multi-space
+export is rejected at transform time.
+
+## Line types
+
+Lines are newline-delimited JSON objects, each with a `type`. They appear in
+this order: `version`, `space`, `page`×N (parents before children),
+`page_comment`×N (parents before children), `resolve_space_placeholders`.
+
+### `version`
+
+```json
+{"type":"version","version":2,"source":{"organization_id":"org-123","space_key":"DOCS"}}
+```
+
+`source` is omitted only when neither an organization id nor a space key is known.
+
+### `space`
+
+```json
+{"type":"space","space":{"team":"myteam","title":"Docs","description":"Migrated from Confluence space: DOCS","props":{"import_source_id":"DOCS"}}}
+```
+
+The Space's backing channel is **not** in the contract — it is resolved at import
+time from the import request.
+
+### `page`
+
+```json
+{"type":"page","page":{
+  "team":"myteam",
+  "space_import_source_id":"DOCS",
+  "user":"jdoe",
+  "title":"Home",
+  "content":"<TipTap JSON>",
+  "parent_import_source_id":"100",
+  "create_at":1704106800000,
+  "update_at":1704193200000,
+  "props":{"import_source_id":"101","import_source":"confluence","confluence_author_account_id":"aaid1"},
+  "attachments":[{"path":"101/diagram.png","props":{"import_source_id":"300"}}]
+}}
+```
+
+- `content` is validated as JSON before writing; a converter that yields invalid
+  JSON falls back to a raw-HTML code block (counted as a warning).
+- `update_at` is omitted when the source has no modification date.
+- `parent_import_source_id`, `attachments`, and `update_at` are omitted when empty.
+
+### `page_comment`
+
+```json
+{"type":"page_comment","page_comment":{
+  "page_import_source_id":"101",
+  "parent_comment_import_source_id":"200",
+  "user":"jdoe",
+  "content":"markdown text",
+  "create_at":1704625200000,
+  "update_at":1704625200000,
+  "is_resolved":true,
+  "props":{"import_source_id":"201","import_source":"confluence","inline_anchor":{"anchor_id":"uuid","text":"selected"}}
+}}
+```
+
+`is_resolved` is omitted when false.
+
+### `resolve_space_placeholders`
+
+```json
+{"type":"resolve_space_placeholders","resolve_space_placeholders":{"team":"myteam","space_import_source_id":"DOCS"}}
+```
+
+Emitted last; triggers space-scoped resolution of cross-page link placeholders
+after all pages exist.
+
+## Limits (Docs)
+
+The producer warns (does not drop) when a page exceeds a Docs storage cap:
+
+| Field       | Cap    |
+|-------------|--------|
+| Body        | 2 MiB  |
+| SearchText  | 2 MiB  |
+| Props       | 64 KiB |
+
+## Restrictions
+
+Page view restrictions are **detected, not imported**. Restricted pages are
+listed in a loud warning and in the manifest's `restricted_pages`. Use
+`--fail-on-restricted` to make an unresolved restriction a hard error.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
+	golang.org/x/net v0.48.0
 	golang.org/x/text v0.34.0
 )
 
@@ -94,7 +95,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/image v0.32.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -1,5 +1,15 @@
 # Confluence Cloud CSV-Export Support for mmetl
 
+> **Status:** Implemented by `2ca9cf1` (`feat: Confluence Cloud CSV export
+> support`). This document is retained as the parser implementation record. The
+> emitted Docs contract and import architecture are superseded by
+> [confluence-docs-contract-alignment.md](confluence-docs-contract-alignment.md)
+> and
+> [confluence-jsonl-docs-plugin-integration.md](confluence-jsonl-docs-plugin-integration.md).
+> Mattermost core Space-channel support subsequently landed in
+> [mattermost#37321](https://github.com/mattermost/mattermost/pull/37321); the
+> Docs import job remains the outstanding consumer dependency.
+
 ## Summary
 
 Confluence Cloud's space export format has changed from a single self-describing
@@ -431,7 +441,8 @@ what adding it would take. Two structural facts frame the whole list:
 > are security-relevant, not cosmetic — a view-restricted Confluence page was
 > deliberately hidden from most of the org. Because v1 drops restrictions and has
 > no per-page ACL target, **every restricted page imports fully visible to
-> everyone in the target channel** — an over-exposure of previously-confidential
+> everyone who is a member of the imported Space** — an over-exposure of
+> previously-confidential
 > content. We are accepting this for v1 and will handle it later. The eventual fix
 > has two parts: (1) **detect + warn/exclude** restricted pages so a human decides,
 > and (2) **map restrictions to an ACL** (channel visibility/membership, or a
@@ -461,10 +472,12 @@ anchors, labels (as `import_labels` prop), cross-page links
 
 ## Risks & Open Questions
 
-1. **Server-side Wiki/Pages import must exist** to consume `wiki`/`page`/
-   `page_comment` JSONL — these are not stock Mattermost bulk-import line types.
-   This is the true gating dependency and is *independent* of this parser work.
-   **Confirm the import consumer exists before shipping.**
+1. **A Docs plugin import job must exist** to consume the versioned
+   `space`/`page`/`page_comment` bundle — these are not stock Mattermost
+   bulk-import line types. Core support for the opaque `ChannelTypeSpace`
+   backing channel landed in mattermost#37321, but it does not parse Docs JSONL.
+   The plugin import consumer remains the true gating dependency and is
+   *independent* of this parser work.
 2. **Attachment layout unverified** (sample has none). Item 6 stubs the seam;
    completing it needs an export containing files.
 3. **`links.csv` → downstream shape**: verify what `links.go`/

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -115,9 +115,10 @@ Confirmed headers:
 `user_key → aaid` (Atlassian account ID). The XML export path put the **account
 ID** directly into `CreatedBy`, and `resolveUsername`/the user-supplied mapping
 CSV both key on account ID. So the CSV parser must translate `user_key → aaid`
-and store the **aaid** in `CreatedBy`/`UpdatedBy` and as the `export.Users` map
-key, so the account-ID-keyed `--user-mapping` CSV resolves with zero downstream
-change (see item 5).
+and store the **aaid** in `CreatedBy`/`UpdatedBy`, keying `export.Users` by both
+the aaid and the user_key (see item 5). Note body **@-mentions embed the account
+ID** (`<ri:user ri:account-id="…">`, verified — matches the `aaid` column), so
+aaid keying is what makes mentions resolve, not just the external mapping.
 
 ## Proposed Approach
 
@@ -265,13 +266,27 @@ Either choice keeps shared code unchanged **as long as it is applied
 consistently**; the difference is which key reaches the external `--user-mapping`
 CSV via `UserMapper`.
 
-**Decision: translate `user_key → aaid` in the parser and store the `aaid`.**
-Rationale: the user-supplied `--user-mapping` CSV is keyed on Atlassian account
-ID (`UserMapper.byAccountID`, `user_mapper.go`) — orgs build that CSV from
-Atlassian account IDs, not from Confluence's internal `user_key`. Storing the
-aaid makes the realistic mapping-by-account-ID path work; `resolveUsername`/
-`user_mapper.go` need no change. Populate
-`export.Users[aaid] = &ConfluenceUser{AccountID: aaid, ...}`.
+**Decision: store the `aaid` as the identity, and key `export.Users` by BOTH the
+`aaid` and the `user_key` (alias to the same struct).**
+- `CreatedBy`/`UpdatedBy` = `aaid`, so `resolveUsername` and the external
+  account-ID-keyed `--user-mapping` CSV (`UserMapper.byAccountID`, `user_mapper.go`)
+  resolve — orgs build that CSV from Atlassian account IDs, not Confluence's
+  internal `user_key`, so aaid is the realistic key.
+- Populate `export.Users[aaid] = u` **and** `export.Users[user_key] = u` (same
+  `*ConfluenceUser{AccountID: aaid, ...}`). This costs nothing and closes the
+  mention-resolution gap below.
+
+**Why both keys — mention resolution (reviewer catch, verified).** Body mentions
+become `{{CONF_USER:<key>}}` placeholders (`links.go:145`) that
+`ResolveUserMentions`/`resolveUserMention` (`links.go:270,291`) resolve by looking
+`<key>` up directly in `export.Users`. The capture regex accepts **both**
+`ri:account-id` and `ri:userkey`. In the sample, **all 100 mentions use
+`<ri:user ri:account-id="…">` and those account-ids exactly match the `aaid`
+column** — so an aaid-keyed map is *required* for Cloud CSV mentions to resolve
+(a user_key-only key would miss every mention). Adding the `user_key` alias also
+covers any `ri:userkey` markup (Server/DC-origin content) without a `links.go`
+change — keeping this **parser-only**. (The CSV reader un-doubles the `""`-escaped
+quotes in the body field, so the post-parse markup is normal `ri:account-id="…"`.)
 
 Important nuance (from advisor): `user_mapping.csv` has **no email column** and
 its `username`/`aaid` are opaque IDs, so Confluence's own mapping yields no
@@ -279,10 +294,10 @@ human-readable names. The external `--user-mapping` CSV is therefore the
 *primary* human-resolution mechanism for CSV exports; unmapped users fall through
 to `resolveUsername`'s `confluence_user_<id>` last resort exactly as today.
 
-> Open decision for reviewer: the domain advisor instead recommended storing the
-> raw `user_key`. That only works if the org keys their `--user-mapping` CSV on
-> Confluence internal user_keys (which they typically don't have). Flagging for
-> confirmation, but the plan proceeds with **aaid** as the safer default.
+> Resolved: the earlier aaid-vs-user_key tension (advisor preferred raw
+> `user_key`) is moot once `export.Users` is keyed by **both** — external mapping
+> works via the aaid, and both mention placeholder forms resolve. Identity stored
+> on the page/comment stays the aaid.
 
 ### 6. Attachments (known unknown — design the seam, flag the risk)
 
@@ -341,7 +356,8 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
   blank `spaceid`, plus the current v4), a draft row, the space homepage
   ("Overview"), a page with a parent, the inline-comment `contentproperties` rows
   (`inline-marker-ref`/`inline-original-selection`/`status=resolved`),
-  `user_mapping`, and one storage-format body exercising a macro/`ac:layout`.
+  `user_mapping`, and one storage-format body exercising a macro/`ac:layout` and a
+  `<ri:user ri:account-id="…">` mention.
 - **Unit tests** (`csv_parser_test.go`):
   - gzip-magic sniff: gzipped vs plain `.gz` both parse.
   - a non-CSV/unrecognized zip returns the clear "unsupported export" error.
@@ -349,8 +365,11 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
     → `HistoricalPageIDs`; draft skipped.
   - hierarchy: `parentid`/homepage produce the expected tree + root.
   - comment threading via `parentcommentid`.
-  - user_key→aaid: `CreatedBy` is the aaid; `export.Users` keyed by aaid;
-    end-to-end `resolveUsername` with a supplied mapping CSV resolves correctly.
+  - user_key→aaid: `CreatedBy` is the aaid; `export.Users` keyed by **both** aaid
+    and user_key; end-to-end `resolveUsername` with a supplied mapping CSV resolves.
+  - **mention resolution**: a body `<ri:user ri:account-id="<aaid>">` resolves to
+    `@user` (aaid key path); a synthetic `<ri:user ri:userkey="<user_key>">`
+    resolves via the alias — neither leaves a `{{CONF_USER:…}}` placeholder.
   - bodies: storage format lands verbatim in `Content`; a full parse→transform→
     export produces valid `wiki`/`page`/`page_comment` JSONL lines.
   - inline anchors read directly from `contentproperties` (no HTML scraping);

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -1,0 +1,380 @@
+# Confluence Cloud CSV-Export Support for mmetl
+
+## Summary
+
+Confluence Cloud's space export format has changed from a single self-describing
+`entities.xml` file to a **relational dump of ~40 CSV tables**. The existing
+mmetl Confluence overlay only parses the legacy XML. This plan adds a **CSV
+parser path** that emits the *same* `ConfluenceExport` struct the XML parser
+produces, so every downstream stage — storage-format→TipTap conversion,
+hierarchy, links, user mapping, export, manifest, validation — is reused
+**unchanged**.
+
+The change is deliberately confined to the parser input layer plus a small
+user-identity indirection. It also folds in the one-time work of porting the
+uncommitted overlay onto the current `mmetl` `master`.
+
+### Decisive fact that makes this cheap
+
+Page/comment bodies in `bodycontent.csv` (`body` column) are **still Confluence
+Storage Format** (`<ac:structured-macro>`, `<ac:layout>`, `<ri:url>`,
+`<ac:adf-extension>`, `<ac:emoticon>`, …). Verified against the sample export.
+Therefore `tiptap_converter.go` (the 33 KB, highest-risk component) and
+everything downstream is untouched. Only *how we populate* `ConfluenceExport`
+changes, not the struct or its consumers.
+
+## Goal / Non-Goals
+
+**Goals**
+- `mmetl transform confluence -f <csv-export.zip>` works on the new Cloud CSV export.
+- Auto-detect XML vs CSV vs HTML; keep the legacy XML path fully working.
+- Emit identical `ConfluenceExport` semantics from CSV so no downstream code changes.
+- Land the overlay on current `master` as a clean, committed, tested feature.
+- Portable, committed test fixture (current tests hardcode a colleague's local path).
+
+**Non-Goals**
+- No changes to `tiptap_converter.go`, `export.go`, `hierarchy.go`, `links.go`,
+  `manifest.go`, `intermediate.go` transform logic (beyond what item 5 requires).
+- No server-side Wiki/Pages import work — that is a separate, gating dependency
+  (see Risks). This plan produces JSONL; consuming it is out of scope.
+- Not attempting to fully support blogposts, Team Calendars, whiteboards, or
+  data-classification tables (empty in the sample; parse defensively, ignore).
+
+## Current State (grounded references)
+
+Overlay lives **uncommitted** in a bundle, not yet in the repo:
+- Patch: `~/Downloads/confluence-import-bundle/code-changes/mmetl/our-changes.patch`
+  (touches `commands/transform.go` +239, `go.mod`), pinned to upstream `b87a10c`.
+- Service package (14 files): `~/Downloads/confluence-import-bundle/mmetl-confluence-service/*.go`.
+
+Key seams (bundle paths):
+- `parser.go:19` `ParseConfluenceExport` — indexes zip files, then branches:
+  `entities.xml` present → `parseEntitiesXML` (`parser.go:69`); else `parseHTMLExport`
+  (`parser.go:492`). **This is where the CSV branch is added.**
+- `types.go` — `ConfluenceExport` (target struct) and `ConfluencePage`/`ConfluenceComment`/
+  `ConfluenceUser`/`ConfluenceAttachment`. **No changes needed.**
+- `intermediate.go:409` `resolveUsername(accountID, export)` — looks up
+  `export.Users[accountID]` for email/username, then tries `UserMapper` by
+  email→accountID→username, then heuristics. **Drives the user-key decision (item 5).**
+- `user_mapper.go` — user-supplied mapping CSV keyed by `ConfluenceAccountID`
+  (`GetUsername`), email, username. `ResolveUser(accountID,email,username)`.
+- `attachments.go:17` `attachmentPathRegex = ^attachments/(\d+)/(\d+)/(\d+)$` —
+  XML-export on-disk layout. **Unverified for CSV exports (item 6).**
+- `validation.go:65` `ValidateExportFormat` — **unconditionally requires
+  `entities.xml`** and appends a fatal error otherwise; called from `ValidateAll`
+  (`validation.go:212`), which the ported command runs *after* parsing and then
+  hard-aborts on `!Valid` (`our-changes.patch:202,218`). **This blocks every CSV
+  export and must be fixed (item 7).**
+- `confluence_test.go:19` — `TestParseRealExport` reads a hardcoded local zip and
+  `t.Skip`s if absent (not CI-portable).
+
+Divergence blocking a clean `git apply` onto `master`:
+- `commands/transform.go`: `master` added the `--bot-owner` flag + bot-export path
+  (commit history) after the patch's base; context lines won't match.
+- `go.mod`: `master` has `golang.org/x/text v0.34.0` (patch assumes `v0.32.0`) and
+  the `golang.org/x/net` line has moved. The patch promotes `x/net` from indirect
+  to direct.
+
+### Sample export ground truth (verified)
+
+- `~/Downloads/Confluence-export-mattermost.atlassian.net-~5d3eaa4376cb3e0d9d31cf8e/`
+- `exportDescriptor.properties(.gz)`: `exportFormat=csv`, `exportType=space`,
+  `source=cloud`, `spaceKey=~5d3eaa…`, `backupAttachments=true`,
+  `inlineTasksFileIncluded=true`. Java `.properties` (`#comment` first line, `k=v`).
+- **`.gz` files are PLAIN TEXT in this sample** (first bytes are `contentid,…`, not
+  gzip magic `1f 8b`). `bodycontent.csv` has no `.gz` suffix at all. → must sniff
+  the 2-byte gzip magic and decompress conditionally, ignoring the extension.
+- First row of every CSV is a **header** with the exact column names below.
+
+Confirmed headers:
+- `content.csv`: `contentid,hibernateversion,contenttype,title,lowertitle,version,creator,creationdate,lastmodifier,lastmoddate,versioncomment,prevver,content_status,pageid,spaceid,child_position,parentid,messageid,pluginkey,pluginver,parentccid,draftpageid,draftspacekey,drafttype,draftpageversion,parentcommentid,username,navigationtype`
+- `bodycontent.csv`: `bodycontentid,body,contentid,bodytypeid` (bodytypeid: 2=page/comment storage, 0=space desc, 1=custom property)
+- `spaces.csv`: `spaceid,spacename,spacekey,spacedescid,homepage,creator,…,spacetype,spacestatus,lowerspacekey`
+- `user_mapping.csv`: `user_key,username,lower_username,aaid`
+- `contentproperties.csv`: `propertyid,propertyname,stringval,longval,dateval,contentid`
+- `links.csv`: `linkid,destpagetitle,destspacekey,contentid,creator,…,lowerdestpagetitle,lowerdestspacekey`
+
+**User-identity reality (decisive for item 5):** in `content.csv`, `creator`/
+`lastmodifier` hold the internal **`user_key`**. `user_mapping.csv` maps
+`user_key → aaid` (Atlassian account ID). The XML export path put the **account
+ID** directly into `CreatedBy`, and `resolveUsername`/the user-supplied mapping
+CSV both key on account ID. So the CSV parser must translate `user_key → aaid`
+and store the **aaid** in `CreatedBy`/`UpdatedBy` and as the `export.Users` map
+key — reproducing XML-path semantics with zero downstream change.
+
+## Proposed Approach
+
+Add `services/confluence/csv_parser.go` implementing `parseCSVExport(zipReader,
+export)`, selected by a new detection step in `ParseConfluenceExport`. It loads
+the relevant tables into row structs, joins them, applies current-vs-historical
+filtering, and populates the existing `ConfluenceExport`. All other files are
+reused as-is except a tiny, optional touch to attachment handling (item 6).
+
+### 1. Port the overlay onto `master` (prerequisite)
+
+- Copy `~/Downloads/confluence-import-bundle/mmetl-confluence-service/*.go` →
+  `services/confluence/` (14 files, including `confluence_test.go`).
+- **Manually re-apply** the `commands/transform.go` half of `our-changes.patch`
+  (do not `git apply`): add `TransformConfluenceCmd`, its flags, its
+  `transformConfluenceCmdF`, and the `slackAttachmentsDir`/`confluenceAttachmentsDir`
+  const split — preserving `master`'s `--bot-owner` additions. Reconcile by hand.
+- `go.mod`: add the `confluence` package's real imports, then `go mod tidy` to let
+  it promote `golang.org/x/net` to a direct dependency naturally. Do **not**
+  hand-edit versions to match the stale patch (keep `x/text v0.34.0`).
+- Gate: `go build ./...` succeeds; `mmetl transform confluence --help` lists flags.
+- Commit this as an isolated "port overlay" commit before touching the parser.
+
+### 2. Format detection in `ParseConfluenceExport` (`parser.go:42-53`)
+
+Extend the existing branch. Priority order:
+1. If `exportDescriptor.properties` present and parses `exportFormat=csv` → `parseCSVExport`.
+   (Prefer this single-line signal over "presence of `content.csv`" — a multi-space
+   or full-site CSV export may lay files out differently; `exportFormat=csv` is stable.)
+   Fall back to `content.csv`/`content.csv.gz` presence only if the descriptor is absent.
+2. Else if `entities.xml` present → `parseEntitiesXML` (unchanged).
+3. Else → `parseHTMLExport` (unchanged).
+
+Add a `readMaybeGzipCSV(f *zip.File) ([][]string, error)` helper: open, peek 2
+bytes, wrap in `gzip.Reader` iff magic == `0x1f 0x8b`, else read plain; parse
+with `encoding/csv` (`FieldsPerRecord=-1`, header row → column-index map by name
+so we are resilient to column reordering).
+
+### 3. Table loading + joins (`csv_parser.go`)
+
+Load into a small in-memory model keyed by `contentid`. Steps, in dependency order:
+
+1. **`exportDescriptor.properties`** → space key, `exportFormat`, `backupAttachments`.
+2. **`spaces.csv`** → `SpaceInfo{Key,Name,Description,HomePageID}`; set
+   `export.Spaces[key]` and legacy `export.SpaceKey/SpaceName`. Populate
+   `HomePageID` **directly from the explicit `homepage` column** (verified:
+   `homepage=2317516965` → the "Overview" page). Do *not* infer root by
+   `parentid==""` — historical/draft rows also have empty `parentid`.
+   `spacedescid` = space-description content row.
+3. **`user_mapping.csv`** (`user_key,username,lower_username,aaid`) → build a
+   `userKey → aaid` translation map. See item 5 for how the identity key is used.
+   Note: this table has **no email column**, and in the sample `username`/`aaid`
+   are themselves opaque account IDs, not human-readable — so it is a translation
+   table only, not a source of display names/emails.
+4. **`content.csv`** → iterate rows, switch on `contenttype`:
+   - `PAGE`: build `ConfluencePage` (translate `creator`/`lastmodifier` per item 5).
+     Apply the **visible-page filter**: `content_status=current` AND `spaceid`
+     non-empty → real page. **`content_status=current` is set on every version
+     row, not just the live one** (verified: 11 of 22 "current" PAGE rows are
+     actually historical, with blank `spaceid`), so `content_status` alone is NOT
+     a sufficient discriminator — `spaceid` presence is the real signal.
+   - `COMMENT`: build `ConfluenceComment` with `PageID=pageid`,
+     `ParentID=parentcommentid` (flat, page-scoped threading — verified). Reuse the
+     existing PageID-backfill-from-parent loop (`intermediate.go:330-337`) for
+     defensiveness.
+     Also carry `ParentID=parentid`, `SpaceKey`, `Version`, and
+     `Position=child_position` — `child_position` is an **opaque position-tree
+     key**, not a compact rank (verified values span `745`…`381695930`); it sorts
+     monotonically so `comparePageOrder` (`hierarchy.go:196`) works unchanged —
+     pass it through as-is, do not renumber or infer depth from magnitude.
+     (`content.csv` also has a trailing `username` column distinct from
+     `creator`/`lastmodifier`; it is empty in all sampled rows — **ignore it**,
+     do not use it for identity.)
+   - `SPACEDESCRIPTION`: attach to space description body.
+   - `CUSTOM`: **drop** (plugin content-property storage; ~74% of rows). Note some
+     CUSTOM rows carry a `pageid` FK (e.g. `content-appearance-draft`) — do not
+     mistake that for a child/version/attachment relationship.
+5. **Historical/draft resolution (`prevver`)** — verified empirically:
+   **`prevver` points DIRECTLY at the canonical current `contentid`, in one hop —
+   it does NOT chain version-to-version.** All historical rows of a page share the
+   same `prevver` value (the live page's id). So:
+   - `HistoricalPageIDs[id] = true` for every `PAGE` row with
+     `content_status=current && spaceid=="" ` (these all carry a non-empty `prevver`).
+     Attach nothing to them; resolve to the canonical page via `prevver` in one step
+     (no chain-walking).
+   - `content_status=draft` rows also use `prevver` (pointing at the page they draft)
+     — skip them; do **not** conflate drafts with historical versions.
+6. **`bodycontent.csv`** (`bodycontentid,body,contentid,bodytypeid`) → join **by
+   `contentid`** (not the `bodycontentid` PK). **Index bodies into a
+   `map[contentid]body` first, then look up per page/comment** to avoid an O(n²)
+   join. Store in `export.BodyContents`; set `page.Content` / `comment.Content`
+   (storage format, verbatim). `bodytypeid` 2 = page/comment storage body.
+7. **`contentproperties.csv`** (`propertyid,propertyname,stringval,longval,dateval,contentid`)
+   → index by `contentid`. **Inline-comment anchors are first-class CSV properties
+   here — no HTML scraping needed** (unlike the XML path's
+   `extractInlineCommentAnchors`): read `inline-marker-ref` and
+   `inline-original-selection` (the actual highlighted text) straight off the
+   comment's own `contentid` rows, and `status=resolved` for `IsResolved`. This is
+   simpler and more robust than the XML path — the `ContentPropertyIDs` indirection
+   is unnecessary for CSV. Skip `extractInlineCommentAnchors` on the CSV path.
+8. **`links.csv`** → per source `contentid`, pre-extracted links
+   (`destspacekey`/`destpagetitle` or URL). Feed whatever `links.go`/
+   `resolve_wiki_placeholders` expects (verify the existing shape and adapt the
+   emit, not the consumer).
+9. **`label.csv` + `content_label.csv`** → join labels onto pages (`labelabletype=CONTENT`).
+10. **`content_perm_set.csv` + `content_perm.csv`** → `PageRestrictions` (types.go:80),
+    joined `content_perm.cps_id → content_perm_set.id → content_perm_set.content_id`.
+    The `username` column in `content_perm` actually holds **`user_key`** values
+    (verified) — key restrictions off `user_key`; do not look them up in
+    `user_mapping.username`.
+
+### 4. Current-vs-historical / draft filtering
+
+Applied inline during `content.csv` parsing (items 4–5 above); this is the
+consolidated rule set:
+- Visible page: `contenttype=PAGE && content_status=current && spaceid != ""`.
+- Historical version: `PAGE/current` with `spaceid=="" && prevver != ""` →
+  `HistoricalPageIDs`. Do **not** emit as a page; downstream already skips these.
+- Draft: `content_status=draft` → skip.
+- Comments: current unless in `HistoricalCommentIDs`; thread via `parentcommentid`.
+
+### 5. User-key indirection (in the parser only — no shared-code changes)
+
+`content.csv` `creator`/`lastmodifier` hold the internal **`user_key`**;
+`user_mapping.csv` maps `user_key → aaid` (Atlassian account ID). Whatever string
+the parser writes into `CreatedBy`/`UpdatedBy` and uses as the `export.Users` map
+key is what every downstream consumer keys off (`resolveUsername`
+`intermediate.go:409`; mention resolution `links.go:272`; restriction lookups).
+Either choice keeps shared code unchanged **as long as it is applied
+consistently**; the difference is which key reaches the external `--user-mapping`
+CSV via `UserMapper`.
+
+**Decision: translate `user_key → aaid` in the parser and store the `aaid`.**
+Rationale: the user-supplied `--user-mapping` CSV is keyed on Atlassian account
+ID (`UserMapper.byAccountID`, `user_mapper.go`), which the XML path already
+produced — orgs build that CSV from Atlassian account IDs, not from Confluence's
+internal `user_key`. Storing the aaid makes the realistic mapping-by-account-ID
+path work and matches XML semantics; `resolveUsername`/`user_mapper.go` need no
+change. Populate `export.Users[aaid] = &ConfluenceUser{AccountID: aaid, ...}`.
+
+Important nuance (from advisor): `user_mapping.csv` has **no email column** and
+its `username`/`aaid` are opaque IDs, so Confluence's own mapping yields no
+human-readable names. The external `--user-mapping` CSV is therefore the
+*primary* human-resolution mechanism for CSV exports; unmapped users fall through
+to `resolveUsername`'s `confluence_user_<id>` last resort exactly as today.
+
+> Open decision for reviewer: the domain advisor instead recommended storing the
+> raw `user_key`. That only works if the org keys their `--user-mapping` CSV on
+> Confluence internal user_keys (which they typically don't have). Flagging for
+> confirmation, but the plan proceeds with **aaid** as the safer default.
+
+### 6. Attachments (known unknown — design the seam, flag the risk)
+
+The sample has **zero** attachments (no `attachments/` directory present at all,
+despite `backupAttachments=true`), so the CSV export's on-disk attachment layout
+is **unverified** — no authoritative Atlassian doc confirms the path convention
+for space CSV exports. `attachments.go:15` assumes
+`attachments/{pageID}/{attachmentID}/{version}`. Plan:
+- Parse the attachment metadata (likely `contenttype=ATTACHMENT` rows in
+  `content.csv`, or a dedicated table in exports that contain files — TBD) into
+  `export.Attachments[pageID]`.
+- Leave `ExtractAttachments` as-is for now; add a `// TODO(csv-attachments):
+  layout unverified` note and log a clear warning if `backupAttachments=true` but
+  no attachment files match the regex.
+- **Explicitly out of scope to finish** until an export *with* attachments is
+  available. Track as a follow-up.
+
+### 7. Pre-flight validation must accept CSV (blocking bug)
+
+`ValidateExportFormat` (`validation.go:65`) unconditionally fails when
+`entities.xml` is absent, and the ported `transformConfluenceCmdF` calls
+`ValidateAll` after parsing and returns `"pre-flight validation failed"` when
+`!Valid` (`our-changes.patch:202,218`). **A CSV export has no `entities.xml`, so
+without this fix every CSV run aborts after a successful parse** — directly
+defeating acceptance criterion #1. Fix: make `ValidateExportFormat` treat
+`exportDescriptor.properties` with `exportFormat=csv` (or presence of
+`content.csv`/`content.csv.gz`) as an equally valid format signal, mirroring the
+detection logic in item 2. Keep the `entities.xml` acceptance for the XML path.
+
+## Files to Change / Add
+
+| File | Change |
+|------|--------|
+| `services/confluence/*.go` (14) | **Add** — port from bundle (item 1) |
+| `commands/transform.go` | **Edit** — manually merge `transform confluence` subcommand onto master's `--bot-owner` version |
+| `go.mod` / `go.sum` | **Edit** — `go mod tidy` (x/net becomes direct) |
+| `services/confluence/parser.go` | **Edit** — add CSV detection branch in `ParseConfluenceExport` |
+| `services/confluence/csv_parser.go` | **Add** — `parseCSVExport` + table loaders + joins + gzip sniff |
+| `services/confluence/csv_parser_test.go` | **Add** — unit tests over a committed fixture |
+| `services/confluence/testdata/csv-export-min.zip` | **Add** — small committed CSV-export fixture |
+| `services/confluence/confluence_test.go` | **Edit** — parametrize fixture path, stop hardcoding a local path |
+| `services/confluence/attachments.go` | **Edit** — add `// TODO(csv-attachments)` + warn when `backupAttachments=true` but no files match the regex (item 6) |
+| `services/confluence/validation.go` | **Edit** — `ValidateExportFormat` must accept the CSV signal, not only `entities.xml` (item 7 — blocking) |
+| `docs/cli/` | **Regen** — `make docs` (new subcommand docs) |
+
+No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
+`export.go`, `hierarchy.go`, `links.go` (consumer), `manifest.go`, `user_mapper.go`.
+(`validation.go` **does** change — see item 7.)
+
+## Testing Strategy
+
+- **Committed fixture**: build `testdata/csv-export-min.zip` from **exact excerpts
+  of the real sample CSVs** (not synthetic) — the non-obvious behaviors are easy to
+  get subtly wrong. Include specifically: the "PV React Summit Business Case"
+  version triad (historical rows v1–v3 all with `prevver`→ the v4 canonical id +
+  blank `spaceid`, plus the current v4), a draft row, the space homepage
+  ("Overview"), a page with a parent, the inline-comment `contentproperties` rows
+  (`inline-marker-ref`/`inline-original-selection`/`status=resolved`),
+  `user_mapping`, and one storage-format body exercising a macro/`ac:layout`.
+- **Unit tests** (`csv_parser_test.go`):
+  - gzip-magic sniff: gzipped vs plain `.gz` both parse.
+  - format detection picks CSV over XML/HTML given `exportFormat=csv`.
+  - visible-page filter: current+spaceid kept; historical (blank spaceid+prevver)
+    → `HistoricalPageIDs`; draft skipped.
+  - hierarchy: `parentid`/homepage produce the expected tree + root.
+  - comment threading via `parentcommentid`.
+  - user_key→aaid: `CreatedBy` is the aaid; `export.Users` keyed by aaid;
+    end-to-end `resolveUsername` with a supplied mapping CSV resolves correctly.
+  - bodies: storage format lands verbatim in `Content`; a full parse→transform→
+    export produces valid `wiki`/`page`/`page_comment` JSONL lines.
+  - inline anchors read directly from `contentproperties` (no HTML scraping);
+    `IsResolved` set from `status=resolved`.
+- **Keep CSV and XML tests in separate files** — do not parametrize both formats
+  through one table-driven test; the join semantics (`prevver`,
+  contentproperties-by-contentid) differ enough that shared helpers would hide
+  format-specific bugs.
+- **End-to-end integration test** over the real sample bundle (zipped):
+  `ParseConfluenceExport → TransformPages → TransformComments → Export`, asserting
+  final counts match the report (**11 visible pages, 8 current comments, 1 space**).
+  This exercises the whole historical/draft filtering chain together.
+- **Gates** (AGENTS.md): `make check-style` and `make test` must pass.
+
+## Acceptance Criteria
+
+- [ ] `mmetl transform confluence -f <csv-export.zip> -t team -c chan` produces a
+      non-empty `wiki-import.jsonl` + manifest without errors on the sample.
+- [ ] Legacy `entities.xml` exports still parse (regression-safe): existing XML
+      tests green.
+- [ ] Format auto-detection selects CSV via `exportDescriptor.properties`.
+- [ ] Pre-flight validation (`ValidateExportFormat`) passes for a CSV export and
+      still passes for an XML export (item 7 regression guard).
+- [ ] `.gz`-suffixed-but-plaintext files and genuinely-gzipped files both parse.
+- [ ] Visible pages only (current + spaced); historical versions and drafts excluded.
+- [ ] Comments threaded; historical comment versions excluded.
+- [ ] Users resolve through the existing `UserMapper` unchanged (aaid indirection).
+- [ ] `make check-style` and `make test` pass; `make docs` up to date.
+- [ ] Committed CSV fixture; no test depends on a machine-local path.
+
+## Risks & Open Questions
+
+1. **Server-side Wiki/Pages import must exist** to consume `wiki`/`page`/
+   `page_comment` JSONL — these are not stock Mattermost bulk-import line types.
+   This is the true gating dependency and is *independent* of this parser work.
+   **Confirm the import consumer exists before shipping.**
+2. **Attachment layout unverified** (sample has none). Item 6 stubs the seam;
+   completing it needs an export containing files.
+3. **`links.csv` → downstream shape**: verify what `links.go`/
+   `resolve_wiki_placeholders` currently expects (it was fed by XML-scraped
+   links) and adapt the *emit*, not the consumer. Low risk, must confirm.
+4. **Inline-comment anchors** move from inline XML markers to
+   `contentproperties` rows — the anchor-UUID↔page-offset correlation the XML
+   path relied on may not reconstruct perfectly; degrade gracefully (comment
+   still imports, just not anchored) rather than failing.
+5. **Blogposts unverified**: sample has zero `BLOGPOST` rows. Cloud CSV likely
+   uses a distinct `contenttype=BLOGPOST`; decide explicitly whether to map them
+   through the PAGE path or exclude them — do not assume they "just work".
+6. **Multi-space CSV layout unverified**: sample is a single `exportType=space`
+   personal space. A multi-space/full-site CSV export may use a different file
+   layout (subdirectories, split tables). Parse defensively; don't assume one
+   space; test separately if the org needs multi-space migration.
+7. **`content.csv` column drift** across Cloud versions — index columns by header
+   name, never by position.
+
+## Rollback
+
+The feature is additive and gated behind a new subcommand + format detection.
+Rollback = revert the commits; the Slack path and legacy XML path are untouched.

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -400,13 +400,24 @@ what adding it would take. Two structural facts frame the whole list:
 | Table(s) | Data lost | To add later |
 |----------|-----------|--------------|
 | `spacepermissions`, `spaceroles`, `spacerole_*`, `space_owner` | Space-level permissions / roles / ownership | Map to channel membership + roles; needs a channel-ACL design |
-| `content_perm(_set)` | Per-page view/edit restrictions | New `page` restriction field + importer support; parser join already speced (item 10) |
+| `content_perm(_set)` | Per-page **view/edit restrictions** — allowlists of who may read (View) vs. edit (Edit) a specific page, overriding space defaults | New `page` restriction field + importer support; parser join already speced (item 10) |
 | `likes` | Page/comment likes | Map to reactions; needs a reaction line type |
 | `notifications` | Watches / subscriptions | Map to follows; low value, likely never |
 | `AO_BAF3AA_AOINLINE_TASK` | Inline-task **state** (status/assignee/due date) | Task markup in the body still renders; state needs a task model |
 | `content_relation` | Page "copy" relationships | Cosmetic; likely never |
 | `pagetemplates`, `templateattachment*`, `templateproperties` | Space templates | Separate template-import feature |
 | `AO_950DC3_*` (Team Calendars), `AO_187CCC_SIDEBAR_LINK`, `content_data_classification_mapping`, `bandana`, `os_propertyentry`, `space_alias` | Calendars, sidebar links, data classification, space config | Out of scope; mostly empty in practice |
+
+> **⚠️ Confidentiality note (deferred — do later):** page **View** restrictions
+> are security-relevant, not cosmetic — a view-restricted Confluence page was
+> deliberately hidden from most of the org. Because v1 drops restrictions and has
+> no per-page ACL target, **every restricted page imports fully visible to
+> everyone in the target channel** — an over-exposure of previously-confidential
+> content. We are accepting this for v1 and will handle it later. The eventual fix
+> has two parts: (1) **detect + warn/exclude** restricted pages so a human decides,
+> and (2) **map restrictions to an ACL** (channel visibility/membership, or a
+> real per-page restriction field once the importer supports one). Until then,
+> migrations of spaces with restricted pages should be treated as widening access.
 
 ### Fields dropped within imported entities
 | Entity | Dropped field(s) | To add later |

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -233,11 +233,16 @@ Load into a small in-memory model keyed by `contentid`. Steps, in dependency ord
    `resolve_wiki_placeholders` expects (verify the existing shape and adapt the
    emit, not the consumer).
 9. **`label.csv` + `content_label.csv`** → join labels onto pages (`labelabletype=CONTENT`).
-10. **`content_perm_set.csv` + `content_perm.csv`** → `PageRestrictions` (types.go:80),
-    joined `content_perm.cps_id → content_perm_set.id → content_perm_set.content_id`.
-    The `username` column in `content_perm` actually holds **`user_key`** values
-    (verified) — key restrictions off `user_key`; do not look them up in
-    `user_mapping.username`.
+10. **`content_perm_set.csv` + `content_perm.csv`** → **parse only; not emitted in
+    v1** (see "Data fidelity" below). The join is
+    `content_perm.cps_id → content_perm_set.id → content_perm_set.content_id`, and
+    the `username` column holds **`user_key`** values (verified) — key off
+    `user_key`, not `user_mapping.username`. `ConfluencePage.Restrictions`
+    (`types.go:72`) can hold this, but neither `IntermediatePage` nor
+    `PageImportData` has a restrictions field, so it cannot reach the JSONL without
+    type + server-importer changes. **Recommendation: skip parsing restrictions in
+    v1** to avoid populating a struct nothing reads; defer to the follow-up in the
+    Data fidelity section.
 
 ### 4. Current-vs-historical / draft filtering
 
@@ -371,6 +376,58 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
 - [ ] Users resolve through the existing `UserMapper` unchanged (aaid indirection).
 - [ ] `make check-style` and `make test` pass; `make docs` up to date.
 - [ ] Committed CSV fixture; no test depends on a machine-local path.
+
+## Data Fidelity — What Is Not Migrated (and how to add it later)
+
+This documents everything in the CSV export that v1 drops, so migrations set
+expectations correctly and we can pick items up incrementally. Each item notes
+what adding it would take. Two structural facts frame the whole list:
+
+- The **output line types** (`wiki`, `page`, `page_comment`) only have the fields
+  in `export.go`'s `*ImportData` structs. Anything with no field there cannot be
+  emitted regardless of what the parser collects.
+- Adding any dropped field is a **three-layer change**: parser → a new field on
+  the `Intermediate*` + `*ImportData` struct → **server-side Wiki/Pages importer
+  support** for that field. The third layer is outside this repo, so most of these
+  are gated on the importer, not on mmetl.
+
+### Content format note
+- **Pages**: `content` is **TipTap JSON**. **Comments**: `content` is **Markdown**
+  (`transformComment`, `intermediate.go:371`) — comments render as normal posts,
+  not rich pages. Intentional; listed here so it isn't mistaken for a gap.
+
+### Entire tables dropped
+| Table(s) | Data lost | To add later |
+|----------|-----------|--------------|
+| `spacepermissions`, `spaceroles`, `spacerole_*`, `space_owner` | Space-level permissions / roles / ownership | Map to channel membership + roles; needs a channel-ACL design |
+| `content_perm(_set)` | Per-page view/edit restrictions | New `page` restriction field + importer support; parser join already speced (item 10) |
+| `likes` | Page/comment likes | Map to reactions; needs a reaction line type |
+| `notifications` | Watches / subscriptions | Map to follows; low value, likely never |
+| `AO_BAF3AA_AOINLINE_TASK` | Inline-task **state** (status/assignee/due date) | Task markup in the body still renders; state needs a task model |
+| `content_relation` | Page "copy" relationships | Cosmetic; likely never |
+| `pagetemplates`, `templateattachment*`, `templateproperties` | Space templates | Separate template-import feature |
+| `AO_950DC3_*` (Team Calendars), `AO_187CCC_SIDEBAR_LINK`, `content_data_classification_mapping`, `bandana`, `os_propertyentry`, `space_alias` | Calendars, sidebar links, data classification, space config | Out of scope; mostly empty in practice |
+
+### Fields dropped within imported entities
+| Entity | Dropped field(s) | To add later |
+|--------|------------------|--------------|
+| Page | **version number**, **last-modified time**, **last modifier**, `versioncomment` | Add `update_at`/`edited_by`/`version` to `PageImportData` + importer support |
+| Page | Only the **current version** is imported — no version history | Would require a page-revision import model |
+| Comment | update time, last editor | Add fields to `PageCommentImportData` + importer support |
+| Attachment | media type, file size, uploader, upload time, attachment comment | Extend `AttachmentImportData.Props` (parser can fill from the attachment table) |
+| `contentproperties` | All keys except `inline-marker-ref`, `inline-original-selection`, `status=resolved` (e.g. `sync-rev`, `share-id`, cover/appearance, `sourceTemplateKey`, `collabService`) | Case-by-case; most are Confluence-internal and not meaningful in Mattermost |
+
+### Records excluded by design
+- **Drafts** (`content_status=draft`) — skipped.
+- **Historical versions** — skipped; only the live page/comment.
+- **`CUSTOM` content** (~74% of `content.csv`) — plugin storage, not user content.
+- **Blogposts** — not handled (see Risk #5); decide map-to-page vs exclude.
+
+### Preserved in v1 (for contrast)
+Page hierarchy (parent + `child_position` order), space→wiki mapping, page body
+(TipTap) and comment body (Markdown), comment threads + resolved state + inline
+anchors, labels (as `import_labels` prop), cross-page links
+(`resolve_wiki_placeholders`), creator + creation time, attachment bytes + path.
 
 ## Risks & Open Questions
 

--- a/implementation-plans/confluence-csv-export-support.md
+++ b/implementation-plans/confluence-csv-export-support.md
@@ -4,11 +4,16 @@
 
 Confluence Cloud's space export format has changed from a single self-describing
 `entities.xml` file to a **relational dump of ~40 CSV tables**. The existing
-mmetl Confluence overlay only parses the legacy XML. This plan adds a **CSV
-parser path** that emits the *same* `ConfluenceExport` struct the XML parser
-produces, so every downstream stage — storage-format→TipTap conversion,
-hierarchy, links, user mapping, export, manifest, validation — is reused
-**unchanged**.
+mmetl Confluence overlay only parses the legacy XML. This plan **replaces the XML
+parser with a CSV parser** that emits the *same* `ConfluenceExport` struct, so
+every downstream stage — storage-format→TipTap conversion, hierarchy, links, user
+mapping, export, manifest, validation — is reused **unchanged**.
+
+**CSV is the only supported input.** We do not need the XML (or HTML) parser: the
+legacy `parseEntitiesXML`/`parseHTMLExport` paths and their XML-only helpers are
+**deleted**, not kept as a fallback. This removes ~800 lines of dead tokenizer
+code and eliminates dual-format branching, detection ambiguity, and XML
+regression surface.
 
 The change is deliberately confined to the parser input layer plus a small
 user-identity indirection. It also folds in the one-time work of porting the
@@ -27,7 +32,7 @@ changes, not the struct or its consumers.
 
 **Goals**
 - `mmetl transform confluence -f <csv-export.zip>` works on the new Cloud CSV export.
-- Auto-detect XML vs CSV vs HTML; keep the legacy XML path fully working.
+- CSV is the sole input format; delete the XML/HTML parser and its dead helpers.
 - Emit identical `ConfluenceExport` semantics from CSV so no downstream code changes.
 - Land the overlay on current `master` as a clean, committed, tested feature.
 - Portable, committed test fixture (current tests hardcode a colleague's local path).
@@ -35,6 +40,9 @@ changes, not the struct or its consumers.
 **Non-Goals**
 - No changes to `tiptap_converter.go`, `export.go`, `hierarchy.go`, `links.go`,
   `manifest.go`, `intermediate.go` transform logic (beyond what item 5 requires).
+- **No backward compatibility with legacy `entities.xml` exports** — explicitly
+  dropped at the user's direction. If a legacy XML export ever resurfaces, it is a
+  separate future effort.
 - No server-side Wiki/Pages import work — that is a separate, gating dependency
   (see Risks). This plan produces JSONL; consuming it is out of scope.
 - Not attempting to fully support blogposts, Team Calendars, whiteboards, or
@@ -50,7 +58,11 @@ Overlay lives **uncommitted** in a bundle, not yet in the repo:
 Key seams (bundle paths):
 - `parser.go:19` `ParseConfluenceExport` — indexes zip files, then branches:
   `entities.xml` present → `parseEntitiesXML` (`parser.go:69`); else `parseHTMLExport`
-  (`parser.go:492`). **This is where the CSV branch is added.**
+  (`parser.go:492`). **Its body is replaced with a CSV-only implementation;
+  `parseEntitiesXML`, `parseHTMLExport`, and every XML-only helper (`getXMLAttr`,
+  `readElementText`, `parseXMLTime`, `parse*Element`, …) plus the `encoding/xml`
+  import are deleted.** (Note: `tiptap_converter.go` also uses `encoding/xml` for
+  storage-format bodies — that is a different file and stays.)
 - `types.go` — `ConfluenceExport` (target struct) and `ConfluencePage`/`ConfluenceComment`/
   `ConfluenceUser`/`ConfluenceAttachment`. **No changes needed.**
 - `intermediate.go:409` `resolveUsername(accountID, export)` — looks up
@@ -65,8 +77,12 @@ Key seams (bundle paths):
   (`validation.go:212`), which the ported command runs *after* parsing and then
   hard-aborts on `!Valid` (`our-changes.patch:202,218`). **This blocks every CSV
   export and must be fixed (item 7).**
-- `confluence_test.go:19` — `TestParseRealExport` reads a hardcoded local zip and
-  `t.Skip`s if absent (not CI-portable).
+- `confluence_test.go:19` — `TestParseRealExport`/`TestTransformRealExport`/
+  `TestExportJSONL` read a hardcoded local **XML** zip and `t.Skip` if absent (not
+  CI-portable). These XML-fixture tests are **removed** (or replaced with CSV
+  equivalents); XML-macro converter tests that don't depend on the parser
+  (`TestConvertHTMLToTipTap_*`) stay — they exercise `tiptap_converter.go`, which
+  is unaffected.
 
 Divergence blocking a clean `git apply` onto `master`:
 - `commands/transform.go`: `master` added the `--bot-owner` flag + bot-export path
@@ -100,15 +116,17 @@ Confirmed headers:
 ID** directly into `CreatedBy`, and `resolveUsername`/the user-supplied mapping
 CSV both key on account ID. So the CSV parser must translate `user_key → aaid`
 and store the **aaid** in `CreatedBy`/`UpdatedBy` and as the `export.Users` map
-key — reproducing XML-path semantics with zero downstream change.
+key, so the account-ID-keyed `--user-mapping` CSV resolves with zero downstream
+change (see item 5).
 
 ## Proposed Approach
 
 Add `services/confluence/csv_parser.go` implementing `parseCSVExport(zipReader,
-export)`, selected by a new detection step in `ParseConfluenceExport`. It loads
-the relevant tables into row structs, joins them, applies current-vs-historical
-filtering, and populates the existing `ConfluenceExport`. All other files are
-reused as-is except a tiny, optional touch to attachment handling (item 6).
+export)`, called directly by a slimmed-down `ParseConfluenceExport`. It loads the
+relevant tables into row structs, joins them, applies current-vs-historical
+filtering, and populates the existing `ConfluenceExport`. The XML/HTML parser is
+deleted (item 2). All other files are reused as-is except attachment handling
+(item 6) and the validation gate (item 7).
 
 ### 1. Port the overlay onto `master` (prerequisite)
 
@@ -124,15 +142,24 @@ reused as-is except a tiny, optional touch to attachment handling (item 6).
 - Gate: `go build ./...` succeeds; `mmetl transform confluence --help` lists flags.
 - Commit this as an isolated "port overlay" commit before touching the parser.
 
-### 2. Format detection in `ParseConfluenceExport` (`parser.go:42-53`)
+### 2. Replace the parser body; delete the XML/HTML paths (`parser.go:42-53`)
 
-Extend the existing branch. Priority order:
-1. If `exportDescriptor.properties` present and parses `exportFormat=csv` → `parseCSVExport`.
-   (Prefer this single-line signal over "presence of `content.csv`" — a multi-space
-   or full-site CSV export may lay files out differently; `exportFormat=csv` is stable.)
-   Fall back to `content.csv`/`content.csv.gz` presence only if the descriptor is absent.
-2. Else if `entities.xml` present → `parseEntitiesXML` (unchanged).
-3. Else → `parseHTMLExport` (unchanged).
+`ParseConfluenceExport` no longer branches — it validates that this is a CSV
+export and calls `parseCSVExport` directly:
+1. If `exportDescriptor.properties` parses `exportFormat=csv`, or `content.csv`/
+   `content.csv.gz` is present → `parseCSVExport`. (Prefer the `exportFormat=csv`
+   single-line signal; a multi-space/full-site export may lay files out
+   differently.)
+2. Otherwise → return a clear error ("unsupported export: expected a Confluence
+   Cloud CSV export"). **No XML/HTML fallback.**
+
+Delete `parseEntitiesXML`, `parseHTMLExport`, `parseHTMLPage`, all `parse*Element`
+readers, and the XML-only helpers (`getXMLAttr`, `readElementText`,
+`readIDElement`, `parseXMLTime`, `skipElement`, …) plus the now-unused
+`encoding/xml` import from `parser.go`. Go won't error on unused *functions*, but
+`make check-style` (golangci `unused`) and the dropped import will — so remove
+them in the same change. Add a CSV timestamp parser (dates look like
+`2024-05-31 10:03:18.78`, not the XML format `parseXMLTime` handled).
 
 Add a `readMaybeGzipCSV(f *zip.File) ([][]string, error)` helper: open, peek 2
 bytes, wrap in `gzip.Reader` iff magic == `0x1f 0x8b`, else read plain; parse
@@ -235,11 +262,11 @@ CSV via `UserMapper`.
 
 **Decision: translate `user_key → aaid` in the parser and store the `aaid`.**
 Rationale: the user-supplied `--user-mapping` CSV is keyed on Atlassian account
-ID (`UserMapper.byAccountID`, `user_mapper.go`), which the XML path already
-produced — orgs build that CSV from Atlassian account IDs, not from Confluence's
-internal `user_key`. Storing the aaid makes the realistic mapping-by-account-ID
-path work and matches XML semantics; `resolveUsername`/`user_mapper.go` need no
-change. Populate `export.Users[aaid] = &ConfluenceUser{AccountID: aaid, ...}`.
+ID (`UserMapper.byAccountID`, `user_mapper.go`) — orgs build that CSV from
+Atlassian account IDs, not from Confluence's internal `user_key`. Storing the
+aaid makes the realistic mapping-by-account-ID path work; `resolveUsername`/
+`user_mapper.go` need no change. Populate
+`export.Users[aaid] = &ConfluenceUser{AccountID: aaid, ...}`.
 
 Important nuance (from advisor): `user_mapping.csv` has **no email column** and
 its `username`/`aaid` are opaque IDs, so Confluence's own mapping yields no
@@ -275,10 +302,10 @@ for space CSV exports. `attachments.go:15` assumes
 `ValidateAll` after parsing and returns `"pre-flight validation failed"` when
 `!Valid` (`our-changes.patch:202,218`). **A CSV export has no `entities.xml`, so
 without this fix every CSV run aborts after a successful parse** — directly
-defeating acceptance criterion #1. Fix: make `ValidateExportFormat` treat
-`exportDescriptor.properties` with `exportFormat=csv` (or presence of
-`content.csv`/`content.csv.gz`) as an equally valid format signal, mirroring the
-detection logic in item 2. Keep the `entities.xml` acceptance for the XML path.
+defeating acceptance criterion #1. Fix: **replace** the `entities.xml` requirement
+in `ValidateExportFormat` with the CSV signal (`exportFormat=csv` or presence of
+`content.csv`/`content.csv.gz`), mirroring the detection in item 2. The
+`entities.xml` check is removed, not kept — there is no XML path anymore.
 
 ## Files to Change / Add
 
@@ -287,18 +314,18 @@ detection logic in item 2. Keep the `entities.xml` acceptance for the XML path.
 | `services/confluence/*.go` (14) | **Add** — port from bundle (item 1) |
 | `commands/transform.go` | **Edit** — manually merge `transform confluence` subcommand onto master's `--bot-owner` version |
 | `go.mod` / `go.sum` | **Edit** — `go mod tidy` (x/net becomes direct) |
-| `services/confluence/parser.go` | **Edit** — add CSV detection branch in `ParseConfluenceExport` |
-| `services/confluence/csv_parser.go` | **Add** — `parseCSVExport` + table loaders + joins + gzip sniff |
+| `services/confluence/parser.go` | **Rewrite** — `ParseConfluenceExport` becomes CSV-only; **delete** `parseEntitiesXML`, `parseHTMLExport`, `parse*Element`, XML-only helpers, and the `encoding/xml` import (item 2) |
+| `services/confluence/csv_parser.go` | **Add** — `parseCSVExport` + table loaders + joins + gzip sniff + CSV timestamp parser |
 | `services/confluence/csv_parser_test.go` | **Add** — unit tests over a committed fixture |
 | `services/confluence/testdata/csv-export-min.zip` | **Add** — small committed CSV-export fixture |
-| `services/confluence/confluence_test.go` | **Edit** — parametrize fixture path, stop hardcoding a local path |
+| `services/confluence/confluence_test.go` | **Edit** — **remove** XML-fixture tests (`TestParseRealExport`/`TestTransformRealExport`/`TestExportJSONL`); keep parser-independent `TestConvertHTMLToTipTap_*` |
 | `services/confluence/attachments.go` | **Edit** — add `// TODO(csv-attachments)` + warn when `backupAttachments=true` but no files match the regex (item 6) |
-| `services/confluence/validation.go` | **Edit** — `ValidateExportFormat` must accept the CSV signal, not only `entities.xml` (item 7 — blocking) |
+| `services/confluence/validation.go` | **Edit** — `ValidateExportFormat` requires the CSV signal, drops the `entities.xml` requirement (item 7 — blocking) |
 | `docs/cli/` | **Regen** — `make docs` (new subcommand docs) |
 
 No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
 `export.go`, `hierarchy.go`, `links.go` (consumer), `manifest.go`, `user_mapper.go`.
-(`validation.go` **does** change — see item 7.)
+(`parser.go` and `validation.go` **do** change — see items 2 and 7.)
 
 ## Testing Strategy
 
@@ -312,7 +339,7 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
   `user_mapping`, and one storage-format body exercising a macro/`ac:layout`.
 - **Unit tests** (`csv_parser_test.go`):
   - gzip-magic sniff: gzipped vs plain `.gz` both parse.
-  - format detection picks CSV over XML/HTML given `exportFormat=csv`.
+  - a non-CSV/unrecognized zip returns the clear "unsupported export" error.
   - visible-page filter: current+spaceid kept; historical (blank spaceid+prevver)
     → `HistoricalPageIDs`; draft skipped.
   - hierarchy: `parentid`/homepage produce the expected tree + root.
@@ -323,10 +350,6 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
     export produces valid `wiki`/`page`/`page_comment` JSONL lines.
   - inline anchors read directly from `contentproperties` (no HTML scraping);
     `IsResolved` set from `status=resolved`.
-- **Keep CSV and XML tests in separate files** — do not parametrize both formats
-  through one table-driven test; the join semantics (`prevver`,
-  contentproperties-by-contentid) differ enough that shared helpers would hide
-  format-specific bugs.
 - **End-to-end integration test** over the real sample bundle (zipped):
   `ParseConfluenceExport → TransformPages → TransformComments → Export`, asserting
   final counts match the report (**11 visible pages, 8 current comments, 1 space**).
@@ -337,11 +360,11 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
 
 - [ ] `mmetl transform confluence -f <csv-export.zip> -t team -c chan` produces a
       non-empty `wiki-import.jsonl` + manifest without errors on the sample.
-- [ ] Legacy `entities.xml` exports still parse (regression-safe): existing XML
-      tests green.
-- [ ] Format auto-detection selects CSV via `exportDescriptor.properties`.
-- [ ] Pre-flight validation (`ValidateExportFormat`) passes for a CSV export and
-      still passes for an XML export (item 7 regression guard).
+- [ ] `ParseConfluenceExport` accepts CSV via `exportDescriptor.properties`; a
+      non-CSV zip returns a clear "unsupported export" error.
+- [ ] XML/HTML parser code and `encoding/xml` import removed from `parser.go`;
+      `make check-style` reports no unused-code/import errors.
+- [ ] Pre-flight validation (`ValidateExportFormat`) passes for a CSV export.
 - [ ] `.gz`-suffixed-but-plaintext files and genuinely-gzipped files both parse.
 - [ ] Visible pages only (current + spaced); historical versions and drafts excluded.
 - [ ] Comments threaded; historical comment versions excluded.
@@ -376,5 +399,8 @@ No changes to: `types.go`, `tiptap_converter.go`, `intermediate.go` (transform),
 
 ## Rollback
 
-The feature is additive and gated behind a new subcommand + format detection.
-Rollback = revert the commits; the Slack path and legacy XML path are untouched.
+The feature is gated behind a new `transform confluence` subcommand — the Slack
+path is untouched, so rollback = revert the commits. Note that because the XML
+parser is deleted (not kept as a fallback), reverting only the CSV commits would
+also restore the XML parser; a partial rollback that keeps the port but drops CSV
+is not a supported state.

--- a/implementation-plans/confluence-docs-contract-alignment.md
+++ b/implementation-plans/confluence-docs-contract-alignment.md
@@ -1,0 +1,236 @@
+# Confluence CSV → Docs contract alignment (mmetl)
+
+## Summary
+
+Follow-up to the CSV export work ([confluence-csv-export-support.md](confluence-csv-export-support.md))
+and the cross-repo reconciliation in
+[confluence-jsonl-docs-plugin-integration.md](confluence-jsonl-docs-plugin-integration.md).
+This plan covers the **mmetl-side** changes only — bringing the emitted bundle in
+line with the Mattermost Docs (Spaces/Pages) domain and closing the fidelity gaps
+the reconciliation surfaced. It does not touch `mattermost-plugin-docs` or
+`mattermost` core.
+
+Scope, in priority order:
+
+1. **Commit to single-space** — remove the dead multi-space scaffolding.
+2. **Proper naming** — rename the `wiki`/`wiki-poc` contract to the Docs `space`
+   vocabulary and version it.
+3. **Attachments** — parse attachment metadata from the CSV so extraction and
+   placeholder normalization actually work.
+4. **Bundle, validation, restrictions, tests** — the remaining producer gaps.
+
+## Goals / Non-Goals
+
+**Goals**
+- One bundle = one Space; simple, correct, and matches the CSV export format.
+- A v2 JSONL contract named in Docs terms (`space`, `page`, `page_comment`).
+- Attachment metadata populated and `CONF_ATTACHMENT` tokens resolved.
+- A single self-contained `--bundle` output; validation aligned to Docs limits;
+  restricted pages detected and surfaced.
+
+**Non-Goals**
+- **Multi-space in one bundle** — explicitly deferred. We may revisit if a
+  site/global CSV export format appears; today each Confluence space exports
+  separately, so N spaces = N bundles. (This is a reversible decision; §1 keeps a
+  clean single-space seam rather than deleting the concept of a Space.)
+- No import-side work (parsing, jobs, ACL) — that lives in the Docs plugin.
+- No access-policy / backing-channel ownership — the import request is
+  authoritative for that; mmetl stops dictating it (§3) but does not model it.
+- Not resolving page **restrictions** into an ACL (still deferred) — only
+  detecting and warning (§7).
+
+## Current State (grounded references)
+
+- Emits v1 lines `version`, `channel`, `wiki`, `page`, `page_comment`,
+  `resolve_wiki_placeholders` ([export.go:24,152-408](../services/confluence/export.go)).
+- **Multi-space scaffolding is dead code**: `ConfluenceExport.Spaces`
+  ([types.go:16](../services/confluence/types.go)), `setupWikisFromSpaces` looping
+  `range export.Spaces` ([intermediate.go:189](../services/confluence/intermediate.go)),
+  and `ExportWikis` emitting one `wiki` per space ([export.go:180](../services/confluence/export.go)).
+  The CSV parser only ever inserts one space ([csv_parser.go:247](../services/confluence/csv_parser.go))
+  and assigns every page `page.SpaceKey = export.SpaceKey` — nothing populates >1.
+- **Attachments unpopulated**: `csv_parser.go` has no `ATTACHMENT` handling, so
+  `export.Attachments` is empty, `ExtractAttachments` matches nothing
+  ([attachments.go:38](../services/confluence/attachments.go)), and
+  `ConvertAttachmentPlaceholdersToFileIDs` is a no-op because its `filenameToID`
+  map is empty ([intermediate.go:247-256](../services/confluence/intermediate.go),
+  [links.go:345](../services/confluence/links.go)) — so `CONF_ATTACHMENT` tokens
+  are never rewritten to `CONF_FILE`.
+- **Channel dictated by producer**: every `wiki`/`page` line carries Team+Channel,
+  and `--create-channel` emits a `channel` line ([export.go:159](../services/confluence/export.go)).
+  `--channel` is currently a **required** flag ([transform.go](../commands/transform.go)).
+- **Identity already preserved** (from the CSV work): `props.confluence_author_account_id`
+  on pages/comments + a manifest `users` list.
+- Body size warned only >10 MiB; Docs caps Body/SearchText at 2 MiB and Props at
+  64 KiB. `update_at` captured (`IntermediatePage.UpdateAt`) but not emitted.
+
+## Proposed Approach
+
+### 1. Commit to single-space (remove multi-space scaffolding)
+
+- Collapse `Intermediate.Wikis []` + `Intermediate.Wiki` to a **single**
+  `Intermediate.Space` (see §2 for the rename). `setupWikisFromSpaces`
+  ([intermediate.go:189](../services/confluence/intermediate.go)) becomes
+  `setupSpace`: take the one space from `export.Spaces`/`export.SpaceKey`, build
+  one `IntermediateSpace`.
+- `ExportWikis` loop → `ExportSpace` (writes exactly one `space` line).
+- **Guardrail**: if `len(export.Spaces) > 1` (cannot happen from CSV today),
+  return a clear error — "multi-space exports are not supported; import one space
+  per bundle" — so the assumption is enforced, not silently mis-handled.
+- Keep `SpaceInfo`/`export.Spaces` as the parse-side shape (cheap, and the natural
+  seam if multi-space returns), but the transform/export side is single-space.
+
+### 2. Proper naming — v2 Docs contract
+
+Rename the wiki-poc vocabulary to Docs terms and bump the version. New line types
+and fields:
+
+| v1 (now) | v2 (target) |
+|----------|-------------|
+| `wiki` line / `WikiImportData` | `space` line / `SpaceImportData` |
+| `wiki_import_source_id` | `space_import_source_id` |
+| `resolve_wiki_placeholders` / `ResolveWikiPlaceholdersImportData` | `resolve_space_placeholders` / `ResolveSpacePlaceholdersImportData` |
+| `page`, `page_comment` | unchanged |
+| `version: 1` | `version: 2` |
+
+- Rename the Go identifiers to match (`IntermediateWiki`→`IntermediateSpace`,
+  `ExportWiki(s)`→`ExportSpace`, etc.) and update the `transform.go` summary
+  prints (`Wikis:` → `Spaces:`).
+- **Version + source namespace**: emit `version: 2` and add a bundle-level
+  **source namespace** so numeric page IDs / space keys can't collide across
+  Confluence instances. Carry it once (not per line): add
+  `source.organization_id` and `source.space_key` to the manifest (derive
+  `organization_id` from `exportDescriptor.properties` `organizationId`, already
+  present), and include the same in the `version` line's payload. Entity source
+  IDs stay bare and are interpreted within the bundle namespace; the importer must
+  scope all source-ID lookups to the job (never global).
+- This is a v2-only contract; there is no shipped consumer of v1, so no
+  compatibility shim is required. Document the schema in `docs/`.
+
+### 3. Stop dictating the backing channel
+
+Per the reconciliation, the Docs plugin owns the Space's backing channel; mmetl
+must not decide it.
+
+- Drop the `channel` line and `ExportChannel`/`AutoCreateChannel`/`--create-channel`.
+- Remove `Channel` from the `space`/`page` contract (backing channel is resolved
+  at import time from the import request).
+- Keep `--team` as target-team context. Make `--channel` **optional** and
+  **deprecated** (documented as ignored in v2), or remove it; do not keep it as a
+  required backing-channel input.
+
+### 4. Attachments
+
+Root cause: the CSV parser never populates `export.Attachments`.
+
+- In `csv_parser.go` `loadContent`, handle `contenttype=ATTACHMENT` rows: build
+  `ConfluenceAttachment{ID: contentid, PageID: pageid, FileName: title,
+  CreatedBy: resolveActor(creator), CreatedAt: creationdate}` and append to
+  `export.Attachments[pageid]`. Pull `MediaType`/`FileSize` from
+  `contentproperties` if present (e.g. `media-type`, `file-size`) — best-effort,
+  since the sample has none.
+- With `export.Attachments` populated, `filenameToID` is non-empty and
+  `ConvertAttachmentPlaceholdersToFileIDs` rewrites `CONF_ATTACHMENT` → `CONF_FILE`
+  ([intermediate.go:247](../services/confluence/intermediate.go)); pages then get
+  their `attachments` arrays and `ExtractAttachments` can place files.
+- **Verify the on-disk file layout** (blocking, needs data): the current regex
+  `attachments/{pageID}/{attachmentID}/{version}` ([attachments.go:17](../services/confluence/attachments.go))
+  is the XML-era layout and is **unverified for CSV**. Acquire a real CSV export
+  that contains attachments, confirm the path convention, and adjust the regex
+  (make it a small set of candidate patterns if needed). Until verified, ship the
+  metadata parsing + the existing warning and gate closure on a real fixture.
+- Keep emitting both `CONF_ATTACHMENT` (unresolved) and `CONF_FILE` (normalized)
+  handling downstream until attachments are fully verified.
+
+### 5. Single self-contained bundle
+
+- Add `--bundle <out.zip>` producing one archive:
+
+  ```text
+  import.jsonl
+  import-manifest.json
+  data/<page-id>/<attachment>
+  ```
+
+- When `--bundle` is set, write into a temp staging dir and zip; otherwise keep
+  the current loose-file behavior. Fix the misleading "Next steps" recipe
+  ([transform.go:397](../commands/transform.go)) so it never omits the JSONL.
+
+### 6. Validation aligned to Docs
+
+- Lower the body warning to the Docs cap: warn/refuse Body and SearchText above
+  **2 MiB** (`PageBodyMaxBytes`/`PageSearchTextMaxBytes`), and page Props above
+  **64 KiB** (`PagePropsMaxBytes`).
+- **Emit `update_at`**: add `update_at` to `PageImportData`/`PageCommentImportData`
+  and populate from `IntermediatePage.UpdateAt` (already captured).
+- **Validate TipTap** with `json.Valid` before writing each page's `content`;
+  on failure keep the existing code-block fallback but count it as a warning.
+- Keep leaning on the manifest `users` list + `--fallback-user` for user
+  validation; add a strict `--require-user-mapping` that fails if any author is
+  unmapped (opt-in).
+
+### 7. Detect and warn on restricted pages
+
+Restrictions are still not imported, but silently importing a view-restricted
+page widens access. Add **detection** (not enforcement):
+
+- Parse `content_perm_set.csv` (+`content_perm.csv`) enough to identify pages with
+  a `View` restriction (do not resolve principals).
+- Emit a loud warning listing restricted page IDs/titles and add a
+  `restricted_pages` array to the manifest.
+- Optional `--fail-on-restricted` for operators who want a hard stop until the ACL
+  story exists.
+
+### 8. Tests
+
+- Extend `csv_parser_test.go` / add `export_test.go`:
+  - v2 schema: assert exact emitted keys per line (`space`,
+    `space_import_source_id`, `resolve_space_placeholders`, `version: 2`, source
+    namespace).
+  - single-space guardrail: a synthetic two-space export errors.
+  - attachments: `ATTACHMENT` rows populate `export.Attachments`; a
+    `CONF_ATTACHMENT` body token becomes `CONF_FILE`; page `attachments` array
+    present.
+  - `--bundle`: archive contains `import.jsonl` + `import-manifest.json` + `data/`.
+  - validation: >2 MiB body warns; invalid TipTap falls back + warns; `update_at`
+    emitted.
+  - restrictions: a page with a `View` `content_perm_set` produces a warning +
+    manifest entry.
+- Update the end-to-end run against the real sample; regenerate `docs/`.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `services/confluence/export.go` | Rename wiki→space types/fields/methods; drop `channel` line; single `ExportSpace`; `version: 2` + source namespace; `update_at` |
+| `services/confluence/intermediate.go` | `setupSpace` (single); `IntermediateSpace`; multi-space guardrail; TipTap `json.Valid` check |
+| `services/confluence/csv_parser.go` | Parse `ATTACHMENT` content rows → `export.Attachments`; parse `content_perm*` for restriction detection |
+| `services/confluence/attachments.go` | Verify/adjust CSV attachment path layout (pending real fixture) |
+| `services/confluence/validation.go` | 2 MiB / 64 KiB caps; restricted-page reporting |
+| `services/confluence/manifest.go` | `source` namespace; `restricted_pages` |
+| `services/confluence/types.go` | Rename `IntermediateWiki`→`IntermediateSpace` (transform side) |
+| `commands/transform.go` | `--bundle`; deprecate/relax `--channel`; drop `--create-channel`; fix recipe; summary wording |
+| `docs/cli/` | `make docs` |
+
+## Risks & Open Questions
+
+1. **Attachment file layout is unverified** — §4 metadata parsing is safe, but
+   closing the attachments item needs a real CSV export containing files to
+   confirm the on-disk path. This is the one item that can't be fully finished
+   from the current sample.
+2. **No shipped consumer** — the v2 contract is being defined ahead of the Docs
+   import API. Names/fields here should be agreed with the plugin team so both
+   sides land together (see the integration plan's rollout).
+3. **`update_at` is advisory** — even when emitted, the plugin's interactive
+   `CreatePage` overwrites timestamps; preserving them needs the plugin's
+   import-specific methods. mmetl emitting it is necessary but not sufficient.
+4. Dropping `channel`/`--create-channel` is a behavior change; acceptable now
+   because nothing consumes it, but coordinate before anyone builds on v1.
+
+## Rollout
+
+1. §1 single-space + §2 naming/version (contract-shaping, do first, together).
+2. §3 channel removal + §5 bundle (producer surface).
+3. §4 attachments metadata + §6 validation + §7 restrictions.
+4. §8 tests throughout; close the attachments item once a real
+   attachment-bearing CSV export is available.

--- a/implementation-plans/confluence-docs-contract-alignment.md
+++ b/implementation-plans/confluence-docs-contract-alignment.md
@@ -1,5 +1,17 @@
 # Confluence CSV → Docs contract alignment (mmetl)
 
+> **Status:** Implemented by `0430bbd`, `c62beaf`, and the channel-surface
+> cleanup that followed. The v2 contract, single-Space bundle, attachment
+> metadata, restriction detection, validation, and tests are in place. The
+> deprecated channel surface is now fully removed: the `--channel` flag,
+> `Transformer.ChannelName`, `Validator.ChannelName`, `ManifestTarget.Channel`,
+> the channel constructor arguments, and the optional server-side channel
+> lookup/membership validation are all gone. The manifest serializes
+> `target.team` with no `channel` key. The **only** remaining producer blocker
+> is verifying the CSV attachment byte layout against a real attachment-bearing
+> export. The target team carried by the bundle is advisory metadata; the Docs
+> import request is authoritative.
+
 ## Summary
 
 Follow-up to the CSV export work ([confluence-csv-export-support.md](confluence-csv-export-support.md))
@@ -41,30 +53,26 @@ Scope, in priority order:
 
 ## Current State (grounded references)
 
-- Emits v1 lines `version`, `channel`, `wiki`, `page`, `page_comment`,
-  `resolve_wiki_placeholders` ([export.go:24,152-408](../services/confluence/export.go)).
-- **Multi-space scaffolding is dead code**: `ConfluenceExport.Spaces`
-  ([types.go:16](../services/confluence/types.go)), `setupWikisFromSpaces` looping
-  `range export.Spaces` ([intermediate.go:189](../services/confluence/intermediate.go)),
-  and `ExportWikis` emitting one `wiki` per space ([export.go:180](../services/confluence/export.go)).
-  The CSV parser only ever inserts one space ([csv_parser.go:247](../services/confluence/csv_parser.go))
-  and assigns every page `page.SpaceKey = export.SpaceKey` — nothing populates >1.
-- **Attachments unpopulated**: `csv_parser.go` has no `ATTACHMENT` handling, so
-  `export.Attachments` is empty, `ExtractAttachments` matches nothing
-  ([attachments.go:38](../services/confluence/attachments.go)), and
-  `ConvertAttachmentPlaceholdersToFileIDs` is a no-op because its `filenameToID`
-  map is empty ([intermediate.go:247-256](../services/confluence/intermediate.go),
-  [links.go:345](../services/confluence/links.go)) — so `CONF_ATTACHMENT` tokens
-  are never rewritten to `CONF_FILE`.
-- **Channel dictated by producer**: every `wiki`/`page` line carries Team+Channel,
-  and `--create-channel` emits a `channel` line ([export.go:159](../services/confluence/export.go)).
-  `--channel` is currently a **required** flag ([transform.go](../commands/transform.go)).
-- **Identity already preserved** (from the CSV work): `props.confluence_author_account_id`
-  on pages/comments + a manifest `users` list.
-- Body size warned only >10 MiB; Docs caps Body/SearchText at 2 MiB and Props at
-  64 KiB. `update_at` captured (`IntermediatePage.UpdateAt`) but not emitted.
+- Emits v2 `version`, `space`, `page`, `page_comment`, and
+  `resolve_space_placeholders` lines; no channel line or entity channel field
+  ([export.go](../services/confluence/export.go)).
+- Enforces one bundle = one Space on the parse and transform paths.
+- Parses attachment metadata and normalizes `CONF_ATTACHMENT` placeholders to
+  source-ID-based `CONF_FILE` placeholders. Attachment byte extraction still
+  assumes the unverified legacy path layout.
+- **Done:** the `--channel` flag and all Confluence channel plumbing are
+  removed. There is no `Transformer.ChannelName`, `Validator.ChannelName`,
+  `ManifestTarget.Channel`, or channel constructor argument, and the optional
+  server-side channel lookup/membership validation is gone. The manifest
+  serializes `target.team` with no `channel` key.
+- `--team` and emitted `team` values remain producer/operator intent and are
+  advisory to the importer. The import request chooses the actual destination.
+- Preserves identity through `props.confluence_author_account_id` and the
+  manifest `users` list.
+- Applies Docs Body/Props warnings, validates TipTap JSON, emits `update_at`, and
+  detects View-restricted pages with warning/fail behavior.
 
-## Proposed Approach
+## Implemented Approach and Remaining Follow-ups
 
 ### 1. Commit to single-space (remove multi-space scaffolding)
 
@@ -107,17 +115,31 @@ and fields:
 - This is a v2-only contract; there is no shipped consumer of v1, so no
   compatibility shim is required. Document the schema in `docs/`.
 
-### 3. Stop dictating the backing channel
+### 3. Stop dictating the backing channel; make team advisory — **done**
 
-Per the reconciliation, the Docs plugin owns the Space's backing channel; mmetl
-must not decide it.
+The Docs plugin owns the Space's opaque `ChannelTypeSpace` backing channel;
+mmetl must not decide or attempt to discover it. The import request is
+authoritative for the actual target team and access policy.
 
-- Drop the `channel` line and `ExportChannel`/`AutoCreateChannel`/`--create-channel`.
-- Remove `Channel` from the `space`/`page` contract (backing channel is resolved
-  at import time from the import request).
-- Keep `--team` as target-team context. Make `--channel` **optional** and
-  **deprecated** (documented as ignored in v2), or remove it; do not keep it as a
-  required backing-channel input.
+Completed:
+
+- **Done:** dropped the `channel` line and `ExportChannel`/`AutoCreateChannel`/`--create-channel`.
+- **Done:** removed `Channel` from the `space`/`page` contract (the backing channel
+  is created and resolved by the Docs importer).
+- **Done:** removed the `target.channel` manifest field (the manifest serializes
+  `target.team` with no `channel` key) and the optional server-side channel
+  lookup/membership validation. A Space backing channel is hidden from generic
+  channel lookup, and there is no channel field in v2.
+- **Done:** removed the `--channel` flag entirely, along with
+  `Transformer.ChannelName`, `Validator.ChannelName`, and the `channelName`
+  arguments to `NewTransformer`/`NewValidator`/`NewManifest`. mmetl no longer
+  creates, identifies, discovers, or validates the Space backing channel.
+- **Done:** `--team` remains required and its emitted `team` values are
+  **advisory operator metadata**; its CLI description now says so explicitly.
+  Optional server validation may still confirm the advisory team exists, but it
+  never inspects any regular or Space channel. The importer records the team for
+  audit and may warn when it differs from the requested team, but must never
+  route an import from the bundle value.
 
 ### 4. Attachments
 
@@ -186,7 +208,8 @@ page widens access. Add **detection** (not enforcement):
 - Extend `csv_parser_test.go` / add `export_test.go`:
   - v2 schema: assert exact emitted keys per line (`space`,
     `space_import_source_id`, `resolve_space_placeholders`, `version: 2`, source
-    namespace).
+    namespace); assert no channel line, no entity `channel`, and no manifest
+    `target.channel`.
   - single-space guardrail: a synthetic two-space export errors.
   - attachments: `ATTACHMENT` rows populate `export.Attachments`; a
     `CONF_ATTACHMENT` body token becomes `CONF_FILE`; page `attachments` array
@@ -206,10 +229,10 @@ page widens access. Add **detection** (not enforcement):
 | `services/confluence/intermediate.go` | `setupSpace` (single); `IntermediateSpace`; multi-space guardrail; TipTap `json.Valid` check |
 | `services/confluence/csv_parser.go` | Parse `ATTACHMENT` content rows → `export.Attachments`; parse `content_perm*` for restriction detection |
 | `services/confluence/attachments.go` | Verify/adjust CSV attachment path layout (pending real fixture) |
-| `services/confluence/validation.go` | 2 MiB / 64 KiB caps; restricted-page reporting |
-| `services/confluence/manifest.go` | `source` namespace; `restricted_pages` |
+| `services/confluence/validation.go` | 2 MiB / 64 KiB caps; restricted-page reporting; remove legacy target-channel validation |
+| `services/confluence/manifest.go` | `source` namespace; `restricted_pages`; keep target team as advisory metadata and remove `target.channel` |
 | `services/confluence/types.go` | Rename `IntermediateWiki`→`IntermediateSpace` (transform side) |
-| `commands/transform.go` | `--bundle`; deprecate/relax `--channel`; drop `--create-channel`; fix recipe; summary wording |
+| `commands/transform.go` | `--bundle`; deprecate then remove `--channel`; document `--team` as advisory metadata; drop `--create-channel`; fix recipe; summary wording |
 | `docs/cli/` | `make docs` |
 
 ## Risks & Open Questions
@@ -218,19 +241,25 @@ page widens access. Add **detection** (not enforcement):
    closing the attachments item needs a real CSV export containing files to
    confirm the on-disk path. This is the one item that can't be fully finished
    from the current sample.
-2. **No shipped consumer** — the v2 contract is being defined ahead of the Docs
-   import API. Names/fields here should be agreed with the plugin team so both
-   sides land together (see the integration plan's rollout).
+2. **No shipped consumer** — the v2 producer contract exists ahead of the Docs
+   import API. Freeze any remaining field changes with the plugin team before
+   the first consumer lands (see the integration plan's rollout).
 3. **`update_at` is advisory** — even when emitted, the plugin's interactive
    `CreatePage` overwrites timestamps; preserving them needs the plugin's
    import-specific methods. mmetl emitting it is necessary but not sufficient.
-4. Dropping `channel`/`--create-channel` is a behavior change; acceptable now
-   because nothing consumes it, but coordinate before anyone builds on v1.
+4. Dropping `channel`/`--create-channel` is intentional: mattermost#37321 makes
+   Space backing channels opaque and plugin-managed. The `target.channel`
+   manifest field and the `--channel` flag are now **removed** — no channel
+   surface remains on the producer.
 
 ## Rollout
 
-1. §1 single-space + §2 naming/version (contract-shaping, do first, together).
-2. §3 channel removal + §5 bundle (producer surface).
-3. §4 attachments metadata + §6 validation + §7 restrictions.
-4. §8 tests throughout; close the attachments item once a real
-   attachment-bearing CSV export is available.
+1. **Done:** single-Space v2 contract, channel line removal, bundle output,
+   attachment metadata, validation, restriction detection, and producer tests.
+2. **Done:** removed manifest `target.channel`, the legacy channel validation,
+   and the `--channel` flag (plus all channel plumbing). No channel surface
+   remains on the producer.
+3. Close attachment extraction once a real attachment-bearing CSV export proves
+   the on-disk layout. **This is the remaining producer blocker.**
+4. Freeze the resulting producer schema with the Docs import consumer and run
+   the cross-repository E2E suite.

--- a/implementation-plans/confluence-jsonl-docs-plugin-integration.md
+++ b/implementation-plans/confluence-jsonl-docs-plugin-integration.md
@@ -1,0 +1,201 @@
+# Confluence JSONL → Mattermost Docs integration
+
+## Bottom line
+
+The JSONL produced by `mmetl` cannot currently be imported into the checked-out Docs plugin or Mattermost `master` as-is. It targets the older Mattermost `wiki-poc` import contract, while ownership of Spaces and Pages has moved into `mattermost-plugin-docs`.
+
+The recommended architecture is:
+
+```text
+Confluence export
+  → mmetl versioned ZIP bundle
+  → Docs plugin admin import API/job
+      → DOCS_Space / DOCS_Page / comments / mappings
+      → Mattermost APIs for channels, users, membership, and files
+```
+
+The Docs plugin should own parsing, validation, import jobs, idempotency, hierarchy, comments, attachments, and link resolution. Mattermost core should remain unaware of Docs-specific JSONL entities.
+
+## Current incompatibilities
+
+- `mmetl` emits custom `wiki`, `page`, `page_comment`, and `resolve_wiki_placeholders` lines ([export.go](../services/confluence/export.go:20)).
+- Docs `master` contains foundational Space/Page storage but no import API, import job, comments, attachment ownership, or search implementation ([api.go](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/api.go:14)).
+- Mattermost bulk import has no fields for these entities and rejects unknown line types ([import_types.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/imports/import_types.go:15), [import.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go:398)).
+- The old [`wiki-poc` importer](/Users/willyfrog/.supacode/repos/mattermost/wiki-poc/server/channels/app/import_wiki_functions.go:74) is useful as an algorithm and test reference, but writes obsolete core Wiki/Page models rather than plugin tables.
+
+## Changes required in `mmetl`
+
+> **Status update — CSV support has since landed** (branch
+> `worktree-confluence-csv-parser`, see [confluence-csv-export-support.md](confluence-csv-export-support.md)).
+> This changes the baseline several items below were written against:
+> - Input is now **Confluence Cloud CSV** exports (the legacy `entities.xml`/HTML
+>   parser was removed). The producer emits the **same v1 line types** — `wiki`,
+>   `page`, `page_comment`, `resolve_wiki_placeholders` — so every contract item
+>   below (§1 versioning, §3 bundle, source namespace) is still open.
+> - **Identity is now preserved** for downstream matching: every `page`/`page_comment`
+>   carries `props.confluence_author_account_id` (the Atlassian account ID), and the
+>   manifest now includes a `users` list of `{account_id, confluence_username,
+>   mattermost_username}`. The Docs importer should consume these (see §4 and the
+>   plugin-side mapping tables) rather than re-deriving identity.
+> - `ValidateExportFormat` now accepts the CSV signal (it no longer requires
+>   `entities.xml`).
+> - **CSV space exports are single-space by construction** (`exportType=space`),
+>   which changes the multi-space item in §5.
+
+### 1. Freeze and version the contract
+
+- Continue accepting v1 `wiki` records as an adapter format, but define each one as a Docs Space.
+- For v2, rename `wiki` to `space`.
+- Do not treat `wiki.channel` as the Space backing channel; the plugin creates its own `ChannelTypeSpace` channel.
+- Make the import request authoritative for target team and access policy.
+- Add a source namespace, such as Confluence cloud/site ID. Numeric page IDs and space keys can collide across Confluence instances.
+
+### 2. Fix comment scoping
+
+Standalone comments still contain only `page_import_source_id` ([export.go](../services/confluence/export.go:70)); no space/wiki source ID. Add a space source ID, or require the importer to resolve comments through a job-scoped mapping table. Never perform a global source-ID lookup. (With CSV single-space bundles the collision is bounded to *cross-instance* re-use of numeric IDs, but the job-scoped mapping is still the correct fix — see §1's source namespace.) Note the comment now carries `props.confluence_author_account_id` for author attribution, which is orthogonal to scoping.
+
+### 3. Produce a complete bundle
+
+Still unaddressed: the printed ZIP recipe zips only the attachments dir (`cd data && zip -r ../import.zip .`) and omits the separately written JSONL, which is emitted to the `--output` path in the cwd ([transform.go](../commands/transform.go:397)). The bundle should contain:
+
+```text
+import.jsonl
+import-manifest.json
+data/<page-id>/<attachment>
+```
+
+Ideally add `--bundle output.zip` so operators cannot package it incorrectly.
+
+### 4. Align validation with Docs
+
+- Docs pages cap Body and SearchText at 2 MiB (`PageBodyMaxBytes`/`PageSearchTextMaxBytes`, [page.go:23](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:23),[:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:29)); `mmetl` currently warns only above 10 MiB. Also cap Props at 64 KiB (`PagePropsMaxBytes`, [page.go:26](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:26)) — relevant now that `mmetl` stamps `props.confluence_author_account_id`, `import_labels`, and `confluence_space_key` into every page.
+- User validation is now partly served by the manifest `users` list (`{account_id, confluence_username, mattermost_username}`): `mmetl` cannot check usernames against a live server, but it surfaces every source user and its resolved/fallback Mattermost username so an operator can review unmapped users pre-import. `--fallback-user` covers unmapped users; keep requiring an explicit valid fallback. The importer should validate the manifest users against the target server.
+- `update_at` is still dropped: `IntermediatePage.UpdateAt` is populated but `PageImportData` emits only `create_at`. Emitting it is necessary but not sufficient — the plugin's interactive `CreatePage` stamps `CreateAt`/`UpdateAt`/`LastModifiedBy` itself ([page.go:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/app/page.go:29)), so preserving source timestamps also requires the import-specific methods in the plugin §2.
+- Validate TipTap JSON before output (still not done).
+
+### 5. Fix fidelity blockers
+
+- The CSV parser does not populate `export.Attachments` at all ([csv_parser.go](../services/confluence/csv_parser.go)), so attachment metadata is absent, `ExtractAttachments` matches nothing, and — because normalization needs the filename→ID map — `CONF_ATTACHMENT` tokens are **not** rewritten to `CONF_FILE`. A runtime warning was added when `backupAttachments=true` but no files match ([attachments.go:38](../services/confluence/attachments.go:38)). Net: **attachments are effectively unsupported in the CSV path today** and the attachment file layout for CSV exports is still unverified.
+- Multi-space is **not applicable to a single CSV bundle**: Confluence Cloud CSV exports are `exportType=space` (one space per export), and the CSV parser assigns every page to the single `export.SpaceKey`. The multi-space `Spaces`/`ExportWikis` scaffolding is XML-era carryover. Treat **one bundle = one Space**; migrating N spaces means N bundles imported separately. Either drop the multi-space scaffolding or gate it behind a verified multi-space export format — do not claim multi-space support from the current code.
+- Page restrictions (`content_perm`) are currently **not parsed** in the CSV path (deliberately deferred — see [confluence-csv-export-support.md](confluence-csv-export-support.md)), and there is no runtime warning identifying restricted pages. Detect/block or explicitly acknowledge them; otherwise restricted content becomes visible to every imported Space member.
+- Continue to support both unresolved `CONF_ATTACHMENT` and normalized `CONF_FILE` tokens until the attachment path is fixed and the producer always normalizes them.
+
+### 6. Add tests
+
+CSV-parser unit tests now exist ([csv_parser_test.go](../services/confluence/csv_parser_test.go): gzip sniff, historical/draft filtering, mention resolution, identity props, inline anchors, labels). Still missing: tests asserting the **exact emitted JSONL schema** per line type, bundle layout + checksums, source-ID collisions across instances, comment scoping, hierarchy, re-imports, and a full `mmetl → Docs` fixture. (Multi-space routing is no longer a test target — see §5; test one-bundle-one-Space instead.)
+
+## Changes required in `mattermost-plugin-docs`
+
+Base the work on `origin/MM-69268-page-tree-crud-url-api`, not the foundations-only `master` (verified still unmerged: `master` is 3 commits of foundations only; the branch is 62 commits ahead and adds `server/api.go` REST routes, `api_page.go`/`api_space.go`, page move/duplicate, and migration `000004`). On `master` today, `initRouter` registers **zero** routes ([api.go:14](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/api.go:14)); the Space/Page routes exist only on the branch. `CreateSpace` exists at the store layer on `master` ([space_store.go:30](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/store/space_store.go:30)) but the app/HTTP `handleCreateSpace` is on the branch. **No import API (`/imports`) exists on either.**
+
+The plugin should ingest `mmetl`'s new bundle artifacts directly: the manifest `users` list as the authoritative source-user → Mattermost-username map, and each entity's `props.confluence_author_account_id` for attribution — rather than re-deriving identity from raw content.
+
+### 1. Add durable import persistence
+
+Suggested tables:
+
+- `DOCS_ImportJob`: state, phase, actor, target, checksum, counts, errors, timestamps.
+- `DOCS_ImportEntity`: `(source_namespace, entity_type, external_id, scope_id) → local_id`.
+- Comment and page-file ownership tables.
+
+Use explicit source-ID columns/tables instead of repeatedly scanning JSONB Props. Confirmed necessary: `DOCS_Page` today has a `Props` JSONB column but **no source-ID column** — the closest field, `OriginalId` ([page.go:61](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:61)), is a version-snapshot pointer, not an external import key. So without new mapping tables the importer would have to scan `Props` for `import_source_id`. Seed `DOCS_ImportEntity` from `mmetl`'s manifest `users` list (for user identities) plus the per-line `*_import_source_id` fields (for spaces/pages/comments).
+
+### 2. Add import-specific services
+
+Normal interactive `CreatePage` does not accept source props or timestamps ([page.go](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/app/page.go:29)). Add dedicated methods such as:
+
+- `ImportSpace`
+- `ImportPage`
+- `ImportComment`
+- `AttachImportedFile`
+- `FinalizeImport`
+
+These methods should preserve source metadata atomically, avoid per-entity notifications, derive `SearchText` from TipTap, and enforce the existing depth-10 hierarchy limit.
+
+### 3. Implement a restartable job
+
+1. Verify ZIP limits, paths, manifest, and checksum.
+2. Parse and preflight without writes.
+3. Resolve teams, users, source IDs, hierarchy, and capabilities.
+4. Create Spaces/backing channels with compensation for orphan channels.
+5. Insert pages topologically in bounded transactions.
+6. Import comments and attachments.
+7. Repair hierarchy and resolve links.
+8. Compare final counts with the manifest and mark the job complete.
+
+Retries should resume from committed phases; re-running the same bundle should be a no-op.
+
+### 4. Add comment persistence
+
+The plugin currently has no comment model. Add author, source timestamp, parent comment, resolved state, inline anchor, Props, and scoped source ID. Do not silently discard comments.
+
+### 5. Add attachment ownership
+
+`UploadFile` can place files in the Space backing channel, but Docs needs durable Page→File ownership and authorized download URLs. A plugin-owned join table may avoid a core change. If Files must have a first-class `PageId`, that becomes an additional Mattermost core change.
+
+### 6. Resolve placeholders safely
+
+Traverse parsed TipTap JSON rather than blindly replacing strings. Resolve page IDs/titles and attachment source IDs to canonical Docs URLs. Report unresolved references and make finalization idempotent.
+
+### 7. Add the admin API
+
+Add routes such as:
+
+- `POST /api/v1/imports`
+- `GET /api/v1/imports/{id}`
+- `POST /api/v1/imports/{id}/retry`
+- `POST /api/v1/imports/{id}/cancel`
+
+Require system-admin authorization initially. Add audit records, progress events, and cleanup. Uploaded archives must use cluster-visible durable storage, not local `/tmp`.
+
+### 8. Define membership and ACL semantics
+
+JSONL contains authors but no reader membership. The import request must specify an access policy, such as an existing membership-source channel or an explicit member list. Create one backing Space channel per imported space and copy/sync authorized membership. Default to private/admin-only when restrictions are unknown. Note the linkage model: `DOCS_Space.ChannelId` ([space.go:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/space.go:29)) references a channel by ID, and that channel's `ChannelTypeSpace` (`"S"`) is a **core** concept supplied by the core branch (below) — the plugin does not define a channel-type enum itself. With CSV bundles being one-space (mmetl §5), this is exactly one backing channel per bundle.
+
+## Changes required in Mattermost
+
+For the intended Space-channel implementation, land `origin/MM-69268-page-tree-crud-url-api-core`, which supplies `ChannelTypeSpace` and the feature flag. Verified present on that branch and **not yet merged to master** (despite a misleadingly-titled `merge to master` commit on the branch): `ChannelTypeSpace ChannelType = "S"` ([channel.go:32](/Users/willyfrog/Proyectos/mattermost/server/public/model/channel.go:32)) and `EnableDocs` ([feature_flags.go:111](/Users/willyfrog/Proyectos/mattermost/server/public/model/feature_flags.go:111)); neither exists on `master`. The bulk importer still rejects unknown line types with a 400 ([import.go:397](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go:397)), so Docs JSONL must never reach it.
+
+Do not extend standard `mmctl import` with Docs-specific parsing. Optionally add:
+
+```text
+mmctl docs import <bundle.zip>
+mmctl docs import validate <bundle.zip>
+mmctl docs import status <job-id>
+```
+
+**Naming caveat:** an `mmctl docs` command already exists — it generates mmctl's own cobra documentation ([docs.go:13](/Users/willyfrog/Proyectos/mattermost/server/cmd/mmctl/commands/docs.go:13)). Reusing `docs` for a Docs-feature import would collide; either rename the existing doc-gen command, pick a different verb (e.g. `mmctl spaces import`), or carefully nest the new subcommands under it. These commands should call the plugin API. Core changes may be needed only if the archive/file design requires generic durable plugin uploads or first-class Page-owned `FileInfo`.
+
+Docs search and UI belong primarily in the plugin. Mattermost global search does not index `DOCS_Page.SearchText`; AI/RAG integration is a separate Docs ↔ Mattermost AI project.
+
+## Rollout sequence
+
+1. Land the Docs CRUD and core `ChannelTypeSpace` branches.
+2. Freeze the v2 contract and add v1 compatibility fixtures.
+3. Implement import/mapping tables plus Spaces, pages, hierarchy, and idempotency.
+4. Add comments, attachments, access policy, and final link resolution.
+5. Add upload/status APIs and optional `mmctl docs` commands.
+6. Run a three-repository E2E test covering counts, hierarchy, links, authors, permissions, retries, and checksums.
+7. Enable production Confluence imports only after those tests pass.
+
+A page-only milestone is acceptable only if unsupported comments, attachments, and restricted pages are rejected or require an explicit `allow_partial` acknowledgement. The importer must not report full success while silently dropping them.
+
+## End-state operator flow
+
+```bash
+mkdir -p staging
+mmetl transform confluence \
+  --team myteam \
+  --channel docs \
+  --file confluence-export.zip \
+  --output staging/import.jsonl \
+  --attachments-dir staging
+
+(cd staging && zip -r ../confluence-docs.zip import.jsonl import-manifest.json data)
+
+mmctl docs import confluence-docs.zip
+mmctl docs import status <job-id>
+```
+
+The `--channel` flag in this example is legacy v1 behavior. In the v2 contract it should either be removed or explicitly repurposed as an access-policy input; it must not be used as a Docs Space backing channel.
+

--- a/implementation-plans/confluence-jsonl-docs-plugin-integration.md
+++ b/implementation-plans/confluence-jsonl-docs-plugin-integration.md
@@ -1,8 +1,19 @@
 # Confluence JSONL → Mattermost Docs integration
 
+> **Status:** Producer and CRUD foundations are available; the Docs import
+> consumer is not. `mmetl` emits the v2 bundle, Mattermost core Space-channel
+> support landed in
+> [mattermost#37321](https://github.com/mattermost/mattermost/pull/37321), and
+> Docs Space/Page CRUD landed in
+> [mattermost-plugin-docs#4](https://github.com/mattermost/mattermost-plugin-docs/pull/4).
+> The remaining work is the durable Docs plugin import API/job and its
+> end-to-end validation.
+
 ## Bottom line
 
-The JSONL produced by `mmetl` cannot currently be imported into the checked-out Docs plugin or Mattermost `master` as-is. It targets the older Mattermost `wiki-poc` import contract, while ownership of Spaces and Pages has moved into `mattermost-plugin-docs`.
+The v2 bundle produced by `mmetl` cannot yet be imported because the Docs plugin
+has no import API/job. It must not be sent to Mattermost's standard bulk
+importer, which remains unaware of Docs-specific JSONL entities.
 
 The recommended architecture is:
 
@@ -10,53 +21,68 @@ The recommended architecture is:
 Confluence export
   → mmetl versioned ZIP bundle
   → Docs plugin admin import API/job
-      → DOCS_Space / DOCS_Page / comments / mappings
-      → Mattermost APIs for channels, users, membership, and files
+      → DOCS_Space / DOCS_Page / import mappings
+      → threaded Mattermost posts in the Space backing channel for comments
+      → Mattermost plugin APIs for channels, users, membership, and files
 ```
 
-The Docs plugin should own parsing, validation, import jobs, idempotency, hierarchy, comments, attachments, and link resolution. Mattermost core should remain unaware of Docs-specific JSONL entities.
+The Docs plugin owns bundle parsing, validation, import jobs, idempotency,
+hierarchy, threaded comments, attachments, and link resolution. Mattermost core
+owns the opaque `ChannelTypeSpace` primitive and posts, but remains unaware of
+Docs JSONL line types.
 
 ## Current incompatibilities
 
-- `mmetl` emits custom `wiki`, `page`, `page_comment`, and `resolve_wiki_placeholders` lines ([export.go](../services/confluence/export.go:20)).
-- Docs `master` contains foundational Space/Page storage but no import API, import job, comments, attachment ownership, or search implementation ([api.go](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/api.go:14)).
-- Mattermost bulk import has no fields for these entities and rejects unknown line types ([import_types.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/imports/import_types.go:15), [import.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go:398)).
-- The old [`wiki-poc` importer](/Users/willyfrog/.supacode/repos/mattermost/wiki-poc/server/channels/app/import_wiki_functions.go:74) is useful as an algorithm and test reference, but writes obsolete core Wiki/Page models rather than plugin tables.
+- `mmetl` emits custom v2 `space`, `page`, `page_comment`, and
+  `resolve_space_placeholders` lines
+  ([export.go](../services/confluence/export.go)).
+- Docs `master` now has Space/Page CRUD and creates a `ChannelTypeSpace` backing
+  channel, but it still has no bundle import API, durable import job, import
+  mappings, or complete attachment import path.
+- Mattermost bulk import has no fields for these entities and rejects unknown
+  line types ([import_types.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/imports/import_types.go:15),
+  [import.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go:398)).
+- The old [`wiki-poc` importer](/Users/willyfrog/.supacode/repos/mattermost/wiki-poc/server/channels/app/import_wiki_functions.go:74)
+  remains useful as an algorithm and test reference, but writes obsolete core
+  Wiki/Page models rather than plugin tables and Space-channel posts.
 
 ## Changes required in `mmetl`
 
-> **Status update — CSV support has since landed** (branch
-> `worktree-confluence-csv-parser`, see [confluence-csv-export-support.md](confluence-csv-export-support.md)).
-> This changes the baseline several items below were written against:
-> - Input is now **Confluence Cloud CSV** exports (the legacy `entities.xml`/HTML
->   parser was removed). The producer emits the **same v1 line types** — `wiki`,
->   `page`, `page_comment`, `resolve_wiki_placeholders` — so every contract item
->   below (§1 versioning, §3 bundle, source namespace) is still open.
-> - **Identity is now preserved** for downstream matching: every `page`/`page_comment`
->   carries `props.confluence_author_account_id` (the Atlassian account ID), and the
->   manifest now includes a `users` list of `{account_id, confluence_username,
->   mattermost_username}`. The Docs importer should consume these (see §4 and the
->   plugin-side mapping tables) rather than re-deriving identity.
-> - `ValidateExportFormat` now accepts the CSV signal (it no longer requires
->   `entities.xml`).
-> - **CSV space exports are single-space by construction** (`exportType=space`),
->   which changes the multi-space item in §5.
+> **Status:** The producer work is substantially complete; see
+> [confluence-docs-contract-alignment.md](confluence-docs-contract-alignment.md).
+> Input is Confluence Cloud CSV, output is the v2 single-Space bundle, identity
+> metadata is preserved, and restrictions are detected. The legacy channel
+> surface is fully removed: no `--channel` flag, no `target.channel` manifest
+> field, no channel constructor arguments, and no server-side channel
+> validation — mmetl never names the Space backing channel. Bundle `team`
+> values are advisory metadata; the import request is authoritative. The only
+> material data blocker still on the producer side is verification of the
+> attachment byte layout against a real attachment-bearing CSV export.
 
 ### 1. Freeze and version the contract
 
-- Continue accepting v1 `wiki` records as an adapter format, but define each one as a Docs Space.
-- For v2, rename `wiki` to `space`.
-- Do not treat `wiki.channel` as the Space backing channel; the plugin creates its own `ChannelTypeSpace` channel.
-- Make the import request authoritative for target team and access policy.
-- Add a source namespace, such as Confluence cloud/site ID. Numeric page IDs and space keys can collide across Confluence instances.
+- v2 is defined and documented as `space`, `page`, `page_comment`, and
+  `resolve_space_placeholders`; there is no shipped v1 consumer to preserve.
+- The bundle-level source namespace scopes numeric page/comment IDs and space
+  keys across Confluence instances.
+- The import request is authoritative for target team and access policy. Bundle
+  `team` values are advisory metadata: record them for audit and warn on a
+  mismatch, but never route the import from them.
+- The bundle never carries or selects the Space backing channel. The Docs plugin
+  creates its own `ChannelTypeSpace` channel in the requested team.
 
 ### 2. Fix comment scoping
 
-Standalone comments still contain only `page_import_source_id` ([export.go](../services/confluence/export.go:70)); no space/wiki source ID. Add a space source ID, or require the importer to resolve comments through a job-scoped mapping table. Never perform a global source-ID lookup. (With CSV single-space bundles the collision is bounded to *cross-instance* re-use of numeric IDs, but the job-scoped mapping is still the correct fix — see §1's source namespace.) Note the comment now carries `props.confluence_author_account_id` for author attribution, which is orthogonal to scoping.
+Resolve every comment through the current import job's page and comment mapping
+tables. Never perform a global lookup by bare `page_import_source_id` or comment
+source ID. The single-Space bundle and source namespace bound collisions, while
+the job mapping supplies the local page/post IDs needed for idempotent retries.
+`props.confluence_author_account_id` remains the attribution key and is
+orthogonal to scoping.
 
 ### 3. Produce a complete bundle
 
-Still unaddressed: the printed ZIP recipe zips only the attachments dir (`cd data && zip -r ../import.zip .`) and omits the separately written JSONL, which is emitted to the `--output` path in the cwd ([transform.go](../commands/transform.go:397)). The bundle should contain:
+Implemented by `--bundle`; the archive contains:
 
 ```text
 import.jsonl
@@ -64,31 +90,47 @@ import-manifest.json
 data/<page-id>/<attachment>
 ```
 
-Ideally add `--bundle output.zip` so operators cannot package it incorrectly.
+The importer should reject archives that do not contain the JSONL and manifest,
+and verify the manifest checksums before writing anything.
 
 ### 4. Align validation with Docs
 
-- Docs pages cap Body and SearchText at 2 MiB (`PageBodyMaxBytes`/`PageSearchTextMaxBytes`, [page.go:23](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:23),[:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:29)); `mmetl` currently warns only above 10 MiB. Also cap Props at 64 KiB (`PagePropsMaxBytes`, [page.go:26](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:26)) — relevant now that `mmetl` stamps `props.confluence_author_account_id`, `import_labels`, and `confluence_space_key` into every page.
-- User validation is now partly served by the manifest `users` list (`{account_id, confluence_username, mattermost_username}`): `mmetl` cannot check usernames against a live server, but it surfaces every source user and its resolved/fallback Mattermost username so an operator can review unmapped users pre-import. `--fallback-user` covers unmapped users; keep requiring an explicit valid fallback. The importer should validate the manifest users against the target server.
-- `update_at` is still dropped: `IntermediatePage.UpdateAt` is populated but `PageImportData` emits only `create_at`. Emitting it is necessary but not sufficient — the plugin's interactive `CreatePage` stamps `CreateAt`/`UpdateAt`/`LastModifiedBy` itself ([page.go:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/app/page.go:29)), so preserving source timestamps also requires the import-specific methods in the plugin §2.
-- Validate TipTap JSON before output (still not done).
+- The producer warns on the Docs Body/Props limits, validates TipTap JSON, emits
+  `update_at`, and surfaces source users in the manifest.
+- `SearchText` is importer-derived from TipTap, so its authoritative 2 MiB check
+  belongs in the plugin preflight/import-specific page method.
+- The importer must validate mapped/fallback usernames against the target server
+  and preserve source timestamps through import-specific methods; interactive
+  CRUD methods overwrite them.
 
 ### 5. Fix fidelity blockers
 
-- The CSV parser does not populate `export.Attachments` at all ([csv_parser.go](../services/confluence/csv_parser.go)), so attachment metadata is absent, `ExtractAttachments` matches nothing, and — because normalization needs the filename→ID map — `CONF_ATTACHMENT` tokens are **not** rewritten to `CONF_FILE`. A runtime warning was added when `backupAttachments=true` but no files match ([attachments.go:38](../services/confluence/attachments.go:38)). Net: **attachments are effectively unsupported in the CSV path today** and the attachment file layout for CSV exports is still unverified.
-- Multi-space is **not applicable to a single CSV bundle**: Confluence Cloud CSV exports are `exportType=space` (one space per export), and the CSV parser assigns every page to the single `export.SpaceKey`. The multi-space `Spaces`/`ExportWikis` scaffolding is XML-era carryover. Treat **one bundle = one Space**; migrating N spaces means N bundles imported separately. Either drop the multi-space scaffolding or gate it behind a verified multi-space export format — do not claim multi-space support from the current code.
-- Page restrictions (`content_perm`) are currently **not parsed** in the CSV path (deliberately deferred — see [confluence-csv-export-support.md](confluence-csv-export-support.md)), and there is no runtime warning identifying restricted pages. Detect/block or explicitly acknowledge them; otherwise restricted content becomes visible to every imported Space member.
-- Continue to support both unresolved `CONF_ATTACHMENT` and normalized `CONF_FILE` tokens until the attachment path is fixed and the producer always normalizes them.
+- Attachment metadata and `CONF_ATTACHMENT` → `CONF_FILE` normalization are
+  implemented. The on-disk CSV attachment layout remains unverified; keep both
+  placeholder forms supported until a real fixture proves extraction.
+- One bundle equals one Space; migrating N spaces means N independent jobs.
+- View restrictions are detected, warned, included in the manifest, and can fail
+  production with `--fail-on-restricted`. They are not converted into an ACL.
 
 ### 6. Add tests
 
-CSV-parser unit tests now exist ([csv_parser_test.go](../services/confluence/csv_parser_test.go): gzip sniff, historical/draft filtering, mention resolution, identity props, inline anchors, labels). Still missing: tests asserting the **exact emitted JSONL schema** per line type, bundle layout + checksums, source-ID collisions across instances, comment scoping, hierarchy, re-imports, and a full `mmetl → Docs` fixture. (Multi-space routing is no longer a test target — see §5; test one-bundle-one-Space instead.)
+Parser and exact-schema producer tests exist. Remaining integration coverage is
+plugin-side: archive/checksum validation, source-ID collisions, threaded comment
+scoping, hierarchy, retries/re-imports, membership, attachments, and one full
+`mmetl → Docs` fixture.
 
 ## Changes required in `mattermost-plugin-docs`
 
-Base the work on `origin/MM-69268-page-tree-crud-url-api`, not the foundations-only `master` (verified still unmerged: `master` is 3 commits of foundations only; the branch is 62 commits ahead and adds `server/api.go` REST routes, `api_page.go`/`api_space.go`, page move/duplicate, and migration `000004`). On `master` today, `initRouter` registers **zero** routes ([api.go:14](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/api.go:14)); the Space/Page routes exist only on the branch. `CreateSpace` exists at the store layer on `master` ([space_store.go:30](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/store/space_store.go:30)) but the app/HTTP `handleCreateSpace` is on the branch. **No import API (`/imports`) exists on either.**
+Space/Page CRUD from mattermost-plugin-docs#4 is now on `master`: it creates an
+opaque `ChannelTypeSpace` backing channel and exposes scoped Space/Page APIs.
+The remaining work starts from that baseline. There is still no import API
+(`/imports`) or durable import job.
 
-The plugin should ingest `mmetl`'s new bundle artifacts directly: the manifest `users` list as the authoritative source-user → Mattermost-username map, and each entity's `props.confluence_author_account_id` for attribution — rather than re-deriving identity from raw content.
+The plugin should ingest `mmetl`'s bundle artifacts directly: the manifest
+`users` list as the source-user → Mattermost-username proposal, and each
+entity's `props.confluence_author_account_id` for attribution, rather than
+re-deriving identity from raw content. The target server must validate the
+proposed usernames before writes.
 
 ### 1. Add durable import persistence
 
@@ -96,7 +138,8 @@ Suggested tables:
 
 - `DOCS_ImportJob`: state, phase, actor, target, checksum, counts, errors, timestamps.
 - `DOCS_ImportEntity`: `(source_namespace, entity_type, external_id, scope_id) → local_id`.
-- Comment and page-file ownership tables.
+- Page-file ownership tables. Comments use Mattermost posts in the Space
+  backing channel; their source IDs still use `DOCS_ImportEntity` mappings.
 
 Use explicit source-ID columns/tables instead of repeatedly scanning JSONB Props. Confirmed necessary: `DOCS_Page` today has a `Props` JSONB column but **no source-ID column** — the closest field, `OriginalId` ([page.go:61](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/page.go:61)), is a version-snapshot pointer, not an external import key. So without new mapping tables the importer would have to scan `Props` for `import_source_id`. Seed `DOCS_ImportEntity` from `mmetl`'s manifest `users` list (for user identities) plus the per-line `*_import_source_id` fields (for spaces/pages/comments).
 
@@ -110,14 +153,22 @@ Normal interactive `CreatePage` does not accept source props or timestamps ([pag
 - `AttachImportedFile`
 - `FinalizeImport`
 
-These methods should preserve source metadata atomically, avoid per-entity notifications, derive `SearchText` from TipTap, and enforce the existing depth-10 hierarchy limit.
+These methods should preserve source metadata atomically, avoid per-entity
+notifications, derive and validate `SearchText` from TipTap, and enforce the
+existing depth-10 hierarchy limit. `ImportComment` creates a Mattermost post in
+the Space backing channel and records the source-comment → post mapping; it does
+not write a plugin-owned comment row.
 
 ### 3. Implement a restartable job
 
 1. Verify ZIP limits, paths, manifest, and checksum.
-2. Parse and preflight without writes.
-3. Resolve teams, users, source IDs, hierarchy, and capabilities.
-4. Create Spaces/backing channels with compensation for orphan channels.
+2. Parse and preflight without writes. Treat bundle `team` as advisory
+   metadata; the request's target team is authoritative, and a mismatch is
+   recorded as a warning/audit detail.
+3. Resolve the requested team, users, source IDs, hierarchy, and capabilities;
+   require Mattermost 11.10+ with `EnableDocs=true`.
+4. Create Spaces/backing channels through the Docs/plugin API, persist the
+   returned channel ID immediately, and compensate for orphan channels.
 5. Insert pages topologically in bounded transactions.
 6. Import comments and attachments.
 7. Repair hierarchy and resolve links.
@@ -125,9 +176,27 @@ These methods should preserve source metadata atomically, avoid per-entity notif
 
 Retries should resume from committed phases; re-running the same bundle should be a no-op.
 
-### 4. Add comment persistence
+### 4. Import comments as Space-channel post threads
 
-The plugin currently has no comment model. Add author, source timestamp, parent comment, resolved state, inline anchor, Props, and scoped source ID. Do not silently discard comments.
+Comments are Mattermost posts in the Space's `ChannelTypeSpace` backing
+channel, not plugin-owned comment rows:
+
+- A top-level Confluence page comment becomes a root post carrying the local
+  Docs page ID and source metadata in Props.
+- A reply resolves `parent_comment_import_source_id` through the job mapping and
+  is created in the corresponding Mattermost thread (`RootId`). Preserve the
+  immediate source-parent ID in Props when Confluence nesting is deeper than
+  Mattermost's flat reply model.
+- Record every source comment ID → post ID mapping in `DOCS_ImportEntity` before
+  dependent replies run. Retries reuse the mapping and never duplicate posts.
+- Preserve author, source timestamps, page ID, inline anchor, resolved state,
+  and `confluence_author_account_id` in the post/Props contract.
+- Use an import-specific post path that suppresses notifications and ordinary
+  interactive side effects. Space membership supplies post authorization, and
+  core excludes Space-channel posts from normal chat unread/read-state queries.
+
+Do not silently discard comments or report a full import when a thread cannot
+be reconstructed.
 
 ### 5. Add attachment ownership
 
@@ -150,52 +219,96 @@ Require system-admin authorization initially. Add audit records, progress events
 
 ### 8. Define membership and ACL semantics
 
-JSONL contains authors but no reader membership. The import request must specify an access policy, such as an existing membership-source channel or an explicit member list. Create one backing Space channel per imported space and copy/sync authorized membership. Default to private/admin-only when restrictions are unknown. Note the linkage model: `DOCS_Space.ChannelId` ([space.go:29](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/space.go:29)) references a channel by ID, and that channel's `ChannelTypeSpace` (`"S"`) is a **core** concept supplied by the core branch (below) — the plugin does not define a channel-type enum itself. With CSV bundles being one-space (mmetl §5), this is exactly one backing channel per bundle.
+JSONL contains authors but no reader membership. The import request must specify
+the authoritative target team and an access policy, such as an existing
+membership-source channel or an explicit member list. Bundle `team` is advisory
+metadata only. Create one backing Space channel per bundle and copy/sync the
+authorized membership; default to private/admin-only when restrictions are
+unknown.
 
-## Changes required in Mattermost
+`DOCS_Space.ChannelId` ([space.go](/Users/willyfrog/Proyectos/mattermost-plugin-docs/server/model/space.go))
+is the durable linkage and must be persisted immediately after creation. Space
+channels are intentionally absent from generic get/list/search APIs, so recovery
+must use the stored ID and plugin `GetChannelOfType`, never channel discovery by
+name. Add/remove members through the plugin/Docs APIs.
 
-For the intended Space-channel implementation, land `origin/MM-69268-page-tree-crud-url-api-core`, which supplies `ChannelTypeSpace` and the feature flag. Verified present on that branch and **not yet merged to master** (despite a misleadingly-titled `merge to master` commit on the branch): `ChannelTypeSpace ChannelType = "S"` ([channel.go:32](/Users/willyfrog/Proyectos/mattermost/server/public/model/channel.go:32)) and `EnableDocs` ([feature_flags.go:111](/Users/willyfrog/Proyectos/mattermost/server/public/model/feature_flags.go:111)); neither exists on `master`. The bulk importer still rejects unknown line types with a 400 ([import.go:397](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go:397)), so Docs JSONL must never reach it.
+Standard channel ABAC, privacy conversion, schemes, and move operations do not
+govern `ChannelTypeSpace`. Space membership is the available channel-level
+authorization boundary; finer page restrictions require a future plugin-owned
+ACL. View-restricted Confluence pages must therefore remain warning/fail items,
+not be treated as faithfully migrated.
+
+## Mattermost baseline and constraints
+
+Core support landed in mattermost#37321 (merge `5f7f967a`):
+
+- `ChannelTypeSpace = "S"` and `EnableDocs` (default false).
+- Plugin `RestoreChannel` and `GetChannelOfType` APIs, documented for Mattermost
+  11.10+.
+- Plugin lifecycle and member operations support Space channels, while generic
+  `/channels` creation/get/list/search/export/analytics paths intentionally hide
+  or reject them.
+- Space membership participates in authorization, but ordinary chat unread,
+  read-state, lifecycle posts, and channel events are suppressed where
+  appropriate.
+
+The importer must preflight Mattermost 11.10+ and `EnableDocs=true`, create the
+backing channel through the Docs/plugin path, and persist its returned ID. It
+must not use generic channel REST APIs to discover or manage the Space.
+
+The standard bulk importer still rejects unknown Docs line types with a 400
+([import.go](/Users/willyfrog/Proyectos/mattermost/server/channels/app/import.go)),
+so Docs JSONL must never reach it. No additional core import parsing is planned.
+Core changes may still be needed if the archive/file design requires generic
+durable plugin uploads or first-class Page-owned `FileInfo`.
+
+Follow-up: a post-merge review noted that plugin `RestoreChannel` does not emit
+the equivalent core audit record. Until that is fixed upstream, the Docs import
+job must audit compensation/restore operations itself.
 
 Do not extend standard `mmctl import` with Docs-specific parsing. Optionally add:
 
 ```text
-mmctl docs import <bundle.zip>
-mmctl docs import validate <bundle.zip>
-mmctl docs import status <job-id>
+mmctl spaces import <bundle.zip>
+mmctl spaces import validate <bundle.zip>
+mmctl spaces import status <job-id>
 ```
 
-**Naming caveat:** an `mmctl docs` command already exists — it generates mmctl's own cobra documentation ([docs.go:13](/Users/willyfrog/Proyectos/mattermost/server/cmd/mmctl/commands/docs.go:13)). Reusing `docs` for a Docs-feature import would collide; either rename the existing doc-gen command, pick a different verb (e.g. `mmctl spaces import`), or carefully nest the new subcommands under it. These commands should call the plugin API. Core changes may be needed only if the archive/file design requires generic durable plugin uploads or first-class Page-owned `FileInfo`.
+**Naming note:** an `mmctl docs` command already exists — it generates mmctl's
+own cobra documentation
+([docs.go](/Users/willyfrog/Proyectos/mattermost/server/cmd/mmctl/commands/docs.go)).
+Use a non-conflicting command such as `mmctl spaces`; it should call the plugin
+API rather than parse Docs entities in core.
 
 Docs search and UI belong primarily in the plugin. Mattermost global search does not index `DOCS_Page.SearchText`; AI/RAG integration is a separate Docs ↔ Mattermost AI project.
 
 ## Rollout sequence
 
-1. Land the Docs CRUD and core `ChannelTypeSpace` branches.
-2. Freeze the v2 contract and add v1 compatibility fixtures.
-3. Implement import/mapping tables plus Spaces, pages, hierarchy, and idempotency.
-4. Add comments, attachments, access policy, and final link resolution.
-5. Add upload/status APIs and optional `mmctl docs` commands.
-6. Run a three-repository E2E test covering counts, hierarchy, links, authors, permissions, retries, and checksums.
-7. Enable production Confluence imports only after those tests pass.
+1. **Done:** land Docs CRUD, core `ChannelTypeSpace`, and the mmetl v2 contract.
+2. Implement import jobs/mapping tables plus Spaces, pages, hierarchy, target
+   team authority, and idempotency.
+3. Import `page_comment` records as Space-channel post threads; add attachments,
+   access policy, and final link resolution.
+4. Add upload/status APIs and optional `mmctl spaces import` commands.
+5. Run a three-repository E2E test covering counts, hierarchy, links, threaded
+   comments, authors, membership, restrictions, retries, and checksums.
+6. Enable production Confluence imports only after those tests pass.
 
 A page-only milestone is acceptable only if unsupported comments, attachments, and restricted pages are rejected or require an explicit `allow_partial` acknowledgement. The importer must not report full success while silently dropping them.
 
 ## End-state operator flow
 
 ```bash
-mkdir -p staging
 mmetl transform confluence \
   --team myteam \
-  --channel docs \
   --file confluence-export.zip \
-  --output staging/import.jsonl \
-  --attachments-dir staging
+  --bundle confluence-docs.zip
 
-(cd staging && zip -r ../confluence-docs.zip import.jsonl import-manifest.json data)
-
-mmctl docs import confluence-docs.zip
-mmctl docs import status <job-id>
+mmctl spaces import --team myteam confluence-docs.zip
+mmctl spaces import status <job-id>
 ```
 
-The `--channel` flag in this example is legacy v1 behavior. In the v2 contract it should either be removed or explicitly repurposed as an access-policy input; it must not be used as a Docs Space backing channel.
-
+The import command's `--team` is authoritative. The bundle's `team` value is an
+advisory record of producer/operator intent; a mismatch is warned and audited
+but does not redirect the import. No channel argument is accepted: the Docs
+plugin creates and owns the Space backing channel.

--- a/services/confluence/attachments.go
+++ b/services/confluence/attachments.go
@@ -98,42 +98,36 @@ func (t *Transformer) ExtractAttachments(zipReader *zip.Reader, export *Confluen
 		for _, att := range attachments {
 			var zipFile *zip.File
 			var zipPath string
+			var srcMap map[string]*zip.File
 
-			// Strategy 1: Exact match by attachment ID
+			// Strategy 1: exact match by attachment ID under the metadata page.
 			if pageFiles != nil {
 				if f, ok := pageFiles[att.ID]; ok {
-					zipFile = f
-					zipPath = f.Name
+					zipFile, zipPath, srcMap = f, f.Name, pageFiles
 				}
 			}
 
-			// Strategy 2: Try different page ID (use attachment's own PageID)
+			// Strategy 2: exact match by attachment ID under the attachment's own page.
 			if zipFile == nil && att.PageID != "" && att.PageID != pageID {
 				if altPageFiles := zipAttachmentsByPage[att.PageID]; altPageFiles != nil {
 					if f, ok := altPageFiles[att.ID]; ok {
-						zipFile = f
-						zipPath = f.Name
+						zipFile, zipPath, srcMap = f, f.Name, altPageFiles
 					}
 				}
 			}
 
-			// Strategy 3: Fall back to any available file under the page (for mismatched metadata)
-			if zipFile == nil && pageFiles != nil && len(pageFiles) > 0 {
-				for attID, f := range pageFiles {
-					zipFile = f
-					zipPath = f.Name
-					t.Logger.Debugf("Fallback match: expected ID %s, using %s", att.ID, attID)
-					delete(pageFiles, attID) // Mark as used
-					break
-				}
-			}
-
+			// Only deterministic, id-verified matches are accepted. We never fall
+			// back to an arbitrary file under the page: that could silently swap
+			// two attachments. An unmatched entry is skipped (and not emitted).
 			if zipFile == nil {
-				t.Logger.Warnf("Attachment file not found in ZIP: %s (page: %s, attachment ID: %s)",
-					att.FilePath, pageID, att.ID)
+				t.Logger.Warnf("No id-verified file for attachment in ZIP: %s (page: %s, attachment ID: %s) — skipping",
+					att.FileName, pageID, att.ID)
 				skippedCount++
 				continue
 			}
+
+			// Mark consumed so it cannot match another entry or be re-emitted.
+			delete(srcMap, att.ID)
 
 			// Determine output path: {pageID}/{filename} (relative to data/ directory)
 			// The server adds "data/" prefix during import, so JSONL paths should NOT include it
@@ -164,34 +158,20 @@ func (t *Transformer) ExtractAttachments(zipReader *zip.Reader, export *Confluen
 		}
 	}
 
-	// Also extract any attachments in ZIP that weren't in the metadata
-	extraCount := 0
-	for pageID, pageFiles := range zipAttachmentsByPage {
-		for attachmentID, f := range pageFiles {
-			// Generate a filename from the path
-			fileName := fmt.Sprintf("attachment_%s", attachmentID)
-			outputFullPath := filepath.Join(t.Config.AttachmentsDir, pageID, fileName)
-
-			outputDir := filepath.Dir(outputFullPath)
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
-				t.Logger.Warnf("Failed to create directory for extra attachment: %v", err)
-				continue
-			}
-
-			if err := extractZipFile(f, outputFullPath); err != nil {
-				t.Logger.Warnf("Failed to extract extra attachment %s: %v", f.Name, err)
-				continue
-			}
-			extraCount++
-		}
+	// Files in the ZIP that were not referenced by any attachment metadata are
+	// intentionally NOT extracted: pages reference attachments by source ID, so
+	// an unreferenced file could never be resolved and would only inflate the
+	// bundle, its checksum, and the extraction counts.
+	unreferenced := 0
+	for _, pageFiles := range zipAttachmentsByPage {
+		unreferenced += len(pageFiles)
 	}
-
-	if extraCount > 0 {
-		t.Logger.Infof("Extracted %d additional attachments not present in the CSV metadata", extraCount)
+	if unreferenced > 0 {
+		t.Logger.Infof("Ignoring %d ZIP attachment file(s) not referenced by any page metadata", unreferenced)
 	}
 
 	t.Logger.Infof("Attachment extraction complete: %d extracted, %d skipped", extractedCount, skippedCount)
-	t.Stats.AttachmentsExtracted = extractedCount + extraCount
+	t.Stats.AttachmentsExtracted = extractedCount
 	t.Stats.AttachmentsSkipped = skippedCount
 
 	return nil

--- a/services/confluence/attachments.go
+++ b/services/confluence/attachments.go
@@ -187,7 +187,7 @@ func (t *Transformer) ExtractAttachments(zipReader *zip.Reader, export *Confluen
 	}
 
 	if extraCount > 0 {
-		t.Logger.Infof("Extracted %d additional attachments not in XML metadata", extraCount)
+		t.Logger.Infof("Extracted %d additional attachments not present in the CSV metadata", extraCount)
 	}
 
 	t.Logger.Infof("Attachment extraction complete: %d extracted, %d skipped", extractedCount, skippedCount)

--- a/services/confluence/attachments.go
+++ b/services/confluence/attachments.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// attachmentPathRegex matches Confluence attachment paths: attachments/{pageID}/{attachmentID}/{version}
+var attachmentPathRegex = regexp.MustCompile(`^attachments/(\d+)/(\d+)/(\d+)$`)
+
+// sanitizeFilename removes path traversal characters from filenames to prevent directory escape attacks.
+// A malicious Confluence export could contain filenames like "../../../../etc/passwd".
+func sanitizeFilename(filename string) string {
+	// Get just the base name, stripping any directory components
+	filename = filepath.Base(filename)
+	// Remove any remaining path separators (paranoid check)
+	filename = strings.ReplaceAll(filename, "/", "_")
+	filename = strings.ReplaceAll(filename, "\\", "_")
+	// Remove leading dots to prevent hidden files and relative paths
+	filename = strings.TrimLeft(filename, ".")
+	// If filename is now empty, use a safe default
+	if filename == "" {
+		filename = "unnamed_attachment"
+	}
+	return filename
+}
+
+// ExtractAttachments extracts attachment files from the Confluence export ZIP
+// to the configured attachments directory.
+func (t *Transformer) ExtractAttachments(zipReader *zip.Reader, export *ConfluenceExport) error {
+	if t.Config.SkipAttachments {
+		t.Logger.Info("Skipping attachment extraction (--skip-attachments)")
+		return nil
+	}
+
+	if t.Config.AttachmentsDir == "" {
+		t.Logger.Warn("No attachments directory configured, skipping extraction")
+		return nil
+	}
+
+	t.Logger.Info("Extracting attachments from Confluence export")
+
+	// Build a map of actual attachment files in the ZIP organized by page ID
+	// Key: pageID, Value: map[attachmentID]*zip.File
+	zipAttachmentsByPage := make(map[string]map[string]*zip.File)
+
+	for _, f := range zipReader.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		matches := attachmentPathRegex.FindStringSubmatch(f.Name)
+		if matches == nil {
+			continue
+		}
+		pageID := matches[1]
+		attachmentID := matches[2]
+
+		if zipAttachmentsByPage[pageID] == nil {
+			zipAttachmentsByPage[pageID] = make(map[string]*zip.File)
+		}
+		// Store by attachmentID - if multiple versions, later one wins (typically higher version)
+		zipAttachmentsByPage[pageID][attachmentID] = f
+	}
+
+	t.Logger.Infof("Found %d pages with attachments in ZIP", len(zipAttachmentsByPage))
+
+	// TODO(csv-attachments): the on-disk attachment layout for Confluence Cloud CSV
+	// exports is unverified (the sample export contained no attachment files). The
+	// attachmentPathRegex above encodes the legacy XML-export layout
+	// (attachments/{pageID}/{attachmentID}/{version}); confirm and adjust it against
+	// a real CSV export that contains attachments. Warn loudly when the export
+	// claims attachments but none matched, so the mismatch is not silent.
+	if len(zipAttachmentsByPage) == 0 && len(export.Attachments) > 0 {
+		t.Logger.Warnf("Export references %d pages with attachment metadata but no files matched the expected attachments/{pageID}/{attachmentID}/{version} layout; the CSV export attachment layout may differ — attachments will be skipped", len(export.Attachments))
+	}
+
+	extractedCount := 0
+	skippedCount := 0
+
+	// Iterate through all attachments in the parsed export metadata
+	for pageID, attachments := range export.Attachments {
+		pageFiles := zipAttachmentsByPage[pageID]
+		if pageFiles == nil {
+			// Try using attachment's own PageID if different
+			if len(attachments) > 0 && attachments[0].PageID != pageID {
+				pageFiles = zipAttachmentsByPage[attachments[0].PageID]
+			}
+		}
+
+		for _, att := range attachments {
+			var zipFile *zip.File
+			var zipPath string
+
+			// Strategy 1: Exact match by attachment ID
+			if pageFiles != nil {
+				if f, ok := pageFiles[att.ID]; ok {
+					zipFile = f
+					zipPath = f.Name
+				}
+			}
+
+			// Strategy 2: Try different page ID (use attachment's own PageID)
+			if zipFile == nil && att.PageID != "" && att.PageID != pageID {
+				if altPageFiles := zipAttachmentsByPage[att.PageID]; altPageFiles != nil {
+					if f, ok := altPageFiles[att.ID]; ok {
+						zipFile = f
+						zipPath = f.Name
+					}
+				}
+			}
+
+			// Strategy 3: Fall back to any available file under the page (for mismatched metadata)
+			if zipFile == nil && pageFiles != nil && len(pageFiles) > 0 {
+				for attID, f := range pageFiles {
+					zipFile = f
+					zipPath = f.Name
+					t.Logger.Debugf("Fallback match: expected ID %s, using %s", att.ID, attID)
+					delete(pageFiles, attID) // Mark as used
+					break
+				}
+			}
+
+			if zipFile == nil {
+				t.Logger.Warnf("Attachment file not found in ZIP: %s (page: %s, attachment ID: %s)",
+					att.FilePath, pageID, att.ID)
+				skippedCount++
+				continue
+			}
+
+			// Determine output path: {pageID}/{filename} (relative to data/ directory)
+			// The server adds "data/" prefix during import, so JSONL paths should NOT include it
+			// But files are placed in data/ subdirectory in ZIP for correct lookup
+			// Sanitize filename to prevent path traversal attacks (e.g. "../../../../etc/passwd")
+			safeFilename := sanitizeFilename(att.FileName)
+			outputRelPath := filepath.Join(pageID, safeFilename)
+			outputFullPath := filepath.Join(t.Config.AttachmentsDir, pageID, safeFilename)
+
+			// Create directory structure
+			outputDir := filepath.Dir(outputFullPath)
+			if err := os.MkdirAll(outputDir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", outputDir, err)
+			}
+
+			// Extract the file
+			if err := extractZipFile(zipFile, outputFullPath); err != nil {
+				t.Logger.Warnf("Failed to extract attachment %s: %v", att.FileName, err)
+				skippedCount++
+				continue
+			}
+
+			// Update the attachment's FilePath to the output location
+			att.FilePath = outputRelPath
+
+			extractedCount++
+			t.Logger.Debugf("Extracted: %s -> %s", zipPath, outputFullPath)
+		}
+	}
+
+	// Also extract any attachments in ZIP that weren't in the metadata
+	extraCount := 0
+	for pageID, pageFiles := range zipAttachmentsByPage {
+		for attachmentID, f := range pageFiles {
+			// Generate a filename from the path
+			fileName := fmt.Sprintf("attachment_%s", attachmentID)
+			outputFullPath := filepath.Join(t.Config.AttachmentsDir, pageID, fileName)
+
+			outputDir := filepath.Dir(outputFullPath)
+			if err := os.MkdirAll(outputDir, 0755); err != nil {
+				t.Logger.Warnf("Failed to create directory for extra attachment: %v", err)
+				continue
+			}
+
+			if err := extractZipFile(f, outputFullPath); err != nil {
+				t.Logger.Warnf("Failed to extract extra attachment %s: %v", f.Name, err)
+				continue
+			}
+			extraCount++
+		}
+	}
+
+	if extraCount > 0 {
+		t.Logger.Infof("Extracted %d additional attachments not in XML metadata", extraCount)
+	}
+
+	t.Logger.Infof("Attachment extraction complete: %d extracted, %d skipped", extractedCount, skippedCount)
+	t.Stats.AttachmentsExtracted = extractedCount + extraCount
+	t.Stats.AttachmentsSkipped = skippedCount
+
+	return nil
+}
+
+// extractZipFile extracts a single file from a zip archive to the destination path.
+func extractZipFile(zipFile *zip.File, destPath string) error {
+	rc, err := zipFile.Open()
+	if err != nil {
+		return fmt.Errorf("failed to open zip entry: %w", err)
+	}
+	defer rc.Close()
+
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer destFile.Close()
+
+	if _, err := io.Copy(destFile, rc); err != nil {
+		return fmt.Errorf("failed to copy file contents: %w", err)
+	}
+
+	return nil
+}

--- a/services/confluence/confluence_test.go
+++ b/services/confluence/confluence_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractInlineCommentAnchors(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]string
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			expected: map[string]string{},
+		},
+		{
+			name:     "no inline comments",
+			content:  "<p>Hello world</p>",
+			expected: map[string]string{},
+		},
+		{
+			name:     "single inline comment",
+			content:  `<p>Some text <ac:inline-comment-marker ac:ref="123456">highlighted text</ac:inline-comment-marker> more text</p>`,
+			expected: map[string]string{"123456": "highlighted text"},
+		},
+		{
+			name:     "multiple inline comments",
+			content:  `<p><ac:inline-comment-marker ac:ref="111">first anchor</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="222">second anchor</ac:inline-comment-marker></p>`,
+			expected: map[string]string{"111": "first anchor", "222": "second anchor"},
+		},
+		{
+			name:     "inline comment with nested HTML",
+			content:  `<ac:inline-comment-marker ac:ref="456"><strong>bold</strong> and <em>italic</em> text</ac:inline-comment-marker>`,
+			expected: map[string]string{"456": "bold and italic text"},
+		},
+		{
+			name:    "real confluence format",
+			content: `<p>User submits <ac:inline-comment-marker ac:ref="f9c7bf1b-0d36-42a6-8dfa-85c6a6fd2d74">Contact us form either in portal or cloud</ac:inline-comment-marker></p>`,
+			expected: map[string]string{
+				"f9c7bf1b-0d36-42a6-8dfa-85c6a6fd2d74": "Contact us form either in portal or cloud",
+			},
+		},
+		{
+			name:     "whitespace handling",
+			content:  `<ac:inline-comment-marker ac:ref="789">   trimmed text   </ac:inline-comment-marker>`,
+			expected: map[string]string{"789": "trimmed text"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractInlineCommentAnchors(tc.content)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestConvertHTMLToMarkdown_JiraMacro(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name: "JIRA macro extracts key only",
+			html: `<p>Here's the epic for some more context: <ac:structured-macro ac:name="jira">
+				<ac:parameter ac:name="server">System JIRA</ac:parameter>
+				<ac:parameter ac:name="serverId">fa8b0166-b019-31be-aef3-0e1e83e7ecff</ac:parameter>
+				<ac:parameter ac:name="key">MM-50469</ac:parameter>
+			</ac:structured-macro></p>`,
+			expected: "Here's the epic for some more context: MM-50469",
+		},
+		{
+			name: "JIRA macro with key first",
+			html: `<p>Link to <ac:structured-macro ac:name="jira">
+				<ac:parameter ac:name="key">PROJ-123</ac:parameter>
+				<ac:parameter ac:name="server">JIRA Server</ac:parameter>
+			</ac:structured-macro> ticket</p>`,
+			expected: "Link to PROJ-123 ticket",
+		},
+		{
+			name:     "JIRA macro without key",
+			html:     `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="server">JIRA</ac:parameter></ac:structured-macro>`,
+			expected: "",
+		},
+		{
+			name:     "Code macro in comment",
+			html:     `<p>Use this code:</p><ac:structured-macro ac:name="code"><ac:plain-text-body>const x = 1;</ac:plain-text-body></ac:structured-macro>`,
+			expected: "Use this code:\n\n```\nconst x = 1;\n```",
+		},
+		{
+			name:     "Info panel macro",
+			html:     `<ac:structured-macro ac:name="info"><p>Important note</p></ac:structured-macro>`,
+			expected: "> Important note",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertHTMLToMarkdown(tc.html)
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(result))
+		})
+	}
+}
+
+func TestConvertHTMLToTipTap_JiraMacro(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		contains string
+	}{
+		{
+			name: "JIRA macro extracts key",
+			html: `<p>Link: <ac:structured-macro ac:name="jira">
+				<ac:parameter ac:name="key">MM-50469</ac:parameter>
+				<ac:parameter ac:name="server">System JIRA</ac:parameter>
+			</ac:structured-macro></p>`,
+			contains: "MM-50469",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ConvertHTMLToTipTap(tc.html)
+			require.NoError(t, err)
+			assert.Contains(t, result, tc.contains)
+			// Should NOT contain the server ID or server name
+			assert.NotContains(t, result, "System JIRA")
+			assert.NotContains(t, result, "fa8b0166")
+		})
+	}
+}
+
+func TestConvertHTMLToTipTap_ChildrenMacro(t *testing.T) {
+	// Test that dynamic macros like "children" generate placeholder text when no children info provided
+	// Before the fix, this would produce "true1title" from the parameter values
+	tests := []struct {
+		name        string
+		html        string
+		notContains []string
+		contains    string
+	}{
+		{
+			name: "children macro should generate placeholder when no children",
+			html: `<ac:structured-macro ac:name="children">
+				<ac:parameter ac:name="all">true</ac:parameter>
+				<ac:parameter ac:name="first">1</ac:parameter>
+			</ac:structured-macro>`,
+			notContains: []string{"true", "1", "true1"},
+			contains:    "list of child pages",
+		},
+		{
+			name: "contentbylabel macro should generate placeholder",
+			html: `<ac:structured-macro ac:name="contentbylabel">
+				<ac:parameter ac:name="cql">label = "important"</ac:parameter>
+				<ac:parameter ac:name="max">10</ac:parameter>
+			</ac:structured-macro>`,
+			notContains: []string{"important", "10", "cql", "max"},
+			contains:    "pages by label",
+		},
+		{
+			name: "pagetree macro should generate placeholder when no children",
+			html: `<ac:structured-macro ac:name="pagetree">
+				<ac:parameter ac:name="root">@home</ac:parameter>
+				<ac:parameter ac:name="expandCollapseAll">true</ac:parameter>
+			</ac:structured-macro>`,
+			notContains: []string{"@home", "expandCollapseAll"},
+			contains:    "list of child pages",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ConvertHTMLToTipTap(tc.html)
+			require.NoError(t, err)
+			for _, notExpected := range tc.notContains {
+				assert.NotContains(t, result, notExpected, "Result should not contain parameter value: %s", notExpected)
+			}
+			assert.Contains(t, result, tc.contains, "Result should contain placeholder text")
+		})
+	}
+}
+
+func TestConvertHTMLToTipTap_ChildrenMacroWithChildren(t *testing.T) {
+	// Test that children macro generates actual links when children info is provided
+	children := []ChildPageInfo{
+		{ID: "123456", Title: "Getting Started"},
+		{ID: "789012", Title: "User Guide"},
+		{ID: "345678", Title: "FAQ"},
+	}
+
+	html := `<ac:structured-macro ac:name="children">
+		<ac:parameter ac:name="all">true</ac:parameter>
+	</ac:structured-macro>`
+
+	result, err := ConvertHTMLToTipTapWithChildren(html, children)
+	require.NoError(t, err)
+
+	// Should contain bullet list with child page titles
+	assert.Contains(t, result, "bulletList", "Should generate a bullet list")
+	assert.Contains(t, result, "Getting Started", "Should contain first child title")
+	assert.Contains(t, result, "User Guide", "Should contain second child title")
+	assert.Contains(t, result, "FAQ", "Should contain third child title")
+
+	// Should contain CONF_PAGE_ID placeholders for links
+	assert.Contains(t, result, "{{CONF_PAGE_ID:123456}}", "Should contain link placeholder for first child")
+	assert.Contains(t, result, "{{CONF_PAGE_ID:789012}}", "Should contain link placeholder for second child")
+	assert.Contains(t, result, "{{CONF_PAGE_ID:345678}}", "Should contain link placeholder for third child")
+
+	// Should NOT contain parameter values
+	assert.NotContains(t, result, `"true"`, "Should not contain parameter value")
+
+	// Should NOT contain placeholder text since we have children
+	assert.NotContains(t, result, "list of child pages", "Should not contain placeholder when children provided")
+}

--- a/services/confluence/csv_parser.go
+++ b/services/confluence/csv_parser.go
@@ -1,0 +1,517 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/csv"
+	"errors"
+	"io"
+	"strings"
+	"time"
+)
+
+// ErrUnsupportedExportFormat is returned when the ZIP is not a recognized
+// Confluence Cloud CSV space export.
+var ErrUnsupportedExportFormat = errors.New("unsupported export: expected a Confluence Cloud CSV export (content.csv or exportDescriptor.properties with exportFormat=csv)")
+
+// CSV export file names (Confluence Cloud space export in CSV form). Files may be
+// suffixed with ".gz"; in observed exports they are frequently plain text despite
+// the suffix, so readers sniff the gzip magic rather than trust the extension.
+const (
+	fileDescriptor        = "exportDescriptor.properties"
+	fileContent           = "content.csv"
+	fileBodyContent       = "bodycontent.csv"
+	fileSpaces            = "spaces.csv"
+	fileUserMapping       = "user_mapping.csv"
+	fileContentProperties = "contentproperties.csv"
+	fileLabel             = "label.csv"
+	fileContentLabel      = "content_label.csv"
+)
+
+// Confluence content types (content.csv "contenttype" column).
+const (
+	contentTypePage             = "PAGE"
+	contentTypeComment          = "COMMENT"
+	contentTypeSpaceDescription = "SPACEDESCRIPTION"
+	contentTypeCustom           = "CUSTOM"
+)
+
+// csvTable is a parsed CSV file with a header→index map for column lookup by
+// name, so the parser is resilient to column reordering across Cloud versions.
+type csvTable struct {
+	header map[string]int
+	rows   [][]string
+}
+
+// col returns the trimmed value of the named column for the given row, or "" if
+// the column or value is absent.
+func (tb *csvTable) col(row []string, name string) string {
+	i, ok := tb.header[name]
+	if !ok || i >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[i])
+}
+
+// findFile returns the zip entry for base, trying both the plain name and the
+// ".gz" suffix.
+func findFile(fileIndex map[string]*zip.File, base string) *zip.File {
+	if f, ok := fileIndex[base]; ok {
+		return f
+	}
+	if f, ok := fileIndex[base+".gz"]; ok {
+		return f
+	}
+	return nil
+}
+
+// isCSVExport reports whether the ZIP looks like a Confluence Cloud CSV export.
+func isCSVExport(fileIndex map[string]*zip.File) bool {
+	if findFile(fileIndex, fileContent) != nil {
+		return true
+	}
+	if f := findFile(fileIndex, fileDescriptor); f != nil {
+		if props, err := readProperties(f); err == nil && props["exportFormat"] == "csv" {
+			return true
+		}
+	}
+	return false
+}
+
+// readRawBytes reads a zip entry fully, transparently gunzipping when the content
+// starts with the gzip magic bytes (0x1f 0x8b) regardless of the file extension.
+func readRawBytes(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
+		gr, gzErr := gzip.NewReader(bytes.NewReader(data))
+		if gzErr != nil {
+			return nil, gzErr
+		}
+		defer gr.Close()
+		return io.ReadAll(gr)
+	}
+
+	return data, nil
+}
+
+// readProperties parses a Java .properties file (k=v lines, # comments) from a
+// zip entry.
+func readProperties(f *zip.File) (map[string]string, error) {
+	data, err := readRawBytes(f)
+	if err != nil {
+		return nil, err
+	}
+	props := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.IndexByte(line, '='); idx >= 0 {
+			key := strings.TrimSpace(line[:idx])
+			val := strings.TrimSpace(line[idx+1:])
+			props[key] = val
+		}
+	}
+	return props, nil
+}
+
+// readCSV parses a (possibly gzipped) CSV zip entry into a csvTable. The first
+// row is treated as the header. Returns nil (no error) when the file is absent.
+func readCSV(fileIndex map[string]*zip.File, base string) (*csvTable, error) {
+	f := findFile(fileIndex, base)
+	if f == nil {
+		return nil, nil
+	}
+
+	data, err := readRawBytes(f)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := csv.NewReader(bytes.NewReader(data))
+	reader.FieldsPerRecord = -1 // rows may have trailing empties
+	reader.LazyQuotes = true    // tolerate stray quotes inside large HTML bodies
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return &csvTable{header: map[string]int{}}, nil
+	}
+
+	header := make(map[string]int, len(records[0]))
+	for i, name := range records[0] {
+		header[strings.TrimSpace(name)] = i
+	}
+	return &csvTable{header: header, rows: records[1:]}, nil
+}
+
+// parseCSVTimestamp parses Confluence CSV timestamps such as
+// "2024-05-31 10:03:18.78". Confluence emits these in the export's timezone
+// (UTC per exportDescriptor); a zero time is returned for empty/unparseable input.
+func parseCSVTimestamp(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if ts, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+// parseCSVExport populates export from a Confluence Cloud CSV export. It emits
+// the same ConfluenceExport shape as the (removed) XML parser so all downstream
+// transform/export code is reused unchanged.
+func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	// Descriptor (optional) — space key and export metadata.
+	if f := findFile(fileIndex, fileDescriptor); f != nil {
+		if props, err := readProperties(f); err == nil {
+			if key := props["spaceKey"]; key != "" && export.SpaceKey == "" {
+				export.SpaceKey = key
+			}
+		}
+	}
+
+	if err := t.loadSpaces(fileIndex, export); err != nil {
+		return err
+	}
+
+	userKeyToAaid, err := t.loadUsers(fileIndex, export)
+	if err != nil {
+		return err
+	}
+
+	if err := t.loadContent(fileIndex, export, userKeyToAaid); err != nil {
+		return err
+	}
+
+	if err := t.loadBodies(fileIndex, export); err != nil {
+		return err
+	}
+
+	if err := t.loadContentProperties(fileIndex, export); err != nil {
+		return err
+	}
+
+	if err := t.loadLabels(fileIndex, export); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadSpaces reads spaces.csv into export.Spaces (and the legacy single-space
+// fields). The homepage column gives the authoritative root page id.
+func (t *Transformer) loadSpaces(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	tb, err := readCSV(fileIndex, fileSpaces)
+	if err != nil {
+		return err
+	}
+	if tb == nil {
+		return nil
+	}
+	for _, row := range tb.rows {
+		key := tb.col(row, "spacekey")
+		if key == "" {
+			continue
+		}
+		info := &SpaceInfo{
+			Key:        key,
+			Name:       tb.col(row, "spacename"),
+			HomePageID: tb.col(row, "homepage"),
+		}
+		export.Spaces[key] = info
+		// Populate legacy single-space fields from the first (or descriptor) space.
+		if export.SpaceKey == "" || export.SpaceKey == key {
+			export.SpaceKey = key
+			export.SpaceName = info.Name
+		}
+	}
+	return nil
+}
+
+// loadUsers reads user_mapping.csv and returns a user_key→aaid map. It also
+// populates export.Users keyed by BOTH the aaid and the user_key (aliased to the
+// same record) so that (a) creator/lastmodifier references translated to aaid
+// resolve, and (b) body @-mentions — which embed either ri:account-id (=aaid) or
+// ri:userkey — both resolve via ResolveUserMentions.
+func (t *Transformer) loadUsers(fileIndex map[string]*zip.File, export *ConfluenceExport) (map[string]string, error) {
+	userKeyToAaid := make(map[string]string)
+
+	tb, err := readCSV(fileIndex, fileUserMapping)
+	if err != nil {
+		return nil, err
+	}
+	if tb == nil {
+		return userKeyToAaid, nil
+	}
+
+	for _, row := range tb.rows {
+		userKey := tb.col(row, "user_key")
+		if userKey == "" {
+			continue
+		}
+		aaid := tb.col(row, "aaid")
+		username := tb.col(row, "username")
+		if aaid == "" {
+			aaid = userKey
+		}
+		userKeyToAaid[userKey] = aaid
+
+		user := &ConfluenceUser{
+			AccountID: aaid,
+			Username:  username,
+		}
+		export.Users[aaid] = user
+		// Alias by user_key so ri:userkey mentions resolve without a links.go change.
+		if userKey != aaid {
+			export.Users[userKey] = user
+		}
+	}
+	return userKeyToAaid, nil
+}
+
+// resolveActor translates a content.csv creator/lastmodifier user_key to its
+// aaid (falling back to the raw value when unmapped) so downstream username
+// resolution and the account-ID-keyed --user-mapping CSV work unchanged.
+func resolveActor(userKey string, userKeyToAaid map[string]string) string {
+	if userKey == "" {
+		return ""
+	}
+	if aaid, ok := userKeyToAaid[userKey]; ok {
+		return aaid
+	}
+	return userKey
+}
+
+// loadContent reads content.csv and builds pages and comments. Historical/draft
+// discrimination follows the CSV rules: a PAGE row is a historical version when
+// content_status=current but spaceid is blank (its prevver points at the
+// canonical page); such ids are recorded in HistoricalPageIDs and filtered by
+// TransformPages. CUSTOM and SPACEDESCRIPTION rows are dropped.
+func (t *Transformer) loadContent(fileIndex map[string]*zip.File, export *ConfluenceExport, userKeyToAaid map[string]string) error {
+	tb, err := readCSV(fileIndex, fileContent)
+	if err != nil {
+		return err
+	}
+	if tb == nil {
+		return ErrUnsupportedExportFormat
+	}
+
+	for _, row := range tb.rows {
+		id := tb.col(row, "contentid")
+		if id == "" {
+			continue
+		}
+		switch tb.col(row, "contenttype") {
+		case contentTypePage:
+			page := &ConfluencePage{
+				ID:            id,
+				Title:         tb.col(row, "title"),
+				ParentID:      tb.col(row, "parentid"),
+				SpaceKey:      export.SpaceKey,
+				CreatedBy:     resolveActor(tb.col(row, "creator"), userKeyToAaid),
+				CreatedAt:     parseCSVTimestamp(tb.col(row, "creationdate")),
+				UpdatedBy:     resolveActor(tb.col(row, "lastmodifier"), userKeyToAaid),
+				UpdatedAt:     parseCSVTimestamp(tb.col(row, "lastmoddate")),
+				Version:       parsePositionValue(tb.col(row, "version")),
+				Position:      parsePositionValue(tb.col(row, "child_position")),
+				ContentStatus: tb.col(row, "content_status"),
+			}
+			// Historical version: current-status PAGE with no space linkage.
+			if page.ContentStatus == "current" && tb.col(row, "spaceid") == "" {
+				export.HistoricalPageIDs[id] = true
+				page.OriginalVersionID = tb.col(row, "prevver")
+			}
+			export.Pages = append(export.Pages, page)
+
+		case contentTypeComment:
+			comment := &ConfluenceComment{
+				ID:        id,
+				PageID:    tb.col(row, "pageid"),
+				ParentID:  tb.col(row, "parentcommentid"),
+				CreatedBy: resolveActor(tb.col(row, "creator"), userKeyToAaid),
+				CreatedAt: parseCSVTimestamp(tb.col(row, "creationdate")),
+			}
+			// Version rows (prevver set) are historical edits of a live comment.
+			if prevver := tb.col(row, "prevver"); prevver != "" {
+				export.HistoricalCommentIDs[id] = true
+			}
+			export.Comments = append(export.Comments, comment)
+
+		default:
+			// SPACEDESCRIPTION and CUSTOM (plugin content-property storage) are not imported.
+		}
+	}
+
+	return nil
+}
+
+// loadBodies reads bodycontent.csv and attaches each storage-format body to its
+// page/comment by contentid. Bodies are indexed once to avoid an O(n²) join.
+func (t *Transformer) loadBodies(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	tb, err := readCSV(fileIndex, fileBodyContent)
+	if err != nil {
+		return err
+	}
+	if tb == nil {
+		return nil
+	}
+
+	bodyByContentID := make(map[string]string, len(tb.rows))
+	for _, row := range tb.rows {
+		contentID := tb.col(row, "contentid")
+		if contentID == "" {
+			continue
+		}
+		bodyByContentID[contentID] = tb.col(row, "body")
+	}
+	export.BodyContents = bodyByContentID
+
+	for _, page := range export.Pages {
+		if body, ok := bodyByContentID[page.ID]; ok {
+			page.Content = body
+		}
+	}
+	for _, comment := range export.Comments {
+		if body, ok := bodyByContentID[comment.ID]; ok {
+			comment.Content = body
+		}
+	}
+	return nil
+}
+
+// loadContentProperties reads contentproperties.csv and, for each comment,
+// attaches inline-comment anchor and resolved-status data directly from the
+// comment's own property rows (Cloud CSV exports carry these as first-class
+// properties, so no body HTML scraping is required).
+func (t *Transformer) loadContentProperties(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	tb, err := readCSV(fileIndex, fileContentProperties)
+	if err != nil {
+		return err
+	}
+	if tb == nil {
+		return nil
+	}
+
+	type propSet struct {
+		markerRef string
+		selection string
+		resolved  bool
+	}
+	byContentID := make(map[string]*propSet)
+	get := func(id string) *propSet {
+		if p, ok := byContentID[id]; ok {
+			return p
+		}
+		p := &propSet{}
+		byContentID[id] = p
+		return p
+	}
+
+	for _, row := range tb.rows {
+		contentID := tb.col(row, "contentid")
+		if contentID == "" {
+			continue
+		}
+		name := tb.col(row, "propertyname")
+		val := tb.col(row, "stringval")
+		switch name {
+		case "inline-marker-ref":
+			get(contentID).markerRef = val
+		case "inline-original-selection":
+			get(contentID).selection = val
+		case "status":
+			if val == "resolved" {
+				get(contentID).resolved = true
+			}
+		}
+	}
+
+	for _, comment := range export.Comments {
+		p, ok := byContentID[comment.ID]
+		if !ok {
+			continue
+		}
+		comment.IsResolved = p.resolved
+		if p.markerRef != "" || p.selection != "" {
+			comment.InlineAnchor = &InlineAnchor{
+				AnchorID:          p.markerRef,
+				OriginalSelection: p.selection,
+			}
+			if p.markerRef != "" {
+				export.InlineCommentAnchors[p.markerRef] = p.selection
+			}
+		}
+	}
+	return nil
+}
+
+// loadLabels reads label.csv + content_label.csv and attaches label names to
+// their pages.
+func (t *Transformer) loadLabels(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	labelTable, err := readCSV(fileIndex, fileLabel)
+	if err != nil {
+		return err
+	}
+	contentLabelTable, err := readCSV(fileIndex, fileContentLabel)
+	if err != nil {
+		return err
+	}
+	if labelTable == nil || contentLabelTable == nil {
+		return nil
+	}
+
+	labelName := make(map[string]string, len(labelTable.rows))
+	for _, row := range labelTable.rows {
+		if id := labelTable.col(row, "labelid"); id != "" {
+			labelName[id] = labelTable.col(row, "name")
+		}
+	}
+
+	labelsByContentID := make(map[string][]string)
+	for _, row := range contentLabelTable.rows {
+		if contentLabelTable.col(row, "labelabletype") != "CONTENT" {
+			continue
+		}
+		contentID := contentLabelTable.col(row, "contentid")
+		if contentID == "" {
+			contentID = contentLabelTable.col(row, "labelableid")
+		}
+		labelID := contentLabelTable.col(row, "labelid")
+		if name, ok := labelName[labelID]; ok && contentID != "" {
+			labelsByContentID[contentID] = append(labelsByContentID[contentID], name)
+		}
+	}
+
+	for _, page := range export.Pages {
+		if labels, ok := labelsByContentID[page.ID]; ok {
+			page.Labels = append(page.Labels, labels...)
+		}
+	}
+	return nil
+}

--- a/services/confluence/csv_parser.go
+++ b/services/confluence/csv_parser.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -203,10 +204,12 @@ func parseCSVTimestamp(s string) time.Time {
 func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
 	// Descriptor (optional) — space key, org id, and export metadata. The org id
 	// namespaces source IDs across Confluence instances.
+	descriptorKey := ""
 	if f := findFile(fileIndex, fileDescriptor); f != nil {
 		if props, err := readProperties(f); err == nil {
-			if key := props["spaceKey"]; key != "" && export.SpaceKey == "" {
-				export.SpaceKey = key
+			descriptorKey = props["spaceKey"]
+			if descriptorKey != "" && export.SpaceKey == "" {
+				export.SpaceKey = descriptorKey
 			}
 			if org := props["organizationId"]; org != "" {
 				export.OrganizationID = org
@@ -215,6 +218,13 @@ func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *Con
 	}
 
 	if err := t.loadSpaces(fileIndex, export); err != nil {
+		return err
+	}
+
+	// Enforce a single, non-empty, consistent space key before any downstream
+	// filesystem writes (extraction/export). A CSV export always covers one
+	// space; the Space and its pages must share one authoritative key.
+	if err := validateSingleSpaceKey(export, descriptorKey); err != nil {
 		return err
 	}
 
@@ -243,6 +253,35 @@ func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *Con
 		return err
 	}
 
+	return nil
+}
+
+// validateSingleSpaceKey enforces that the export resolves to exactly one
+// non-empty space key, and that a descriptor key (when present) matches the
+// spaces.csv key. On success it pins export.SpaceKey to the authoritative key.
+func validateSingleSpaceKey(export *ConfluenceExport, descriptorKey string) error {
+	if len(export.Spaces) > 1 {
+		return fmt.Errorf("multi-space exports are not supported; import one space per bundle (found %d spaces)", len(export.Spaces))
+	}
+
+	var csvKey string
+	for k := range export.Spaces {
+		csvKey = k
+	}
+
+	if descriptorKey != "" && csvKey != "" && descriptorKey != csvKey {
+		return fmt.Errorf("space key mismatch: exportDescriptor.properties has %q but spaces.csv has %q", descriptorKey, csvKey)
+	}
+
+	key := csvKey
+	if key == "" {
+		key = descriptorKey
+	}
+	if key == "" {
+		return fmt.Errorf("export has no space key (neither exportDescriptor.properties nor spaces.csv provided one)")
+	}
+
+	export.SpaceKey = key
 	return nil
 }
 

--- a/services/confluence/csv_parser.go
+++ b/services/confluence/csv_parser.go
@@ -10,6 +10,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -30,12 +31,14 @@ const (
 	fileContentProperties = "contentproperties.csv"
 	fileLabel             = "label.csv"
 	fileContentLabel      = "content_label.csv"
+	fileContentPermSet    = "content_perm_set.csv"
 )
 
 // Confluence content types (content.csv "contenttype" column).
 const (
 	contentTypePage             = "PAGE"
 	contentTypeComment          = "COMMENT"
+	contentTypeAttachment       = "ATTACHMENT"
 	contentTypeSpaceDescription = "SPACEDESCRIPTION"
 	contentTypeCustom           = "CUSTOM"
 )
@@ -55,6 +58,17 @@ func (tb *csvTable) col(row []string, name string) string {
 		return ""
 	}
 	return strings.TrimSpace(row[i])
+}
+
+// firstCol returns the first of the candidate names present in the header, or ""
+// if none are present. Used to tolerate schema variation across Cloud versions.
+func (tb *csvTable) firstCol(names ...string) string {
+	for _, n := range names {
+		if _, ok := tb.header[n]; ok {
+			return n
+		}
+	}
+	return ""
 }
 
 // findFile returns the zip entry for base, trying both the plain name and the
@@ -187,11 +201,15 @@ func parseCSVTimestamp(s string) time.Time {
 // the same ConfluenceExport shape as the (removed) XML parser so all downstream
 // transform/export code is reused unchanged.
 func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
-	// Descriptor (optional) — space key and export metadata.
+	// Descriptor (optional) — space key, org id, and export metadata. The org id
+	// namespaces source IDs across Confluence instances.
 	if f := findFile(fileIndex, fileDescriptor); f != nil {
 		if props, err := readProperties(f); err == nil {
 			if key := props["spaceKey"]; key != "" && export.SpaceKey == "" {
 				export.SpaceKey = key
+			}
+			if org := props["organizationId"]; org != "" {
+				export.OrganizationID = org
 			}
 		}
 	}
@@ -218,6 +236,10 @@ func (t *Transformer) parseCSVExport(fileIndex map[string]*zip.File, export *Con
 	}
 
 	if err := t.loadLabels(fileIndex, export); err != nil {
+		return err
+	}
+
+	if err := t.loadRestrictions(fileIndex, export); err != nil {
 		return err
 	}
 
@@ -356,12 +378,33 @@ func (t *Transformer) loadContent(fileIndex map[string]*zip.File, export *Conflu
 				ParentID:  tb.col(row, "parentcommentid"),
 				CreatedBy: resolveActor(tb.col(row, "creator"), userKeyToAaid),
 				CreatedAt: parseCSVTimestamp(tb.col(row, "creationdate")),
+				UpdatedBy: resolveActor(tb.col(row, "lastmodifier"), userKeyToAaid),
+				UpdatedAt: parseCSVTimestamp(tb.col(row, "lastmoddate")),
 			}
 			// Version rows (prevver set) are historical edits of a live comment.
 			if prevver := tb.col(row, "prevver"); prevver != "" {
 				export.HistoricalCommentIDs[id] = true
 			}
 			export.Comments = append(export.Comments, comment)
+
+		case contentTypeAttachment:
+			// ATTACHMENT rows carry attachment metadata; the file bytes live under
+			// attachments/ in the ZIP (see attachments.go). MediaType/FileSize are
+			// filled best-effort from contentproperties.csv when present.
+			pageID := tb.col(row, "pageid")
+			if pageID == "" {
+				pageID = tb.col(row, "parentid")
+			}
+			att := &ConfluenceAttachment{
+				ID:        id,
+				PageID:    pageID,
+				FileName:  tb.col(row, "title"),
+				CreatedBy: resolveActor(tb.col(row, "creator"), userKeyToAaid),
+				CreatedAt: parseCSVTimestamp(tb.col(row, "creationdate")),
+			}
+			if pageID != "" {
+				export.Attachments[pageID] = append(export.Attachments[pageID], att)
+			}
 
 		default:
 			// SPACEDESCRIPTION and CUSTOM (plugin content-property storage) are not imported.
@@ -466,6 +509,66 @@ func (t *Transformer) loadContentProperties(fileIndex map[string]*zip.File, expo
 			if p.markerRef != "" {
 				export.InlineCommentAnchors[p.markerRef] = p.selection
 			}
+		}
+	}
+
+	// Best-effort: fill attachment media-type/file-size from content properties.
+	// The observed sample carries none, so absence is expected and harmless.
+	attByID := make(map[string]*ConfluenceAttachment)
+	for _, atts := range export.Attachments {
+		for _, att := range atts {
+			attByID[att.ID] = att
+		}
+	}
+	if len(attByID) > 0 {
+		for _, row := range tb.rows {
+			att, ok := attByID[tb.col(row, "contentid")]
+			if !ok {
+				continue
+			}
+			switch tb.col(row, "propertyname") {
+			case "media-type", "mediaType":
+				att.MediaType = tb.col(row, "stringval")
+			case "file-size", "fileSize":
+				if n, err := strconv.ParseInt(tb.col(row, "longval"), 10, 64); err == nil {
+					att.FileSize = n
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// loadRestrictions detects pages carrying a View restriction from
+// content_perm_set.csv. It records content IDs only (principals are not
+// resolved); the transform surfaces these as warnings and manifest entries so a
+// view-restricted page is not silently widened on import. Column names are
+// probed defensively because the CSV schema is unverified for restrictions.
+func (t *Transformer) loadRestrictions(fileIndex map[string]*zip.File, export *ConfluenceExport) error {
+	tb, err := readCSV(fileIndex, fileContentPermSet)
+	if err != nil {
+		return err
+	}
+	if tb == nil {
+		return nil
+	}
+
+	typeCol := tb.firstCol("cps_type", "type", "permtype", "permission_type")
+	idCol := tb.firstCol("cont_id", "content_id", "contentid", "contid")
+	if idCol == "" {
+		t.Logger.Warn("content_perm_set.csv present but no recognizable content-id column; skipping restriction detection")
+		return nil
+	}
+
+	for _, row := range tb.rows {
+		cid := tb.col(row, idCol)
+		if cid == "" {
+			continue
+		}
+		// When the type column is absent, treat any permission set as a possible
+		// view restriction rather than miss one (conservative — only a warning).
+		if typeCol == "" || strings.EqualFold(tb.col(row, typeCol), "VIEW") {
+			export.RestrictedPageIDs[cid] = true
 		}
 	}
 	return nil

--- a/services/confluence/csv_parser_test.go
+++ b/services/confluence/csv_parser_test.go
@@ -87,7 +87,7 @@ func buildFixtureZip(t *testing.T, files map[string]string) *zip.Reader {
 func newTestTransformer() *Transformer {
 	logger := log.New()
 	logger.SetLevel(log.PanicLevel)
-	return NewTransformer("team", "channel", logger, &TransformConfig{SkipAttachments: true, MaxDepth: 10})
+	return NewTransformer("team", logger, &TransformConfig{SkipAttachments: true, MaxDepth: 10})
 }
 
 func parseFixture(t *testing.T, files map[string]string) (*Transformer, *ConfluenceExport) {

--- a/services/confluence/csv_parser_test.go
+++ b/services/confluence/csv_parser_test.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// csvFixture holds the raw file contents of a synthetic Confluence Cloud CSV
+// export. Values are exact excerpts modeled on a real export's schema. Files
+// whose name ends in ".gz" are gzip-compressed when the fixture zip is built,
+// exercising the gzip-magic sniff.
+var csvFixture = map[string]string{
+	"exportDescriptor.properties": "#comment line\nexportFormat=csv\nexportType=space\nspaceKey=DOCS\n",
+
+	"spaces.csv": "spaceid,spacename,spacekey,spacedescid,homepage,spacetype,spacestatus\n" +
+		"900,Docs Space,DOCS,,100,global,CURRENT\n",
+
+	"user_mapping.csv": "user_key,username,lower_username,aaid\n" +
+		"ukey1,uname1,uname1,aaid1\n" +
+		"ukey2,aaid2,aaid2,aaid2\n",
+
+	// contentid,contenttype,title,version,creator,creationdate,lastmodifier,lastmoddate,prevver,content_status,pageid,spaceid,child_position,parentid,parentcommentid
+	"content.csv": "contentid,contenttype,title,version,creator,creationdate,lastmodifier,lastmoddate,prevver,content_status,pageid,spaceid,child_position,parentid,parentcommentid\n" +
+		"100,PAGE,Home,1,ukey1,2024-01-01 10:00:00.0,ukey1,2024-01-02 10:00:00.0,,current,,900,745,,\n" +
+		"101,PAGE,Child,3,ukey1,2024-01-03 10:00:00.0,ukey2,2024-01-05 10:00:00.0,,current,,900,836,100,\n" +
+		"102,PAGE,Child,1,ukey1,2024-01-03 10:00:00.0,ukey1,2024-01-03 10:00:00.0,101,current,,,836,,\n" +
+		"103,PAGE,Draft page,1,ukey1,2024-01-06 10:00:00.0,ukey1,2024-01-06 10:00:00.0,,draft,,900,900,100,\n" +
+		"200,COMMENT,,1,ukey2,2024-01-07 10:00:00.0,ukey2,2024-01-07 10:00:00.0,,current,101,,,,\n" +
+		"201,COMMENT,,1,ukey1,2024-01-08 10:00:00.0,ukey1,2024-01-08 10:00:00.0,,current,101,,,,200\n" +
+		"202,COMMENT,,1,ukey2,2024-01-07 09:00:00.0,ukey2,2024-01-07 09:00:00.0,200,current,101,,,,\n" +
+		"900,CUSTOM,content-appearance,1,ukey1,2024-01-01 10:00:00.0,ukey1,2024-01-01 10:00:00.0,,current,100,,,,\n",
+
+	// bodycontentid,body,contentid,bodytypeid — gzipped to exercise the sniff.
+	"bodycontent.csv.gz": "bodycontentid,body,contentid,bodytypeid\n" +
+		"1,\"<p>Home mentions <ac:link><ri:user ri:account-id=\"\"aaid2\"\" /></ac:link></p>\",100,2\n" +
+		"2,\"<p>Child mentions <ac:link><ri:user ri:userkey=\"\"ukey2\"\" /></ac:link></p>\",101,2\n" +
+		"3,<p>A top comment</p>,200,2\n" +
+		"4,<p>A reply</p>,201,2\n",
+
+	// propertyid,propertyname,stringval,longval,dateval,contentid
+	"contentproperties.csv": "propertyid,propertyname,stringval,longval,dateval,contentid\n" +
+		"p1,inline-marker-ref,uuid-abc,,,200\n" +
+		"p2,inline-original-selection,highlighted text,,,200\n" +
+		"p3,status,resolved,,,200\n",
+
+	"label.csv":         "labelid,name,namespace\nL1,important,global\n",
+	"content_label.csv": "id,labelid,contentid,labelableid,labelabletype\nx,L1,101,101,CONTENT\n",
+}
+
+// buildFixtureZip builds an in-memory zip.Reader from the given file map,
+// gzip-compressing any entry whose name ends in ".gz".
+func buildFixtureZip(t *testing.T, files map[string]string) *zip.Reader {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	zw := zip.NewWriter(buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		data := []byte(content)
+		if len(name) > 3 && name[len(name)-3:] == ".gz" {
+			gzBuf := &bytes.Buffer{}
+			gw := gzip.NewWriter(gzBuf)
+			_, err = gw.Write(data)
+			require.NoError(t, err)
+			require.NoError(t, gw.Close())
+			data = gzBuf.Bytes()
+		}
+		_, err = w.Write(data)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	return zr
+}
+
+func newTestTransformer() *Transformer {
+	logger := log.New()
+	logger.SetLevel(log.PanicLevel)
+	return NewTransformer("team", "channel", logger, &TransformConfig{SkipAttachments: true, MaxDepth: 10})
+}
+
+func parseFixture(t *testing.T, files map[string]string) (*Transformer, *ConfluenceExport) {
+	t.Helper()
+	tr := newTestTransformer()
+	export, err := tr.ParseConfluenceExport(buildFixtureZip(t, files))
+	require.NoError(t, err)
+	require.NotNil(t, export)
+	return tr, export
+}
+
+func TestParseCSVExport_SpacesAndUsers(t *testing.T) {
+	_, export := parseFixture(t, csvFixture)
+
+	require.Contains(t, export.Spaces, "DOCS")
+	assert.Equal(t, "100", export.Spaces["DOCS"].HomePageID)
+	assert.Equal(t, "DOCS", export.SpaceKey)
+
+	// export.Users is keyed by BOTH aaid and user_key (aliases to same record).
+	require.Contains(t, export.Users, "aaid2", "should be keyed by aaid")
+	require.Contains(t, export.Users, "ukey2", "should also be aliased by user_key")
+	assert.Same(t, export.Users["aaid2"], export.Users["ukey2"])
+	assert.Equal(t, "aaid2", export.Users["ukey2"].AccountID)
+}
+
+func TestParseCSVExport_HistoricalAndDraftFiltering(t *testing.T) {
+	tr, export := parseFixture(t, csvFixture)
+
+	// Page 102 is a historical version (current status, blank spaceid, prevver set).
+	assert.True(t, export.HistoricalPageIDs["102"], "historical version should be flagged")
+	// Comment 202 is a historical version (prevver set).
+	assert.True(t, export.HistoricalCommentIDs["202"])
+
+	// creator user_key must be translated to the aaid on the parsed page.
+	var home *ConfluencePage
+	for _, p := range export.Pages {
+		if p.ID == "100" {
+			home = p
+		}
+	}
+	require.NotNil(t, home)
+	assert.Equal(t, "aaid1", home.CreatedBy, "user_key should be translated to aaid")
+
+	require.NoError(t, tr.Transform(export))
+
+	// Only current, space-linked pages survive: 100 and 101 (102 historical, 103 draft, 900 CUSTOM dropped).
+	gotPages := map[string]bool{}
+	for _, p := range tr.Intermediate.Pages {
+		gotPages[p.ImportSourceID] = true
+	}
+	assert.Equal(t, map[string]bool{"100": true, "101": true}, gotPages)
+
+	// Comments: 200 and 201 survive; 202 (historical) is filtered.
+	gotComments := map[string]bool{}
+	for _, c := range tr.Intermediate.Comments {
+		gotComments[c.ImportSourceID] = true
+	}
+	assert.Equal(t, map[string]bool{"200": true, "201": true}, gotComments)
+}
+
+func TestParseCSVExport_MentionResolution(t *testing.T) {
+	tr, export := parseFixture(t, csvFixture)
+	require.NoError(t, tr.Transform(export))
+
+	var contents string
+	for _, p := range tr.Intermediate.Pages {
+		contents += p.Content
+	}
+	// Both the ri:account-id mention (page 100) and the ri:userkey mention (page 101)
+	// must resolve — no unresolved placeholders left behind.
+	assert.NotContains(t, contents, "{{CONF_USER", "mentions should resolve via both aaid and user_key keys")
+	assert.Contains(t, contents, "@", "resolved mention should render as @username")
+}
+
+func TestParseCSVExport_IdentityProps(t *testing.T) {
+	tr, export := parseFixture(t, csvFixture)
+	require.NoError(t, tr.Transform(export))
+
+	for _, p := range tr.Intermediate.Pages {
+		if p.ImportSourceID == "100" {
+			assert.Equal(t, "aaid1", p.Props["confluence_author_account_id"])
+		}
+	}
+	for _, c := range tr.Intermediate.Comments {
+		if c.ImportSourceID == "200" {
+			assert.Equal(t, "aaid2", c.Props["confluence_author_account_id"])
+		}
+	}
+}
+
+func TestParseCSVExport_InlineAnchorAndResolved(t *testing.T) {
+	_, export := parseFixture(t, csvFixture)
+
+	var comment *ConfluenceComment
+	for _, c := range export.Comments {
+		if c.ID == "200" {
+			comment = c
+		}
+	}
+	require.NotNil(t, comment)
+	assert.True(t, comment.IsResolved, "status=resolved property should set IsResolved")
+	require.NotNil(t, comment.InlineAnchor)
+	assert.Equal(t, "uuid-abc", comment.InlineAnchor.AnchorID)
+	assert.Equal(t, "highlighted text", comment.InlineAnchor.OriginalSelection)
+}
+
+func TestParseCSVExport_Labels(t *testing.T) {
+	_, export := parseFixture(t, csvFixture)
+	for _, p := range export.Pages {
+		if p.ID == "101" {
+			assert.Contains(t, p.Labels, "important")
+		}
+	}
+}
+
+func TestParseCSVExport_BodiesAreStorageFormat(t *testing.T) {
+	_, export := parseFixture(t, csvFixture)
+	for _, p := range export.Pages {
+		if p.ID == "100" {
+			assert.Contains(t, p.Content, "<ac:link>", "gzipped body should decompress and attach verbatim storage format")
+		}
+	}
+}
+
+func TestParseConfluenceExport_UnsupportedFormat(t *testing.T) {
+	tr := newTestTransformer()
+	_, err := tr.ParseConfluenceExport(buildFixtureZip(t, map[string]string{
+		"entities.xml": "<hibernate-generic></hibernate-generic>",
+	}))
+	assert.ErrorIs(t, err, ErrUnsupportedExportFormat)
+}
+
+func TestParseCSVTimestamp(t *testing.T) {
+	assert.False(t, parseCSVTimestamp("2024-05-31 10:03:18.78").IsZero())
+	assert.False(t, parseCSVTimestamp("2024-05-31 10:03:18").IsZero())
+	assert.False(t, parseCSVTimestamp("2024-05-31").IsZero())
+	assert.True(t, parseCSVTimestamp("").IsZero())
+	assert.True(t, parseCSVTimestamp("not-a-date").IsZero())
+}

--- a/services/confluence/export.go
+++ b/services/confluence/export.go
@@ -1,0 +1,496 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/pkg/errors"
+)
+
+// JSONL output types for wiki/page import
+// These match the types expected by the Mattermost wiki import functionality
+
+// LineImportData represents a single line in the JSONL import file.
+type LineImportData struct {
+	Type                    string                             `json:"type"`
+	Version                 *int                               `json:"version,omitempty"`
+	Channel                 *ChannelImportData                 `json:"channel,omitempty"`
+	Wiki                    *WikiImportData                    `json:"wiki,omitempty"`
+	Page                    *PageImportData                    `json:"page,omitempty"`
+	PageComment             *PageCommentImportData             `json:"page_comment,omitempty"`
+	ResolveWikiPlaceholders *ResolveWikiPlaceholdersImportData `json:"resolve_wiki_placeholders,omitempty"`
+}
+
+// ResolveWikiPlaceholdersImportData triggers post-import placeholder resolution.
+type ResolveWikiPlaceholdersImportData struct {
+	Team               *string `json:"team"`
+	WikiImportSourceId *string `json:"wiki_import_source_id"`
+}
+
+// ChannelImportData represents a channel to be created.
+type ChannelImportData struct {
+	Team        *string `json:"team"`
+	Name        *string `json:"name"`
+	DisplayName *string `json:"display_name"`
+	Type        *string `json:"type"` // "O" for public, "P" for private
+	Purpose     *string `json:"purpose,omitempty"`
+	Header      *string `json:"header,omitempty"`
+}
+
+// WikiImportData represents a wiki to be imported.
+type WikiImportData struct {
+	Team        *string                `json:"team"`
+	Channel     *string                `json:"channel"`
+	Title       *string                `json:"title,omitempty"`
+	Description *string                `json:"description,omitempty"`
+	Props       *model.StringInterface `json:"props,omitempty"`
+}
+
+// PageImportData represents a page to be imported.
+type PageImportData struct {
+	Team                 *string                 `json:"team"`
+	WikiImportSourceId   *string                 `json:"wiki_import_source_id"`
+	User                 *string                 `json:"user"`
+	Title                *string                 `json:"title"`
+	Content              *string                 `json:"content"`
+	ParentImportSourceId *string                 `json:"parent_import_source_id,omitempty"`
+	CreateAt             *int64                  `json:"create_at,omitempty"`
+	Props                *model.StringInterface  `json:"props,omitempty"`
+	Attachments          *[]AttachmentImportData `json:"attachments,omitempty"`
+}
+
+// PageCommentImportData represents a comment on a page to be imported.
+type PageCommentImportData struct {
+	PageImportSourceId          *string                `json:"page_import_source_id"`
+	ParentCommentImportSourceId *string                `json:"parent_comment_import_source_id,omitempty"`
+	User                        *string                `json:"user"`
+	Content                     *string                `json:"content"`
+	CreateAt                    *int64                 `json:"create_at,omitempty"`
+	IsResolved                  *bool                  `json:"is_resolved,omitempty"`
+	Props                       *model.StringInterface `json:"props,omitempty"`
+}
+
+// AttachmentImportData represents an attachment to be imported.
+type AttachmentImportData struct {
+	Path  *string                `json:"path"`
+	Props *model.StringInterface `json:"props,omitempty"`
+}
+
+// ExportWriteLine writes a single JSONL line to the writer.
+func ExportWriteLine(writer io.Writer, line *LineImportData) error {
+	b, err := json.Marshal(line)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal JSON for export")
+	}
+
+	if _, err := writer.Write(append(b, '\n')); err != nil {
+		return errors.Wrap(err, "failed to write export data")
+	}
+
+	return nil
+}
+
+// Export writes the transformed data to a JSONL file.
+func (t *Transformer) Export(outputFilePath string) error {
+	outputFile, err := os.Create(outputFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create output file")
+	}
+	defer outputFile.Close()
+
+	// Write version line
+	t.Logger.Info("Exporting version")
+	if err := t.ExportVersion(outputFile); err != nil {
+		return err
+	}
+
+	// Export channel (if auto-creating)
+	if t.Intermediate.Channel != nil {
+		t.Logger.Info("Exporting channel")
+		if err := t.ExportChannel(outputFile); err != nil {
+			return err
+		}
+	}
+
+	// Export wikis (one per space)
+	t.Logger.Infof("Exporting %d wikis", len(t.Intermediate.Wikis))
+	if err := t.ExportWikis(outputFile); err != nil {
+		return err
+	}
+
+	// Export pages
+	t.Logger.Infof("Exporting %d pages", len(t.Intermediate.Pages))
+	if err := t.ExportPages(outputFile); err != nil {
+		return err
+	}
+
+	// Export comments
+	t.Logger.Infof("Exporting %d comments", len(t.Intermediate.Comments))
+	if err := t.ExportComments(outputFile); err != nil {
+		return err
+	}
+
+	// Export resolve_wiki_placeholders directive to resolve cross-page links
+	t.Logger.Info("Exporting placeholder resolution directive")
+	if err := t.ExportResolvePlaceholders(outputFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExportVersion writes the version line.
+func (t *Transformer) ExportVersion(writer io.Writer) error {
+	version := 1
+	versionLine := &LineImportData{
+		Type:    "version",
+		Version: &version,
+	}
+	return ExportWriteLine(writer, versionLine)
+}
+
+// ExportChannel writes the channel line (if auto-creating).
+func (t *Transformer) ExportChannel(writer io.Writer) error {
+	if t.Intermediate.Channel == nil {
+		return nil
+	}
+
+	ch := t.Intermediate.Channel
+	channelLine := &LineImportData{
+		Type: "channel",
+		Channel: &ChannelImportData{
+			Team:        model.NewPointer(ch.Team),
+			Name:        model.NewPointer(ch.Name),
+			DisplayName: model.NewPointer(ch.DisplayName),
+			Type:        model.NewPointer(ch.Type),
+			Purpose:     optionalString(ch.Purpose),
+			Header:      optionalString(ch.Header),
+		},
+	}
+	return ExportWriteLine(writer, channelLine)
+}
+
+// ExportWikis writes wiki lines for all spaces.
+func (t *Transformer) ExportWikis(writer io.Writer) error {
+	for _, wiki := range t.Intermediate.Wikis {
+		props := model.StringInterface{
+			"import_source_id": wiki.SpaceKey,
+		}
+		wikiLine := &LineImportData{
+			Type: "wiki",
+			Wiki: &WikiImportData{
+				Team:        model.NewPointer(wiki.Team),
+				Channel:     model.NewPointer(wiki.Channel),
+				Title:       model.NewPointer(wiki.Title),
+				Description: model.NewPointer(wiki.Description),
+				Props:       &props,
+			},
+		}
+		if err := ExportWriteLine(writer, wikiLine); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ExportWiki writes the wiki line (legacy single-wiki support).
+func (t *Transformer) ExportWiki(writer io.Writer) error {
+	if t.Intermediate.Wiki == nil {
+		return nil
+	}
+
+	props := model.StringInterface{
+		"import_source_id": t.Intermediate.Wiki.SpaceKey,
+	}
+	wikiLine := &LineImportData{
+		Type: "wiki",
+		Wiki: &WikiImportData{
+			Team:        model.NewPointer(t.Intermediate.Wiki.Team),
+			Channel:     model.NewPointer(t.Intermediate.Wiki.Channel),
+			Title:       model.NewPointer(t.Intermediate.Wiki.Title),
+			Description: model.NewPointer(t.Intermediate.Wiki.Description),
+			Props:       &props,
+		},
+	}
+	return ExportWriteLine(writer, wikiLine)
+}
+
+// ExportPages writes all page lines.
+func (t *Transformer) ExportPages(writer io.Writer) error {
+	for _, page := range t.Intermediate.Pages {
+		pageLine := t.GetImportLineFromPage(page)
+		if err := ExportWriteLine(writer, pageLine); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetImportLineFromPage converts an intermediate page to JSONL import format.
+func (t *Transformer) GetImportLineFromPage(page *IntermediatePage) *LineImportData {
+	// Build attachments with import_source_id for placeholder resolution
+	var attachments *[]AttachmentImportData
+	if len(page.Attachments) > 0 {
+		attData := make([]AttachmentImportData, len(page.Attachments))
+		for i, att := range page.Attachments {
+			attProps := model.StringInterface{
+				"import_source_id": att.SourceID,
+			}
+			attData[i] = AttachmentImportData{
+				Path:  model.NewPointer(att.Path),
+				Props: &attProps,
+			}
+		}
+		attachments = &attData
+	}
+
+	// Build props with import tracking
+	props := page.Props
+	if props == nil {
+		props = model.StringInterface{}
+	}
+	props["import_source_id"] = page.ImportSourceID
+	props["import_source"] = "confluence"
+
+	// Wiki source id = SpaceKey (matches WikiImportData.Props["import_source_id"]).
+	// Fall back to the transformer-level SpaceKey for legacy single-space exports
+	// where IntermediatePage.SpaceKey may be unset.
+	wikiSourceId := page.SpaceKey
+	if wikiSourceId == "" && t.Intermediate != nil && t.Intermediate.Wiki != nil {
+		wikiSourceId = t.Intermediate.Wiki.SpaceKey
+	}
+
+	return &LineImportData{
+		Type: "page",
+		Page: &PageImportData{
+			Team:                 model.NewPointer(t.TeamName),
+			WikiImportSourceId:   model.NewPointer(wikiSourceId),
+			User:                 model.NewPointer(page.User),
+			Title:                model.NewPointer(page.Title),
+			Content:              model.NewPointer(page.Content),
+			ParentImportSourceId: optionalString(page.ParentImportSourceID),
+			CreateAt:             model.NewPointer(page.CreateAt),
+			Props:                &props,
+			Attachments:          attachments,
+		},
+	}
+}
+
+// ExportComments writes all comment lines in topologically sorted order.
+// Parents are exported before their children to ensure proper thread resolution during import.
+func (t *Transformer) ExportComments(writer io.Writer) error {
+	// Topologically sort comments so parents come before children
+	sortedComments := topologicalSortComments(t.Intermediate.Comments)
+
+	for _, comment := range sortedComments {
+		commentLine := t.GetImportLineFromComment(comment)
+		if err := ExportWriteLine(writer, commentLine); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// topologicalSortComments sorts comments so that parent comments appear before their children.
+// This ensures that when importing, parent comments exist before children reference them.
+func topologicalSortComments(comments []*IntermediateComment) []*IntermediateComment {
+	if len(comments) == 0 {
+		return comments
+	}
+
+	// Build a map of comment ID -> comment for quick lookup
+	commentByID := make(map[string]*IntermediateComment, len(comments))
+	for _, c := range comments {
+		commentByID[c.ImportSourceID] = c
+	}
+
+	// Build adjacency list: parent -> children
+	children := make(map[string][]*IntermediateComment)
+	var roots []*IntermediateComment
+
+	for _, c := range comments {
+		if c.ParentCommentImportSourceID == "" {
+			// No parent - this is a root comment
+			roots = append(roots, c)
+		} else if _, parentExists := commentByID[c.ParentCommentImportSourceID]; parentExists {
+			// Parent exists in our set - add as child
+			children[c.ParentCommentImportSourceID] = append(children[c.ParentCommentImportSourceID], c)
+		} else {
+			// Parent doesn't exist (orphaned) - treat as root
+			roots = append(roots, c)
+		}
+	}
+
+	// BFS traversal to build sorted list (parents before children)
+	result := make([]*IntermediateComment, 0, len(comments))
+	queue := roots
+
+	for len(queue) > 0 {
+		// Dequeue
+		current := queue[0]
+		queue = queue[1:]
+
+		result = append(result, current)
+
+		// Enqueue children
+		if kids, ok := children[current.ImportSourceID]; ok {
+			queue = append(queue, kids...)
+		}
+	}
+
+	return result
+}
+
+// ExportResolvePlaceholders writes one directive per wiki to resolve cross-page link
+// placeholders after all pages are imported. Resolution is wiki-scoped (uses the
+// wiki's backing channel for page lookup), so each wiki gets its own line.
+func (t *Transformer) ExportResolvePlaceholders(writer io.Writer) error {
+	emit := func(spaceKey string) error {
+		sourceId := spaceKey
+		line := &LineImportData{
+			Type: "resolve_wiki_placeholders",
+			ResolveWikiPlaceholders: &ResolveWikiPlaceholdersImportData{
+				Team:               &t.TeamName,
+				WikiImportSourceId: &sourceId,
+			},
+		}
+		return ExportWriteLine(writer, line)
+	}
+
+	if t.Intermediate != nil {
+		for _, w := range t.Intermediate.Wikis {
+			if err := emit(w.SpaceKey); err != nil {
+				return err
+			}
+		}
+		if t.Intermediate.Wiki != nil && len(t.Intermediate.Wikis) == 0 {
+			return emit(t.Intermediate.Wiki.SpaceKey)
+		}
+	}
+	return nil
+}
+
+// GetImportLineFromComment converts an intermediate comment to JSONL import format.
+func (t *Transformer) GetImportLineFromComment(comment *IntermediateComment) *LineImportData {
+	// Build props with import tracking
+	props := comment.Props
+	if props == nil {
+		props = model.StringInterface{}
+	}
+	props["import_source_id"] = comment.ImportSourceID
+	props["import_source"] = "confluence"
+
+	// Add inline_anchor if this is an inline comment
+	if comment.InlineAnchorID != "" || comment.InlineAnchorText != "" {
+		inlineAnchor := map[string]string{}
+		if comment.InlineAnchorID != "" {
+			inlineAnchor["anchor_id"] = comment.InlineAnchorID
+		}
+		if comment.InlineAnchorText != "" {
+			inlineAnchor["text"] = comment.InlineAnchorText
+		}
+		props["inline_anchor"] = inlineAnchor
+	}
+
+	// Only include is_resolved if true (omit for unresolved comments)
+	var isResolved *bool
+	if comment.IsResolved {
+		isResolved = model.NewPointer(true)
+	}
+
+	return &LineImportData{
+		Type: "page_comment",
+		PageComment: &PageCommentImportData{
+			PageImportSourceId:          model.NewPointer(comment.PageImportSourceID),
+			ParentCommentImportSourceId: optionalString(comment.ParentCommentImportSourceID),
+			User:                        model.NewPointer(comment.User),
+			Content:                     model.NewPointer(comment.Content),
+			CreateAt:                    model.NewPointer(comment.CreateAt),
+			IsResolved:                  isResolved,
+			Props:                       &props,
+		},
+	}
+}
+
+// optionalString returns a pointer to the string if non-empty, otherwise nil.
+func optionalString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// ExportWithManifest writes the transformed data to a JSONL file and generates a manifest.
+// buildManifestUsers returns one ManifestUser per distinct source user (deduped
+// by Atlassian account ID), pairing it with the Mattermost username it resolves
+// to. Sorted by account ID for deterministic output.
+func (t *Transformer) buildManifestUsers(export *ConfluenceExport) []ManifestUser {
+	seen := make(map[string]bool)
+	users := make([]ManifestUser, 0, len(export.Users))
+	for _, u := range export.Users {
+		if u.AccountID == "" || seen[u.AccountID] {
+			continue
+		}
+		seen[u.AccountID] = true
+		users = append(users, ManifestUser{
+			AccountID:          u.AccountID,
+			ConfluenceUsername: u.Username,
+			MattermostUsername: t.resolveUsername(u.AccountID, export),
+		})
+	}
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].AccountID < users[j].AccountID
+	})
+	return users
+}
+
+func (t *Transformer) ExportWithManifest(outputFilePath string, export *ConfluenceExport) error {
+	// First export the JSONL
+	if err := t.Export(outputFilePath); err != nil {
+		return err
+	}
+
+	// Generate manifest
+	manifest := NewManifest(export, t.TeamName, t.ChannelName, t.ExportFile)
+	manifest.SetCounts(len(t.Intermediate.Pages), len(t.Intermediate.Comments), len(t.Intermediate.Wikis), t.Stats)
+
+	// Set user mapping count if available
+	if t.UserMapper != nil {
+		manifest.SetUserMappingCount(t.UserMapper.GetMappingCount())
+	}
+
+	// Record the source users and the Mattermost username each resolved to, so a
+	// later step can audit or re-match users after import. export.Users is keyed
+	// by both aaid and user_key (aliases to the same record), so dedupe by AccountID.
+	manifest.Users = t.buildManifestUsers(export)
+
+	// Copy warnings and errors from stats
+	manifest.Warnings = append(manifest.Warnings, t.Stats.Warnings...)
+	manifest.Errors = append(manifest.Errors, t.Stats.Errors...)
+
+	// Compute checksums
+	if err := manifest.ComputeJSONLChecksum(outputFilePath); err != nil {
+		t.Logger.Warnf("Failed to compute JSONL checksum: %v", err)
+	}
+
+	if t.Config.AttachmentsDir != "" && !t.Config.SkipAttachments {
+		if err := manifest.ComputeAttachmentsChecksum(t.Config.AttachmentsDir); err != nil {
+			t.Logger.Warnf("Failed to compute attachments checksum: %v", err)
+		}
+	}
+
+	// Write manifest
+	manifestPath := outputFilePath[:len(outputFilePath)-len(".jsonl")] + "-manifest.json"
+	if err := manifest.Write(manifestPath); err != nil {
+		return errors.Wrap(err, "failed to write manifest")
+	}
+
+	t.Logger.Infof("Manifest written to %s", manifestPath)
+	return nil
+}

--- a/services/confluence/export.go
+++ b/services/confluence/export.go
@@ -449,7 +449,7 @@ func (t *Transformer) ExportWithManifest(outputFilePath string, export *Confluen
 	}
 
 	// Generate manifest
-	manifest := NewManifest(export, t.TeamName, t.ChannelName, t.ExportFile)
+	manifest := NewManifest(export, t.TeamName, t.ExportFile)
 	spaces := 0
 	if t.Intermediate.Space != nil {
 		spaces = 1

--- a/services/confluence/export.go
+++ b/services/confluence/export.go
@@ -5,6 +5,7 @@ package confluence
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -13,40 +14,45 @@ import (
 	"github.com/pkg/errors"
 )
 
-// JSONL output types for wiki/page import
-// These match the types expected by the Mattermost wiki import functionality
+// JSONL output types for the Mattermost Docs (Spaces/Pages) import contract.
+//
+// This is the v2 contract, named in Docs terms (space/page/page_comment). There
+// is no shipped consumer of an earlier version, so no compatibility shim exists.
+// Entity source IDs (page IDs, space keys) are bare and interpreted within the
+// bundle's source namespace (see SourceImportData); importers must scope all
+// source-ID lookups to the job, never globally.
 
 // LineImportData represents a single line in the JSONL import file.
 type LineImportData struct {
-	Type                    string                             `json:"type"`
-	Version                 *int                               `json:"version,omitempty"`
-	Channel                 *ChannelImportData                 `json:"channel,omitempty"`
-	Wiki                    *WikiImportData                    `json:"wiki,omitempty"`
-	Page                    *PageImportData                    `json:"page,omitempty"`
-	PageComment             *PageCommentImportData             `json:"page_comment,omitempty"`
-	ResolveWikiPlaceholders *ResolveWikiPlaceholdersImportData `json:"resolve_wiki_placeholders,omitempty"`
+	Type                     string                              `json:"type"`
+	Version                  *int                                `json:"version,omitempty"`
+	Source                   *SourceImportData                   `json:"source,omitempty"`
+	Space                    *SpaceImportData                    `json:"space,omitempty"`
+	Page                     *PageImportData                     `json:"page,omitempty"`
+	PageComment              *PageCommentImportData              `json:"page_comment,omitempty"`
+	ResolveSpacePlaceholders *ResolveSpacePlaceholdersImportData `json:"resolve_space_placeholders,omitempty"`
 }
 
-// ResolveWikiPlaceholdersImportData triggers post-import placeholder resolution.
-type ResolveWikiPlaceholdersImportData struct {
-	Team               *string `json:"team"`
-	WikiImportSourceId *string `json:"wiki_import_source_id"`
+// SourceImportData carries the bundle-level source namespace so numeric page IDs
+// and space keys cannot collide across Confluence instances. It rides on the
+// version line and is carried once per bundle (not per entity line).
+type SourceImportData struct {
+	OrganizationId *string `json:"organization_id,omitempty"`
+	SpaceKey       *string `json:"space_key,omitempty"`
 }
 
-// ChannelImportData represents a channel to be created.
-type ChannelImportData struct {
-	Team        *string `json:"team"`
-	Name        *string `json:"name"`
-	DisplayName *string `json:"display_name"`
-	Type        *string `json:"type"` // "O" for public, "P" for private
-	Purpose     *string `json:"purpose,omitempty"`
-	Header      *string `json:"header,omitempty"`
+// ResolveSpacePlaceholdersImportData triggers post-import placeholder resolution,
+// scoped to the space's pages.
+type ResolveSpacePlaceholdersImportData struct {
+	Team                *string `json:"team"`
+	SpaceImportSourceId *string `json:"space_import_source_id"`
 }
 
-// WikiImportData represents a wiki to be imported.
-type WikiImportData struct {
+// SpaceImportData represents a Space to be imported. The backing channel is
+// resolved at import time from the import request, so it is not part of this
+// contract.
+type SpaceImportData struct {
 	Team        *string                `json:"team"`
-	Channel     *string                `json:"channel"`
 	Title       *string                `json:"title,omitempty"`
 	Description *string                `json:"description,omitempty"`
 	Props       *model.StringInterface `json:"props,omitempty"`
@@ -55,12 +61,13 @@ type WikiImportData struct {
 // PageImportData represents a page to be imported.
 type PageImportData struct {
 	Team                 *string                 `json:"team"`
-	WikiImportSourceId   *string                 `json:"wiki_import_source_id"`
+	SpaceImportSourceId  *string                 `json:"space_import_source_id"`
 	User                 *string                 `json:"user"`
 	Title                *string                 `json:"title"`
 	Content              *string                 `json:"content"`
 	ParentImportSourceId *string                 `json:"parent_import_source_id,omitempty"`
 	CreateAt             *int64                  `json:"create_at,omitempty"`
+	UpdateAt             *int64                  `json:"update_at,omitempty"`
 	Props                *model.StringInterface  `json:"props,omitempty"`
 	Attachments          *[]AttachmentImportData `json:"attachments,omitempty"`
 }
@@ -72,6 +79,7 @@ type PageCommentImportData struct {
 	User                        *string                `json:"user"`
 	Content                     *string                `json:"content"`
 	CreateAt                    *int64                 `json:"create_at,omitempty"`
+	UpdateAt                    *int64                 `json:"update_at,omitempty"`
 	IsResolved                  *bool                  `json:"is_resolved,omitempty"`
 	Props                       *model.StringInterface `json:"props,omitempty"`
 }
@@ -104,23 +112,15 @@ func (t *Transformer) Export(outputFilePath string) error {
 	}
 	defer outputFile.Close()
 
-	// Write version line
+	// Write version line (carries the bundle-level source namespace)
 	t.Logger.Info("Exporting version")
 	if err := t.ExportVersion(outputFile); err != nil {
 		return err
 	}
 
-	// Export channel (if auto-creating)
-	if t.Intermediate.Channel != nil {
-		t.Logger.Info("Exporting channel")
-		if err := t.ExportChannel(outputFile); err != nil {
-			return err
-		}
-	}
-
-	// Export wikis (one per space)
-	t.Logger.Infof("Exporting %d wikis", len(t.Intermediate.Wikis))
-	if err := t.ExportWikis(outputFile); err != nil {
+	// Export the single space
+	t.Logger.Info("Exporting space")
+	if err := t.ExportSpace(outputFile); err != nil {
 		return err
 	}
 
@@ -136,7 +136,7 @@ func (t *Transformer) Export(outputFilePath string) error {
 		return err
 	}
 
-	// Export resolve_wiki_placeholders directive to resolve cross-page links
+	// Export resolve_space_placeholders directive to resolve cross-page links
 	t.Logger.Info("Exporting placeholder resolution directive")
 	if err := t.ExportResolvePlaceholders(outputFile); err != nil {
 		return err
@@ -145,80 +145,56 @@ func (t *Transformer) Export(outputFilePath string) error {
 	return nil
 }
 
-// ExportVersion writes the version line.
+// sourceImportData builds the bundle-level source namespace, or nil when neither
+// an organization id nor a space key is available.
+func (t *Transformer) sourceImportData() *SourceImportData {
+	if t.Intermediate == nil {
+		return nil
+	}
+	src := &SourceImportData{}
+	if t.Intermediate.SourceOrganizationID != "" {
+		src.OrganizationId = model.NewPointer(t.Intermediate.SourceOrganizationID)
+	}
+	if t.Intermediate.Space != nil && t.Intermediate.Space.SpaceKey != "" {
+		src.SpaceKey = model.NewPointer(t.Intermediate.Space.SpaceKey)
+	}
+	if src.OrganizationId == nil && src.SpaceKey == nil {
+		return nil
+	}
+	return src
+}
+
+// ExportVersion writes the version line, including the source namespace.
 func (t *Transformer) ExportVersion(writer io.Writer) error {
-	version := 1
+	version := 2
 	versionLine := &LineImportData{
 		Type:    "version",
 		Version: &version,
+		Source:  t.sourceImportData(),
 	}
 	return ExportWriteLine(writer, versionLine)
 }
 
-// ExportChannel writes the channel line (if auto-creating).
-func (t *Transformer) ExportChannel(writer io.Writer) error {
-	if t.Intermediate.Channel == nil {
+// ExportSpace writes the single space line.
+func (t *Transformer) ExportSpace(writer io.Writer) error {
+	if t.Intermediate == nil || t.Intermediate.Space == nil {
 		return nil
 	}
 
-	ch := t.Intermediate.Channel
-	channelLine := &LineImportData{
-		Type: "channel",
-		Channel: &ChannelImportData{
-			Team:        model.NewPointer(ch.Team),
-			Name:        model.NewPointer(ch.Name),
-			DisplayName: model.NewPointer(ch.DisplayName),
-			Type:        model.NewPointer(ch.Type),
-			Purpose:     optionalString(ch.Purpose),
-			Header:      optionalString(ch.Header),
-		},
-	}
-	return ExportWriteLine(writer, channelLine)
-}
-
-// ExportWikis writes wiki lines for all spaces.
-func (t *Transformer) ExportWikis(writer io.Writer) error {
-	for _, wiki := range t.Intermediate.Wikis {
-		props := model.StringInterface{
-			"import_source_id": wiki.SpaceKey,
-		}
-		wikiLine := &LineImportData{
-			Type: "wiki",
-			Wiki: &WikiImportData{
-				Team:        model.NewPointer(wiki.Team),
-				Channel:     model.NewPointer(wiki.Channel),
-				Title:       model.NewPointer(wiki.Title),
-				Description: model.NewPointer(wiki.Description),
-				Props:       &props,
-			},
-		}
-		if err := ExportWriteLine(writer, wikiLine); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ExportWiki writes the wiki line (legacy single-wiki support).
-func (t *Transformer) ExportWiki(writer io.Writer) error {
-	if t.Intermediate.Wiki == nil {
-		return nil
-	}
-
+	space := t.Intermediate.Space
 	props := model.StringInterface{
-		"import_source_id": t.Intermediate.Wiki.SpaceKey,
+		"import_source_id": space.SpaceKey,
 	}
-	wikiLine := &LineImportData{
-		Type: "wiki",
-		Wiki: &WikiImportData{
-			Team:        model.NewPointer(t.Intermediate.Wiki.Team),
-			Channel:     model.NewPointer(t.Intermediate.Wiki.Channel),
-			Title:       model.NewPointer(t.Intermediate.Wiki.Title),
-			Description: model.NewPointer(t.Intermediate.Wiki.Description),
+	spaceLine := &LineImportData{
+		Type: "space",
+		Space: &SpaceImportData{
+			Team:        model.NewPointer(space.Team),
+			Title:       model.NewPointer(space.Title),
+			Description: model.NewPointer(space.Description),
 			Props:       &props,
 		},
 	}
-	return ExportWriteLine(writer, wikiLine)
+	return ExportWriteLine(writer, spaceLine)
 }
 
 // ExportPages writes all page lines.
@@ -258,27 +234,45 @@ func (t *Transformer) GetImportLineFromPage(page *IntermediatePage) *LineImportD
 	props["import_source_id"] = page.ImportSourceID
 	props["import_source"] = "confluence"
 
-	// Wiki source id = SpaceKey (matches WikiImportData.Props["import_source_id"]).
-	// Fall back to the transformer-level SpaceKey for legacy single-space exports
-	// where IntermediatePage.SpaceKey may be unset.
-	wikiSourceId := page.SpaceKey
-	if wikiSourceId == "" && t.Intermediate != nil && t.Intermediate.Wiki != nil {
-		wikiSourceId = t.Intermediate.Wiki.SpaceKey
+	// Space source id = SpaceKey (matches SpaceImportData.Props["import_source_id"]).
+	// Fall back to the single Space's key when IntermediatePage.SpaceKey is unset.
+	spaceSourceId := page.SpaceKey
+	if spaceSourceId == "" && t.Intermediate != nil && t.Intermediate.Space != nil {
+		spaceSourceId = t.Intermediate.Space.SpaceKey
 	}
+
+	// Enforce Docs size limits on the emitted body and props (warn, don't drop).
+	t.checkPageLimits(page, props)
 
 	return &LineImportData{
 		Type: "page",
 		Page: &PageImportData{
 			Team:                 model.NewPointer(t.TeamName),
-			WikiImportSourceId:   model.NewPointer(wikiSourceId),
+			SpaceImportSourceId:  model.NewPointer(spaceSourceId),
 			User:                 model.NewPointer(page.User),
 			Title:                model.NewPointer(page.Title),
 			Content:              model.NewPointer(page.Content),
 			ParentImportSourceId: optionalString(page.ParentImportSourceID),
 			CreateAt:             model.NewPointer(page.CreateAt),
+			UpdateAt:             optionalInt64(page.UpdateAt),
 			Props:                &props,
 			Attachments:          attachments,
 		},
+	}
+}
+
+// checkPageLimits warns (via stats + logger) when a page's emitted body or props
+// exceed the Docs storage caps. The page is still emitted; the operator decides.
+func (t *Transformer) checkPageLimits(page *IntermediatePage, props model.StringInterface) {
+	if n := len(page.Content); n > PageBodyMaxBytes {
+		msg := fmt.Sprintf("page %q body is %d bytes, exceeding the %d-byte Docs limit", page.Title, n, PageBodyMaxBytes)
+		t.Logger.Warn(msg)
+		t.Stats.Warnings = append(t.Stats.Warnings, msg)
+	}
+	if b, err := json.Marshal(props); err == nil && len(b) > PagePropsMaxBytes {
+		msg := fmt.Sprintf("page %q props are %d bytes, exceeding the %d-byte Docs limit", page.Title, len(b), PagePropsMaxBytes)
+		t.Logger.Warn(msg)
+		t.Stats.Warnings = append(t.Stats.Warnings, msg)
 	}
 }
 
@@ -347,33 +341,21 @@ func topologicalSortComments(comments []*IntermediateComment) []*IntermediateCom
 	return result
 }
 
-// ExportResolvePlaceholders writes one directive per wiki to resolve cross-page link
-// placeholders after all pages are imported. Resolution is wiki-scoped (uses the
-// wiki's backing channel for page lookup), so each wiki gets its own line.
+// ExportResolvePlaceholders writes the directive that resolves cross-page link
+// placeholders after all pages are imported. Resolution is space-scoped.
 func (t *Transformer) ExportResolvePlaceholders(writer io.Writer) error {
-	emit := func(spaceKey string) error {
-		sourceId := spaceKey
-		line := &LineImportData{
-			Type: "resolve_wiki_placeholders",
-			ResolveWikiPlaceholders: &ResolveWikiPlaceholdersImportData{
-				Team:               &t.TeamName,
-				WikiImportSourceId: &sourceId,
-			},
-		}
-		return ExportWriteLine(writer, line)
+	if t.Intermediate == nil || t.Intermediate.Space == nil {
+		return nil
 	}
-
-	if t.Intermediate != nil {
-		for _, w := range t.Intermediate.Wikis {
-			if err := emit(w.SpaceKey); err != nil {
-				return err
-			}
-		}
-		if t.Intermediate.Wiki != nil && len(t.Intermediate.Wikis) == 0 {
-			return emit(t.Intermediate.Wiki.SpaceKey)
-		}
+	sourceId := t.Intermediate.Space.SpaceKey
+	line := &LineImportData{
+		Type: "resolve_space_placeholders",
+		ResolveSpacePlaceholders: &ResolveSpacePlaceholdersImportData{
+			Team:                &t.TeamName,
+			SpaceImportSourceId: &sourceId,
+		},
 	}
-	return nil
+	return ExportWriteLine(writer, line)
 }
 
 // GetImportLineFromComment converts an intermediate comment to JSONL import format.
@@ -412,6 +394,7 @@ func (t *Transformer) GetImportLineFromComment(comment *IntermediateComment) *Li
 			User:                        model.NewPointer(comment.User),
 			Content:                     model.NewPointer(comment.Content),
 			CreateAt:                    model.NewPointer(comment.CreateAt),
+			UpdateAt:                    optionalInt64(comment.UpdateAt),
 			IsResolved:                  isResolved,
 			Props:                       &props,
 		},
@@ -424,6 +407,15 @@ func optionalString(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// optionalInt64 returns a pointer to the value if non-zero, otherwise nil, so
+// unset timestamps are omitted rather than emitted as epoch zero.
+func optionalInt64(v int64) *int64 {
+	if v == 0 {
+		return nil
+	}
+	return &v
 }
 
 // ExportWithManifest writes the transformed data to a JSONL file and generates a manifest.
@@ -458,7 +450,12 @@ func (t *Transformer) ExportWithManifest(outputFilePath string, export *Confluen
 
 	// Generate manifest
 	manifest := NewManifest(export, t.TeamName, t.ChannelName, t.ExportFile)
-	manifest.SetCounts(len(t.Intermediate.Pages), len(t.Intermediate.Comments), len(t.Intermediate.Wikis), t.Stats)
+	spaces := 0
+	if t.Intermediate.Space != nil {
+		spaces = 1
+	}
+	manifest.SetCounts(len(t.Intermediate.Pages), len(t.Intermediate.Comments), spaces, t.Stats)
+	manifest.SetRestrictedPages(export)
 
 	// Set user mapping count if available
 	if t.UserMapper != nil {

--- a/services/confluence/export_test.go
+++ b/services/confluence/export_test.go
@@ -81,7 +81,7 @@ func TestExport_V2SchemaAndSourceNamespace(t *testing.T) {
 	spaceProps := space["props"].(map[string]any)
 	assert.Equal(t, "DOCS", spaceProps["import_source_id"])
 
-	// Pages use space_import_source_id and carry update_at.
+	// Pages use space_import_source_id and carry update_at, with no channel field.
 	pages := linesOfType(lines, "page")
 	require.NotEmpty(t, pages)
 	for _, pl := range pages {
@@ -89,7 +89,16 @@ func TestExport_V2SchemaAndSourceNamespace(t *testing.T) {
 		assert.Equal(t, "DOCS", p["space_import_source_id"])
 		_, hasWiki := p["wiki_import_source_id"]
 		assert.False(t, hasWiki, "v1 wiki_import_source_id must be gone")
+		_, hasChannel := p["channel"]
+		assert.False(t, hasChannel, "v2 page line must not carry a channel")
 		assert.Contains(t, p, "update_at", "pages should emit update_at")
+	}
+
+	// Comments carry no channel field either.
+	for _, cl := range linesOfType(lines, "page_comment") {
+		c := cl["page_comment"].(map[string]any)
+		_, hasChannel := c["channel"]
+		assert.False(t, hasChannel, "v2 page_comment line must not carry a channel")
 	}
 
 	// resolve line renamed to resolve_space_placeholders.
@@ -134,7 +143,7 @@ func TestExport_AttachmentsPopulatedAndResolved(t *testing.T) {
 
 	// Parse populates export.Attachments from the ATTACHMENT row.
 	zr := buildFixtureZip(t, files)
-	tr := NewTransformer("team", "channel", quietLogger(), &TransformConfig{MaxDepth: 10, AttachmentsDir: t.TempDir()})
+	tr := NewTransformer("team", quietLogger(), &TransformConfig{MaxDepth: 10, AttachmentsDir: t.TempDir()})
 	export, err := tr.ParseConfluenceExport(zr)
 	require.NoError(t, err)
 	require.Contains(t, export.Attachments, "100")
@@ -175,7 +184,7 @@ func TestExport_RestrictionsDetectedAndReported(t *testing.T) {
 	assert.False(t, export.RestrictedPageIDs["100"], "EDIT-only restriction is not a view widening")
 
 	// Validation surfaces it as a warning by default, an error under --fail.
-	v := NewValidator("team", "")
+	v := NewValidator("team")
 	warnResult := v.ValidateExportContent(export)
 	assert.True(t, warnResult.Valid)
 	require.NotEmpty(t, warnResult.Warnings)
@@ -193,7 +202,7 @@ func TestExport_RestrictionsDetectedAndReported(t *testing.T) {
 	assert.False(t, failResult.Valid, "--fail-on-restricted should fail validation")
 
 	// Manifest records the restricted page with its resolved title.
-	m := NewManifest(export, "team", "", "export.zip")
+	m := NewManifest(export, "team", "export.zip")
 	m.SetRestrictedPages(export)
 	require.Len(t, m.RestrictedPages, 1)
 	assert.Equal(t, "101", m.RestrictedPages[0].ID)
@@ -215,6 +224,78 @@ func TestExport_UpdateAtOmittedWhenZero(t *testing.T) {
 	page := linesOfType(lines, "page")[0]["page"].(map[string]any)
 	_, hasUpdate := page["update_at"]
 	assert.False(t, hasUpdate, "update_at must be omitted when the source has no modification date")
+}
+
+// TestManifest_NoChannelKey proves the marshalled manifest records the advisory
+// target team but carries no channel key — neither nested under target nor at
+// the top level. The Docs plugin owns the Space backing channel; mmetl never
+// names it.
+func TestManifest_NoChannelKey(t *testing.T) {
+	files := cloneFixture(csvFixture)
+	_, export := parseFixture(t, files)
+
+	m := NewManifest(export, "myteam", "export.zip")
+
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	// The advisory team is present under target.
+	target, ok := decoded["target"].(map[string]any)
+	require.True(t, ok, "manifest must carry a target object")
+	assert.Equal(t, "myteam", target["team"], "target.team must record the advisory team")
+
+	// No channel key anywhere it could have leaked.
+	_, hasTargetChannel := target["channel"]
+	assert.False(t, hasTargetChannel, "target must not carry a channel key (not even empty)")
+	_, hasTopChannel := decoded["channel"]
+	assert.False(t, hasTopChannel, "manifest must not carry a top-level channel key")
+}
+
+// TestExport_CommentFidelity proves page_comment records preserve the fields the
+// downstream Docs importer relies on to reconstruct post threads: the owning
+// page, the parent comment for replies, source author metadata, and inline
+// anchor/resolved state.
+func TestExport_CommentFidelity(t *testing.T) {
+	files := cloneFixture(csvFixture)
+	tr, export := parseFixture(t, files)
+	lines := exportLines(t, tr, export)
+
+	comments := linesOfType(lines, "page_comment")
+	require.NotEmpty(t, comments)
+
+	byID := map[string]map[string]any{}
+	for _, cl := range comments {
+		c := cl["page_comment"].(map[string]any)
+		props := c["props"].(map[string]any)
+		byID[props["import_source_id"].(string)] = c
+	}
+
+	// The top-level comment (200) is a root: no parent, carries author metadata,
+	// its owning page, an inline anchor, and resolved state.
+	root, ok := byID["200"]
+	require.True(t, ok, "root comment 200 must be emitted")
+	assert.Equal(t, "101", root["page_import_source_id"], "comment must reference its owning page")
+	_, hasParent := root["parent_comment_import_source_id"]
+	assert.False(t, hasParent, "a top-level comment has no parent")
+	rootProps := root["props"].(map[string]any)
+	assert.Equal(t, "aaid2", rootProps["confluence_author_account_id"], "source author metadata must be preserved")
+	assert.Equal(t, "confluence", rootProps["import_source"])
+	anchor, ok := rootProps["inline_anchor"].(map[string]any)
+	require.True(t, ok, "inline comment must carry an inline_anchor")
+	assert.Equal(t, "uuid-abc", anchor["anchor_id"])
+	assert.Equal(t, "highlighted text", anchor["text"])
+	assert.Equal(t, true, root["is_resolved"], "resolved inline comment must carry is_resolved")
+
+	// The reply (201) reconstructs threading via parent_comment_import_source_id.
+	reply, ok := byID["201"]
+	require.True(t, ok, "reply comment 201 must be emitted")
+	assert.Equal(t, "200", reply["parent_comment_import_source_id"], "reply must point at its parent comment")
+	assert.Equal(t, "101", reply["page_import_source_id"])
+	replyProps := reply["props"].(map[string]any)
+	assert.Equal(t, "aaid1", replyProps["confluence_author_account_id"])
 }
 
 func cloneFixture(src map[string]string) map[string]string {

--- a/services/confluence/export_test.go
+++ b/services/confluence/export_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exportLines transforms an export and returns the emitted JSONL as decoded maps,
+// keyed nothing — just the raw ordered lines — so tests can assert exact keys.
+func exportLines(t *testing.T, tr *Transformer, export *ConfluenceExport) []map[string]any {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "import.jsonl")
+	require.NoError(t, tr.Transform(export))
+	require.NoError(t, tr.Export(out))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	var lines []map[string]any
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &m))
+		lines = append(lines, m)
+	}
+	require.NoError(t, sc.Err())
+	return lines
+}
+
+func linesOfType(lines []map[string]any, typ string) []map[string]any {
+	var out []map[string]any
+	for _, l := range lines {
+		if l["type"] == typ {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func TestExport_V2SchemaAndSourceNamespace(t *testing.T) {
+	files := cloneFixture(csvFixture)
+	// Add an organization id so the source namespace carries both fields.
+	files["exportDescriptor.properties"] += "organizationId=org-123\n"
+
+	tr, export := parseFixture(t, files)
+	lines := exportLines(t, tr, export)
+
+	// version line: version 2 + source namespace (organization_id + space_key).
+	version := linesOfType(lines, "version")
+	require.Len(t, version, 1)
+	assert.EqualValues(t, 2, version[0]["version"])
+	src, ok := version[0]["source"].(map[string]any)
+	require.True(t, ok, "version line must carry a source namespace")
+	assert.Equal(t, "org-123", src["organization_id"])
+	assert.Equal(t, "DOCS", src["space_key"])
+
+	// Exactly one space line, named in Docs terms with no channel field.
+	spaces := linesOfType(lines, "space")
+	require.Len(t, spaces, 1)
+	space := spaces[0]["space"].(map[string]any)
+	assert.Equal(t, "team", space["team"])
+	_, hasChannel := space["channel"]
+	assert.False(t, hasChannel, "v2 space line must not carry a channel")
+	spaceProps := space["props"].(map[string]any)
+	assert.Equal(t, "DOCS", spaceProps["import_source_id"])
+
+	// Pages use space_import_source_id and carry update_at.
+	pages := linesOfType(lines, "page")
+	require.NotEmpty(t, pages)
+	for _, pl := range pages {
+		p := pl["page"].(map[string]any)
+		assert.Equal(t, "DOCS", p["space_import_source_id"])
+		_, hasWiki := p["wiki_import_source_id"]
+		assert.False(t, hasWiki, "v1 wiki_import_source_id must be gone")
+		assert.Contains(t, p, "update_at", "pages should emit update_at")
+	}
+
+	// resolve line renamed to resolve_space_placeholders.
+	resolve := linesOfType(lines, "resolve_space_placeholders")
+	require.Len(t, resolve, 1)
+	rd := resolve[0]["resolve_space_placeholders"].(map[string]any)
+	assert.Equal(t, "DOCS", rd["space_import_source_id"])
+
+	// None of the retired v1 line types survive.
+	assert.Empty(t, linesOfType(lines, "wiki"))
+	assert.Empty(t, linesOfType(lines, "channel"))
+	assert.Empty(t, linesOfType(lines, "resolve_wiki_placeholders"))
+}
+
+func TestExport_SingleSpaceGuardrail(t *testing.T) {
+	tr := newTestTransformer()
+	export := &ConfluenceExport{
+		Spaces: map[string]*SpaceInfo{
+			"DOCS": {Key: "DOCS", Name: "Docs"},
+			"ENG":  {Key: "ENG", Name: "Engineering"},
+		},
+		RestrictedPageIDs: map[string]bool{},
+	}
+	err := tr.Transform(export)
+	require.Error(t, err, "a two-space export must be rejected")
+	assert.Contains(t, err.Error(), "multi-space")
+}
+
+func TestExport_AttachmentsPopulatedAndResolved(t *testing.T) {
+	files := map[string]string{
+		"exportDescriptor.properties": "exportFormat=csv\nexportType=space\nspaceKey=DOCS\n",
+		"spaces.csv":                  "spaceid,spacename,spacekey,homepage\n900,Docs,DOCS,100\n",
+		"user_mapping.csv":            "user_key,username,aaid\nukey1,uname1,aaid1\n",
+		"content.csv": "contentid,contenttype,title,version,creator,creationdate,lastmodifier,lastmoddate,prevver,content_status,pageid,spaceid,parentid\n" +
+			"100,PAGE,Home,1,ukey1,2024-01-01 10:00:00.0,ukey1,2024-01-02 10:00:00.0,,current,,900,\n" +
+			"300,ATTACHMENT,diagram.png,1,ukey1,2024-01-01 10:00:00.0,ukey1,2024-01-01 10:00:00.0,,current,100,,\n",
+		"bodycontent.csv": "bodycontentid,body,contentid,bodytypeid\n" +
+			"1,\"<p>See <ac:image><ri:attachment ri:filename=\"\"diagram.png\"\" /></ac:image></p>\",100,2\n",
+	}
+
+	// Parse populates export.Attachments from the ATTACHMENT row. SkipAttachments
+	// is false so the page's attachments array is emitted (no extraction needed).
+	tr := NewTransformer("team", "channel", quietLogger(), &TransformConfig{MaxDepth: 10})
+	export, err := tr.ParseConfluenceExport(buildFixtureZip(t, files))
+	require.NoError(t, err)
+	require.Contains(t, export.Attachments, "100")
+	require.Len(t, export.Attachments["100"], 1)
+	assert.Equal(t, "diagram.png", export.Attachments["100"][0].FileName)
+	assert.Equal(t, "300", export.Attachments["100"][0].ID)
+
+	lines := exportLines(t, tr, export)
+	pages := linesOfType(lines, "page")
+	require.Len(t, pages, 1)
+	page := pages[0]["page"].(map[string]any)
+
+	// The body's filename placeholder is rewritten to the attachment id.
+	content := page["content"].(string)
+	assert.Contains(t, content, "{{CONF_FILE:300}}", "CONF_ATTACHMENT should resolve to CONF_FILE by id")
+	assert.NotContains(t, content, "CONF_ATTACHMENT", "no unresolved attachment placeholder should remain")
+
+	// The page carries its attachments array (source id preserved).
+	atts, ok := page["attachments"].([]any)
+	require.True(t, ok, "page should carry an attachments array")
+	require.Len(t, atts, 1)
+	attProps := atts[0].(map[string]any)["props"].(map[string]any)
+	assert.Equal(t, "300", attProps["import_source_id"])
+}
+
+func TestExport_RestrictionsDetectedAndReported(t *testing.T) {
+	files := cloneFixture(csvFixture)
+	files["content_perm_set.csv"] = "id,cps_type,cont_id\nps1,VIEW,101\nps2,EDIT,100\n"
+
+	_, export := parseFixture(t, files)
+	// Only the VIEW-restricted page is flagged.
+	assert.True(t, export.RestrictedPageIDs["101"])
+	assert.False(t, export.RestrictedPageIDs["100"], "EDIT-only restriction is not a view widening")
+
+	// Validation surfaces it as a warning by default, an error under --fail.
+	v := NewValidator("team", "")
+	warnResult := v.ValidateExportContent(export)
+	assert.True(t, warnResult.Valid)
+	require.NotEmpty(t, warnResult.Warnings)
+	assert.Condition(t, func() bool {
+		for _, w := range warnResult.Warnings {
+			if strings.Contains(w, "View restriction") {
+				return true
+			}
+		}
+		return false
+	})
+
+	v.FailOnRestricted = true
+	failResult := v.ValidateExportContent(export)
+	assert.False(t, failResult.Valid, "--fail-on-restricted should fail validation")
+
+	// Manifest records the restricted page with its resolved title.
+	m := NewManifest(export, "team", "", "export.zip")
+	m.SetRestrictedPages(export)
+	require.Len(t, m.RestrictedPages, 1)
+	assert.Equal(t, "101", m.RestrictedPages[0].ID)
+	assert.Equal(t, "Child", m.RestrictedPages[0].Title)
+}
+
+func TestExport_UpdateAtOmittedWhenZero(t *testing.T) {
+	// A page with no lastmoddate must omit update_at rather than emit epoch-zero.
+	files := map[string]string{
+		"exportDescriptor.properties": "exportFormat=csv\nspaceKey=DOCS\n",
+		"spaces.csv":                  "spaceid,spacename,spacekey,homepage\n900,Docs,DOCS,100\n",
+		"user_mapping.csv":            "user_key,username,aaid\nukey1,uname1,aaid1\n",
+		"content.csv": "contentid,contenttype,title,version,creator,creationdate,lastmodifier,lastmoddate,prevver,content_status,pageid,spaceid,parentid\n" +
+			"100,PAGE,Home,1,ukey1,2024-01-01 10:00:00.0,,,,current,,900,\n",
+		"bodycontent.csv": "bodycontentid,body,contentid,bodytypeid\n1,<p>hi</p>,100,2\n",
+	}
+	tr, export := parseFixture(t, files)
+	lines := exportLines(t, tr, export)
+	page := linesOfType(lines, "page")[0]["page"].(map[string]any)
+	_, hasUpdate := page["update_at"]
+	assert.False(t, hasUpdate, "update_at must be omitted when the source has no modification date")
+}
+
+func cloneFixture(src map[string]string) map[string]string {
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func quietLogger() log.FieldLogger {
+	l := log.New()
+	l.SetLevel(log.PanicLevel)
+	return l
+}

--- a/services/confluence/export_test.go
+++ b/services/confluence/export_test.go
@@ -128,17 +128,24 @@ func TestExport_AttachmentsPopulatedAndResolved(t *testing.T) {
 			"300,ATTACHMENT,diagram.png,1,ukey1,2024-01-01 10:00:00.0,ukey1,2024-01-01 10:00:00.0,,current,100,,\n",
 		"bodycontent.csv": "bodycontentid,body,contentid,bodytypeid\n" +
 			"1,\"<p>See <ac:image><ri:attachment ri:filename=\"\"diagram.png\"\" /></ac:image></p>\",100,2\n",
+		// The attachment bytes, under the legacy layout attachments/{page}/{id}/{version}.
+		"attachments/100/300/1": "PNGDATA",
 	}
 
-	// Parse populates export.Attachments from the ATTACHMENT row. SkipAttachments
-	// is false so the page's attachments array is emitted (no extraction needed).
-	tr := NewTransformer("team", "channel", quietLogger(), &TransformConfig{MaxDepth: 10})
-	export, err := tr.ParseConfluenceExport(buildFixtureZip(t, files))
+	// Parse populates export.Attachments from the ATTACHMENT row.
+	zr := buildFixtureZip(t, files)
+	tr := NewTransformer("team", "channel", quietLogger(), &TransformConfig{MaxDepth: 10, AttachmentsDir: t.TempDir()})
+	export, err := tr.ParseConfluenceExport(zr)
 	require.NoError(t, err)
 	require.Contains(t, export.Attachments, "100")
 	require.Len(t, export.Attachments["100"], 1)
 	assert.Equal(t, "diagram.png", export.Attachments["100"][0].FileName)
 	assert.Equal(t, "300", export.Attachments["100"][0].ID)
+
+	// Extraction is required before the attachment (and its content placeholder)
+	// is emitted — only successfully extracted files ship.
+	require.NoError(t, tr.ExtractAttachments(zr, export))
+	assert.Equal(t, "100/diagram.png", export.Attachments["100"][0].FilePath)
 
 	lines := exportLines(t, tr, export)
 	pages := linesOfType(lines, "page")

--- a/services/confluence/hierarchy.go
+++ b/services/confluence/hierarchy.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"fmt"
+	"sort"
+)
+
+// buildPageHierarchy builds the page tree and returns pages in topological order.
+// Parents are always returned before their children.
+func (t *Transformer) buildPageHierarchy(pages []*ConfluencePage) ([]*ConfluencePage, error) {
+	t.Logger.Info("Building page hierarchy")
+
+	// Build lookup maps
+	pageByID := make(map[string]*ConfluencePage)
+	childrenByParent := make(map[string][]*ConfluencePage)
+	rootPages := []*ConfluencePage{}
+
+	for _, page := range pages {
+		pageByID[page.ID] = page
+
+		if page.ParentID == "" {
+			rootPages = append(rootPages, page)
+		} else {
+			childrenByParent[page.ParentID] = append(childrenByParent[page.ParentID], page)
+		}
+	}
+
+	// Detect cycles using DFS
+	if err := t.detectCycles(pages, pageByID); err != nil {
+		return nil, err
+	}
+
+	// Sort root pages by position (with title as fallback for deterministic output)
+	sort.Slice(rootPages, func(i, j int) bool {
+		return comparePageOrder(rootPages[i], rootPages[j])
+	})
+
+	// Perform topological sort (BFS from roots)
+	result := make([]*ConfluencePage, 0, len(pages))
+	visited := make(map[string]bool)
+
+	var visit func(page *ConfluencePage, depth int)
+	visit = func(page *ConfluencePage, depth int) {
+		if visited[page.ID] {
+			return
+		}
+		visited[page.ID] = true
+
+		// Check max depth
+		if depth > t.Config.MaxDepth {
+			t.Logger.Warnf("Page %s (%s) exceeds max depth %d, flattening to max depth",
+				page.ID, page.Title, t.Config.MaxDepth)
+			// Find the ancestor at max depth and re-parent
+			page.ParentID = t.findAncestorAtDepth(page, pageByID, t.Config.MaxDepth-1)
+			t.Stats.PagesFlattened++
+			t.Stats.Warnings = append(t.Stats.Warnings,
+				fmt.Sprintf("Page '%s' flattened from depth %d to max depth %d", page.Title, depth, t.Config.MaxDepth))
+		}
+
+		result = append(result, page)
+
+		// Visit children (sorted by position with title as fallback for deterministic output)
+		children := childrenByParent[page.ID]
+		sort.Slice(children, func(i, j int) bool {
+			return comparePageOrder(children[i], children[j])
+		})
+
+		for _, child := range children {
+			visit(child, depth+1)
+		}
+	}
+
+	// Start from root pages
+	for _, root := range rootPages {
+		visit(root, 1)
+	}
+
+	// Handle orphaned pages (pages with non-existent parents)
+	for _, page := range pages {
+		if !visited[page.ID] {
+			t.Logger.Warnf("Page %s (%s) has invalid parent %s, treating as root",
+				page.ID, page.Title, page.ParentID)
+			page.ParentID = "" // Make it a root page
+			visit(page, 1)
+		}
+	}
+
+	t.Logger.Infof("Hierarchy built: %d pages, %d root pages", len(result), len(rootPages))
+
+	return result, nil
+}
+
+// detectCycles checks for cycles in the page hierarchy.
+func (t *Transformer) detectCycles(pages []*ConfluencePage, pageByID map[string]*ConfluencePage) error {
+	// Track visited state: 0 = unvisited, 1 = visiting (in current path), 2 = visited
+	state := make(map[string]int)
+
+	var dfs func(pageID string, path []string) error
+	dfs = func(pageID string, path []string) error {
+		if state[pageID] == 2 {
+			return nil // Already fully processed
+		}
+		if state[pageID] == 1 {
+			// Found a cycle
+			cyclePath := append(path, pageID)
+			return fmt.Errorf("cycle detected in page hierarchy: %v", cyclePath)
+		}
+
+		state[pageID] = 1
+		path = append(path, pageID)
+
+		page, ok := pageByID[pageID]
+		if !ok {
+			state[pageID] = 2
+			return nil
+		}
+
+		if page.ParentID != "" {
+			if err := dfs(page.ParentID, path); err != nil {
+				return err
+			}
+		}
+
+		state[pageID] = 2
+		return nil
+	}
+
+	for _, page := range pages {
+		if state[page.ID] == 0 {
+			if err := dfs(page.ID, nil); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// findAncestorAtDepth finds the ancestor at the specified depth.
+func (t *Transformer) findAncestorAtDepth(page *ConfluencePage, pageByID map[string]*ConfluencePage, targetDepth int) string {
+	ancestors := t.getAncestors(page, pageByID)
+	if targetDepth >= len(ancestors) {
+		if len(ancestors) > 0 {
+			return ancestors[len(ancestors)-1].ID
+		}
+		return ""
+	}
+	return ancestors[targetDepth].ID
+}
+
+// getAncestors returns the ancestors from root to immediate parent.
+func (t *Transformer) getAncestors(page *ConfluencePage, pageByID map[string]*ConfluencePage) []*ConfluencePage {
+	var ancestors []*ConfluencePage
+	current := page
+	visited := make(map[string]bool)
+
+	for current.ParentID != "" && !visited[current.ParentID] {
+		visited[current.ParentID] = true
+		parent, ok := pageByID[current.ParentID]
+		if !ok {
+			break
+		}
+		ancestors = append([]*ConfluencePage{parent}, ancestors...)
+		current = parent
+	}
+
+	return ancestors
+}
+
+// GetPageDepth returns the depth of a page in the hierarchy (root = 1).
+func GetPageDepth(page *ConfluencePage, pageByID map[string]*ConfluencePage) int {
+	depth := 1
+	current := page
+	visited := make(map[string]bool)
+
+	for current.ParentID != "" && !visited[current.ParentID] {
+		visited[current.ParentID] = true
+		parent, ok := pageByID[current.ParentID]
+		if !ok {
+			break
+		}
+		depth++
+		current = parent
+	}
+
+	return depth
+}
+
+// comparePageOrder compares two pages for sorting.
+// Pages are sorted by Position first (lower position comes first).
+// Pages with Position == 0 are sorted after pages with a position.
+// For pages with the same position (or both 0), sort by title alphabetically.
+func comparePageOrder(a, b *ConfluencePage) bool {
+	// Both have positions - sort by position
+	if a.Position > 0 && b.Position > 0 {
+		if a.Position != b.Position {
+			return a.Position < b.Position
+		}
+		// Same position, fall back to title
+		return a.Title < b.Title
+	}
+
+	// Only a has position - a comes first
+	if a.Position > 0 {
+		return true
+	}
+
+	// Only b has position - b comes first
+	if b.Position > 0 {
+		return false
+	}
+
+	// Neither has position - sort by title
+	return a.Title < b.Title
+}

--- a/services/confluence/intermediate.go
+++ b/services/confluence/intermediate.go
@@ -4,42 +4,31 @@
 package confluence
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // Intermediate holds the transformed data ready for export.
 type Intermediate struct {
-	// Single channel for all wikis (auto-created or user-specified)
-	Channel *IntermediateChannel
+	// Single Space — one bundle covers exactly one Confluence space.
+	Space *IntermediateSpace
 
-	// Multiple wikis (one per Confluence space)
-	Wikis []*IntermediateWiki
-
-	// Legacy single-space field (for backward compatibility)
-	Wiki *IntermediateWiki
+	// SourceOrganizationID namespaces source IDs across Confluence instances.
+	SourceOrganizationID string
 
 	Pages    []*IntermediatePage
 	Comments []*IntermediateComment
 }
 
-// IntermediateChannel represents the channel to be created for the migration.
-type IntermediateChannel struct {
+// IntermediateSpace represents the Space to be created. The backing channel is
+// resolved at import time from the import request, so it is not modeled here.
+type IntermediateSpace struct {
 	Team        string
-	Name        string // Channel name (lowercase)
-	DisplayName string // Display name
-	Type        string // "O" for public, "P" for private
-	Purpose     string
-	Header      string
-}
-
-// IntermediateWiki represents a wiki to be created (one per Confluence space).
-type IntermediateWiki struct {
-	Team        string
-	Channel     string // Channel name this wiki belongs to
-	Title       string // Wiki title (= Confluence space name)
+	Title       string // Space title (= Confluence space name)
 	Description string
 	SpaceKey    string // Original Confluence space key for tracking
 }
@@ -50,9 +39,8 @@ type IntermediatePage struct {
 	ImportSourceID string // Confluence page ID for idempotency
 	Title          string
 
-	// Space/Channel tracking (for multi-space exports)
+	// Space tracking
 	SpaceKey string // Original Confluence space key
-	Channel  string // Target channel name
 
 	// Hierarchy
 	ParentImportSourceID string // Parent's Confluence page ID
@@ -100,6 +88,7 @@ type IntermediateComment struct {
 	// Metadata
 	User     string
 	CreateAt int64
+	UpdateAt int64
 
 	// Props
 	Props model.StringInterface
@@ -144,19 +133,10 @@ func (t *Transformer) TransformPages(export *ConfluenceExport) error {
 		return err
 	}
 
-	// Set up channel (if auto-creating)
-	if t.Config.AutoCreateChannel {
-		t.Intermediate.Channel = &IntermediateChannel{
-			Team:        t.TeamName,
-			Name:        t.ChannelName,
-			DisplayName: t.deriveChannelDisplayName(export),
-			Type:        "O", // Public by default
-			Purpose:     "Migrated from Confluence",
-		}
+	// Set up the single Space (one bundle = one Confluence space).
+	if err := t.setupSpace(export); err != nil {
+		return err
 	}
-
-	// Set up wikis (one per space)
-	t.setupWikisFromSpaces(export)
 
 	// Build children lookup map (pageID -> list of child page info)
 	// This is used to generate child page links for children/pagetree macros
@@ -185,51 +165,35 @@ func (t *Transformer) TransformPages(export *ConfluenceExport) error {
 	return nil
 }
 
-// setupWikisFromSpaces creates wiki entries for each space in the export.
-func (t *Transformer) setupWikisFromSpaces(export *ConfluenceExport) {
-	if len(export.Spaces) > 0 {
-		// Multi-space export
-		for spaceKey, space := range export.Spaces {
-			wiki := &IntermediateWiki{
-				Team:        t.TeamName,
-				Channel:     t.ChannelName,
-				Title:       space.Name,
-				Description: "Migrated from Confluence space: " + spaceKey,
-				SpaceKey:    spaceKey,
-			}
-			t.Intermediate.Wikis = append(t.Intermediate.Wikis, wiki)
-		}
-	} else if export.SpaceKey != "" {
-		// Single-space export (legacy)
-		wiki := &IntermediateWiki{
+// setupSpace builds the single IntermediateSpace from the export. A Confluence
+// CSV export always covers one space; more than one is rejected here so the
+// single-space assumption is enforced rather than silently mis-handled.
+func (t *Transformer) setupSpace(export *ConfluenceExport) error {
+	if len(export.Spaces) > 1 {
+		return fmt.Errorf("multi-space exports are not supported; import one space per bundle (found %d spaces)", len(export.Spaces))
+	}
+
+	t.Intermediate.SourceOrganizationID = export.OrganizationID
+
+	// Prefer the parsed space record; fall back to the descriptor-level space key.
+	for _, space := range export.Spaces {
+		t.Intermediate.Space = &IntermediateSpace{
 			Team:        t.TeamName,
-			Channel:     t.ChannelName,
+			Title:       space.Name,
+			Description: "Migrated from Confluence space: " + space.Key,
+			SpaceKey:    space.Key,
+		}
+		return nil
+	}
+	if export.SpaceKey != "" {
+		t.Intermediate.Space = &IntermediateSpace{
+			Team:        t.TeamName,
 			Title:       export.SpaceName,
 			Description: "Migrated from Confluence space: " + export.SpaceKey,
 			SpaceKey:    export.SpaceKey,
 		}
-		t.Intermediate.Wikis = append(t.Intermediate.Wikis, wiki)
 	}
-
-	// Set legacy Wiki field for backward compatibility (first wiki)
-	if len(t.Intermediate.Wikis) > 0 {
-		t.Intermediate.Wiki = t.Intermediate.Wikis[0]
-	}
-}
-
-// deriveChannelDisplayName creates a display name for the channel.
-func (t *Transformer) deriveChannelDisplayName(export *ConfluenceExport) string {
-	if len(export.Spaces) == 1 {
-		// Single space - use space name
-		for _, space := range export.Spaces {
-			return space.Name
-		}
-	}
-	if export.SpaceName != "" {
-		return export.SpaceName
-	}
-	// Multiple spaces or unknown - use generic name
-	return "Confluence Import"
+	return nil
 }
 
 // transformPage converts a single Confluence page to intermediate format.
@@ -240,6 +204,13 @@ func (t *Transformer) transformPage(confPage *ConfluencePage, export *Confluence
 	if err != nil {
 		t.Logger.Warnf("Failed to convert content for page %s, using raw HTML wrapper: %v", confPage.ID, err)
 		// Fallback: wrap raw HTML in a code block
+		tiptapContent = wrapRawHTMLInCodeBlock(confPage.Content)
+	} else if !json.Valid([]byte(tiptapContent)) {
+		// Guard against a converter that returns malformed JSON: fall back to the
+		// code-block wrapper and count it, so invalid bodies are never emitted.
+		msg := fmt.Sprintf("page %s produced invalid TipTap JSON; using raw HTML code-block fallback", confPage.ID)
+		t.Logger.Warn(msg)
+		t.Stats.Warnings = append(t.Stats.Warnings, msg)
 		tiptapContent = wrapRawHTMLInCodeBlock(confPage.Content)
 	}
 
@@ -298,12 +269,11 @@ func (t *Transformer) transformPage(confPage *ConfluencePage, export *Confluence
 		ImportSourceID:       confPage.ID,
 		Title:                pageTitle,
 		SpaceKey:             spaceKey,
-		Channel:              t.ChannelName,
 		ParentImportSourceID: confPage.ParentID,
 		Content:              tiptapContent,
 		User:                 username,
 		CreateAt:             confPage.CreatedAt.UnixMilli(),
-		UpdateAt:             confPage.UpdatedAt.UnixMilli(),
+		UpdateAt:             timeMillis(confPage.UpdatedAt),
 		Props:                props,
 	}
 
@@ -409,6 +379,7 @@ func (t *Transformer) transformComment(confComment *ConfluenceComment, export *C
 		IsResolved:                  confComment.IsResolved,
 		User:                        username,
 		CreateAt:                    confComment.CreatedAt.UnixMilli(),
+		UpdateAt:                    timeMillis(confComment.UpdatedAt),
 		Props:                       props,
 	}
 
@@ -498,6 +469,15 @@ func looksLikeAccountID(s string) bool {
 		return true
 	}
 	return false
+}
+
+// timeMillis returns the Unix-millisecond timestamp, or 0 for a zero time so the
+// value is omitted rather than emitted as a bogus far-past timestamp.
+func timeMillis(ts time.Time) int64 {
+	if ts.IsZero() {
+		return 0
+	}
+	return ts.UnixMilli()
 }
 
 // wrapRawHTMLInCodeBlock wraps HTML in a TipTap code block as fallback.

--- a/services/confluence/intermediate.go
+++ b/services/confluence/intermediate.go
@@ -1,0 +1,544 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// Intermediate holds the transformed data ready for export.
+type Intermediate struct {
+	// Single channel for all wikis (auto-created or user-specified)
+	Channel *IntermediateChannel
+
+	// Multiple wikis (one per Confluence space)
+	Wikis []*IntermediateWiki
+
+	// Legacy single-space field (for backward compatibility)
+	Wiki *IntermediateWiki
+
+	Pages    []*IntermediatePage
+	Comments []*IntermediateComment
+}
+
+// IntermediateChannel represents the channel to be created for the migration.
+type IntermediateChannel struct {
+	Team        string
+	Name        string // Channel name (lowercase)
+	DisplayName string // Display name
+	Type        string // "O" for public, "P" for private
+	Purpose     string
+	Header      string
+}
+
+// IntermediateWiki represents a wiki to be created (one per Confluence space).
+type IntermediateWiki struct {
+	Team        string
+	Channel     string // Channel name this wiki belongs to
+	Title       string // Wiki title (= Confluence space name)
+	Description string
+	SpaceKey    string // Original Confluence space key for tracking
+}
+
+// IntermediatePage represents a page ready for JSONL export.
+type IntermediatePage struct {
+	// Identifiers
+	ImportSourceID string // Confluence page ID for idempotency
+	Title          string
+
+	// Space/Channel tracking (for multi-space exports)
+	SpaceKey string // Original Confluence space key
+	Channel  string // Target channel name
+
+	// Hierarchy
+	ParentImportSourceID string // Parent's Confluence page ID
+
+	// Content
+	Content string // TipTap JSON content
+
+	// Metadata
+	User     string // Mattermost username
+	CreateAt int64  // Unix timestamp in milliseconds
+	UpdateAt int64
+
+	// Props for import tracking
+	Props model.StringInterface
+
+	// Attachments (path + source ID for placeholder resolution)
+	Attachments []IntermediateAttachment
+}
+
+// IntermediateAttachment holds attachment path and source ID.
+type IntermediateAttachment struct {
+	Path     string // File path relative to attachments dir
+	SourceID string // Confluence attachment ID for placeholder resolution
+}
+
+// IntermediateComment represents a page comment ready for JSONL export.
+type IntermediateComment struct {
+	// Identifiers
+	ImportSourceID     string // Confluence comment ID
+	PageImportSourceID string // Parent page's Confluence ID
+
+	// Threading
+	ParentCommentImportSourceID string // For threaded comments
+
+	// Content
+	Content string // Markdown text
+
+	// Inline anchor for inline comments
+	InlineAnchorID   string // The UUID that links this comment to the TipTap mark
+	InlineAnchorText string // The text that was highlighted when creating the inline comment
+
+	// Status
+	IsResolved bool // True if comment was resolved in Confluence
+
+	// Metadata
+	User     string
+	CreateAt int64
+
+	// Props
+	Props model.StringInterface
+}
+
+// TransformPages transforms Confluence pages to intermediate format.
+func (t *Transformer) TransformPages(export *ConfluenceExport) error {
+	t.Logger.Info("Transforming pages")
+
+	// Filter out historical page versions (old edits), deleted, draft, and archived pages
+	var currentPages []*ConfluencePage
+	historicalSkipped := 0
+	deletedSkipped := 0
+	draftSkipped := 0
+	archivedSkipped := 0
+	for _, page := range export.Pages {
+		if export.HistoricalPageIDs[page.ID] {
+			historicalSkipped++
+			continue
+		}
+		if page.ContentStatus == "deleted" {
+			deletedSkipped++
+			continue
+		}
+		if page.ContentStatus == "draft" {
+			draftSkipped++
+			continue
+		}
+		if page.ContentStatus == "archived" {
+			archivedSkipped++
+			continue
+		}
+		currentPages = append(currentPages, page)
+	}
+	if historicalSkipped > 0 || deletedSkipped > 0 || draftSkipped > 0 || archivedSkipped > 0 {
+		t.Logger.Infof("Skipped %d historical, %d deleted, %d draft, %d archived pages", historicalSkipped, deletedSkipped, draftSkipped, archivedSkipped)
+	}
+
+	// Build page tree and get topologically sorted pages
+	sortedPages, err := t.buildPageHierarchy(currentPages)
+	if err != nil {
+		return err
+	}
+
+	// Set up channel (if auto-creating)
+	if t.Config.AutoCreateChannel {
+		t.Intermediate.Channel = &IntermediateChannel{
+			Team:        t.TeamName,
+			Name:        t.ChannelName,
+			DisplayName: t.deriveChannelDisplayName(export),
+			Type:        "O", // Public by default
+			Purpose:     "Migrated from Confluence",
+		}
+	}
+
+	// Set up wikis (one per space)
+	t.setupWikisFromSpaces(export)
+
+	// Build children lookup map (pageID -> list of child page info)
+	// This is used to generate child page links for children/pagetree macros
+	childrenByParent := make(map[string][]ChildPageInfo)
+	for _, page := range currentPages {
+		if page.ParentID != "" {
+			childrenByParent[page.ParentID] = append(childrenByParent[page.ParentID], ChildPageInfo{
+				ID:    page.ID,
+				Title: page.Title,
+			})
+		}
+	}
+
+	// Transform each page
+	for _, confPage := range sortedPages {
+		// Get children for this page (if any)
+		children := childrenByParent[confPage.ID]
+		intermediatePage, err := t.transformPage(confPage, export, children)
+		if err != nil {
+			t.Logger.Warnf("Failed to transform page %s (%s): %v", confPage.ID, confPage.Title, err)
+			continue
+		}
+		t.Intermediate.Pages = append(t.Intermediate.Pages, intermediatePage)
+	}
+
+	return nil
+}
+
+// setupWikisFromSpaces creates wiki entries for each space in the export.
+func (t *Transformer) setupWikisFromSpaces(export *ConfluenceExport) {
+	if len(export.Spaces) > 0 {
+		// Multi-space export
+		for spaceKey, space := range export.Spaces {
+			wiki := &IntermediateWiki{
+				Team:        t.TeamName,
+				Channel:     t.ChannelName,
+				Title:       space.Name,
+				Description: "Migrated from Confluence space: " + spaceKey,
+				SpaceKey:    spaceKey,
+			}
+			t.Intermediate.Wikis = append(t.Intermediate.Wikis, wiki)
+		}
+	} else if export.SpaceKey != "" {
+		// Single-space export (legacy)
+		wiki := &IntermediateWiki{
+			Team:        t.TeamName,
+			Channel:     t.ChannelName,
+			Title:       export.SpaceName,
+			Description: "Migrated from Confluence space: " + export.SpaceKey,
+			SpaceKey:    export.SpaceKey,
+		}
+		t.Intermediate.Wikis = append(t.Intermediate.Wikis, wiki)
+	}
+
+	// Set legacy Wiki field for backward compatibility (first wiki)
+	if len(t.Intermediate.Wikis) > 0 {
+		t.Intermediate.Wiki = t.Intermediate.Wikis[0]
+	}
+}
+
+// deriveChannelDisplayName creates a display name for the channel.
+func (t *Transformer) deriveChannelDisplayName(export *ConfluenceExport) string {
+	if len(export.Spaces) == 1 {
+		// Single space - use space name
+		for _, space := range export.Spaces {
+			return space.Name
+		}
+	}
+	if export.SpaceName != "" {
+		return export.SpaceName
+	}
+	// Multiple spaces or unknown - use generic name
+	return "Confluence Import"
+}
+
+// transformPage converts a single Confluence page to intermediate format.
+// children contains info about this page's child pages, used for generating navigation links.
+func (t *Transformer) transformPage(confPage *ConfluencePage, export *ConfluenceExport, children []ChildPageInfo) (*IntermediatePage, error) {
+	// Convert HTML content to TipTap JSON, passing children info for navigation macros
+	tiptapContent, err := ConvertHTMLToTipTapWithChildren(confPage.Content, children)
+	if err != nil {
+		t.Logger.Warnf("Failed to convert content for page %s, using raw HTML wrapper: %v", confPage.ID, err)
+		// Fallback: wrap raw HTML in a code block
+		tiptapContent = wrapRawHTMLInCodeBlock(confPage.Content)
+	}
+
+	// Build filename → attachment ID mapping for this page
+	filenameToID := make(map[string]string)
+	if attachments, ok := export.Attachments[confPage.ID]; ok {
+		for _, att := range attachments {
+			filenameToID[att.FileName] = att.ID
+		}
+	}
+
+	// Convert filename-based placeholders to ID-based placeholders
+	if len(filenameToID) > 0 {
+		tiptapContent = ConvertAttachmentPlaceholdersToFileIDs(tiptapContent, filenameToID)
+	}
+
+	// Resolve user mentions ({{CONF_USER:userkey}} -> @username)
+	tiptapContent = ResolveUserMentions(tiptapContent, export.Users)
+
+	// Resolve user
+	username := t.resolveUsername(confPage.CreatedBy, export)
+
+	// Determine space key for this page
+	spaceKey := confPage.SpaceKey
+	if spaceKey == "" {
+		// Fall back to export-level space key (single-space export)
+		spaceKey = export.SpaceKey
+	}
+
+	// Build props
+	props := model.StringInterface{
+		"import_source_id": confPage.ID,
+		"import_source":    "confluence",
+	}
+	if len(confPage.Labels) > 0 {
+		props["import_labels"] = confPage.Labels
+	}
+	if spaceKey != "" {
+		props["confluence_space_key"] = spaceKey
+	}
+	// Preserve the source author's Atlassian account ID so a later Mattermost step
+	// can match the user by account ID (and, via the Atlassian API, email) even
+	// when this migration could not resolve them to a Mattermost username.
+	if confPage.CreatedBy != "" {
+		props["confluence_author_account_id"] = confPage.CreatedBy
+	}
+
+	// Use page title or generate one from ID if empty
+	pageTitle := confPage.Title
+	if pageTitle == "" {
+		pageTitle = fmt.Sprintf("Untitled Page %s", confPage.ID)
+		t.Logger.Warnf("Page %s has no title, using generated title: %s", confPage.ID, pageTitle)
+	}
+
+	page := &IntermediatePage{
+		ImportSourceID:       confPage.ID,
+		Title:                pageTitle,
+		SpaceKey:             spaceKey,
+		Channel:              t.ChannelName,
+		ParentImportSourceID: confPage.ParentID,
+		Content:              tiptapContent,
+		User:                 username,
+		CreateAt:             confPage.CreatedAt.UnixMilli(),
+		UpdateAt:             confPage.UpdatedAt.UnixMilli(),
+		Props:                props,
+	}
+
+	// Handle attachments
+	if attachments, ok := export.Attachments[confPage.ID]; ok && !t.Config.SkipAttachments {
+		for _, att := range attachments {
+			page.Attachments = append(page.Attachments, IntermediateAttachment{
+				Path:     att.FilePath,
+				SourceID: att.ID,
+			})
+			t.Stats.AttachmentCount++
+		}
+	}
+
+	return page, nil
+}
+
+// TransformComments transforms Confluence comments to intermediate format.
+func (t *Transformer) TransformComments(export *ConfluenceExport) error {
+	t.Logger.Info("Transforming comments")
+
+	// Build a map of comment ID → page ID for parent chain resolution
+	commentToPageID := make(map[string]string)
+	for _, confComment := range export.Comments {
+		if confComment.PageID != "" {
+			commentToPageID[confComment.ID] = confComment.PageID
+		}
+	}
+
+	// Resolve PageID for comments that only have ParentID (replies)
+	for _, confComment := range export.Comments {
+		if confComment.PageID == "" && confComment.ParentID != "" {
+			if pageID, ok := commentToPageID[confComment.ParentID]; ok {
+				confComment.PageID = pageID
+			}
+		}
+	}
+
+	historicalSkipped := 0
+	noPageSkipped := 0
+
+	for _, confComment := range export.Comments {
+		// Skip historical versions (old edits of comments)
+		if export.HistoricalCommentIDs[confComment.ID] {
+			historicalSkipped++
+			continue
+		}
+		if confComment.PageID == "" {
+			noPageSkipped++
+			continue
+		}
+		intermediateComment, err := t.transformComment(confComment, export)
+		if err != nil {
+			t.Logger.Warnf("Failed to transform comment %s: %v", confComment.ID, err)
+			continue
+		}
+		t.Intermediate.Comments = append(t.Intermediate.Comments, intermediateComment)
+	}
+
+	if historicalSkipped > 0 || noPageSkipped > 0 {
+		t.Logger.Infof("Skipped %d historical versions, %d without page reference", historicalSkipped, noPageSkipped)
+	}
+
+	return nil
+}
+
+// transformComment converts a single Confluence comment to intermediate format.
+func (t *Transformer) transformComment(confComment *ConfluenceComment, export *ConfluenceExport) (*IntermediateComment, error) {
+	// Convert HTML content to Markdown (comments use plain text/markdown, not TipTap JSON)
+	// This ensures comments render correctly in the Mattermost UI which expects markdown
+	markdownContent := ConvertHTMLToMarkdown(confComment.Content)
+
+	// Resolve user mentions ({{CONF_USER:userkey}} -> @username)
+	markdownContent = ResolveUserMentions(markdownContent, export.Users)
+
+	// Resolve user
+	username := t.resolveUsername(confComment.CreatedBy, export)
+
+	// Build props
+	props := model.StringInterface{
+		"import_source_id": confComment.ID,
+		"import_source":    "confluence",
+	}
+	// Preserve the source author's Atlassian account ID for later user matching.
+	if confComment.CreatedBy != "" {
+		props["confluence_author_account_id"] = confComment.CreatedBy
+	}
+
+	// Get inline anchor info if this is an inline comment
+	var inlineAnchorID, inlineAnchorText string
+	if confComment.InlineAnchor != nil {
+		inlineAnchorID = confComment.InlineAnchor.AnchorID
+		inlineAnchorText = confComment.InlineAnchor.OriginalSelection
+	}
+
+	comment := &IntermediateComment{
+		ImportSourceID:              confComment.ID,
+		PageImportSourceID:          confComment.PageID,
+		ParentCommentImportSourceID: confComment.ParentID,
+		Content:                     markdownContent,
+		InlineAnchorID:              inlineAnchorID,
+		InlineAnchorText:            inlineAnchorText,
+		IsResolved:                  confComment.IsResolved,
+		User:                        username,
+		CreateAt:                    confComment.CreatedAt.UnixMilli(),
+		Props:                       props,
+	}
+
+	return comment, nil
+}
+
+// resolveUsername maps a Confluence account ID to a Mattermost username.
+func (t *Transformer) resolveUsername(accountID string, export *ConfluenceExport) string {
+	var email, username string
+
+	// Get additional user info from Confluence export
+	if user, ok := export.Users[accountID]; ok {
+		email = user.Email
+		username = user.Username
+		// In some Confluence exports, email is stored in the username field
+		if email == "" && strings.Contains(username, "@") {
+			email = username
+		}
+	}
+
+	// Check if accountID is actually an email (common in Confluence exports)
+	if strings.Contains(accountID, "@") {
+		email = accountID
+	}
+
+	// First check user mapper if available
+	if t.UserMapper != nil {
+		// Try email lookup (may be in username field from Confluence)
+		if email != "" {
+			if mmUser, err := t.UserMapper.GetUsernameByEmail(email); err == nil {
+				return mmUser
+			}
+		}
+		// Try account ID lookup
+		if accountID != "" {
+			if mmUser, err := t.UserMapper.GetUsername(accountID); err == nil {
+				return mmUser
+			}
+		}
+		// Try username lookup
+		if username != "" {
+			if mmUser, err := t.UserMapper.GetUsernameByConfluenceUsername(username); err == nil {
+				return mmUser
+			}
+		}
+
+		// If user mapper exists and has a fallback, use it
+		if fallback := t.UserMapper.GetFallbackUsername(); fallback != "" {
+			return fallback
+		}
+	}
+
+	// Fall back to Confluence user data
+	if email != "" {
+		return emailToUsername(email)
+	}
+	// Only use username if it looks like a human-readable name (not an account ID)
+	if username != "" && !looksLikeAccountID(username) {
+		return emailToUsername(username)
+	}
+
+	// Last resort: use account ID - track as unmapped
+	t.Stats.UsersUnmapped++
+	t.Logger.Warnf("Could not resolve username for account %s, using fallback", accountID)
+	if len(accountID) >= 8 {
+		return "confluence_user_" + accountID[:8]
+	}
+	return "confluence_user_" + accountID
+}
+
+// looksLikeAccountID returns true if the string appears to be an Atlassian account ID
+// rather than a human-readable username. Account IDs are typically:
+// - 24-character hex strings (e.g., "5a6771383c7f1842c3d7b906")
+// - UUID format with "557058:" or "712020:" prefixes (e.g., "557058:43d65f7e-87b9-4b8c-81f8-ab731104114e")
+func looksLikeAccountID(s string) bool {
+	// Check for UUID-style account IDs with numeric prefix
+	if strings.Contains(s, ":") && strings.Contains(s, "-") {
+		return true
+	}
+	// Check for 24-character hex strings (common Atlassian format)
+	if len(s) == 24 {
+		for _, c := range s {
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// wrapRawHTMLInCodeBlock wraps HTML in a TipTap code block as fallback.
+func wrapRawHTMLInCodeBlock(html string) string {
+	return `{"type":"doc","content":[{"type":"codeBlock","attrs":{"language":"html"},"content":[{"type":"text","text":` + jsonEscape(html) + `}]}]}`
+}
+
+// emailToUsername extracts username from email address.
+func emailToUsername(email string) string {
+	for i, c := range email {
+		if c == '@' {
+			return email[:i]
+		}
+	}
+	return email
+}
+
+// jsonEscape escapes a string for JSON embedding.
+func jsonEscape(s string) string {
+	// Simple JSON string escaping
+	result := `"`
+	for _, c := range s {
+		switch c {
+		case '"':
+			result += `\"`
+		case '\\':
+			result += `\\`
+		case '\n':
+			result += `\n`
+		case '\r':
+			result += `\r`
+		case '\t':
+			result += `\t`
+		default:
+			if c < 32 {
+				result += `\u` + string('0'+c/16) + string('0'+c%16)
+			} else {
+				result += string(c)
+			}
+		}
+	}
+	result += `"`
+	return result
+}

--- a/services/confluence/intermediate.go
+++ b/services/confluence/intermediate.go
@@ -214,10 +214,16 @@ func (t *Transformer) transformPage(confPage *ConfluencePage, export *Confluence
 		tiptapContent = wrapRawHTMLInCodeBlock(confPage.Content)
 	}
 
-	// Build filename → attachment ID mapping for this page
+	// Build filename → attachment ID mapping for this page, limited to
+	// attachments whose bytes were actually extracted (FilePath set). A content
+	// placeholder must only resolve to a CONF_FILE we are actually shipping;
+	// otherwise it would dangle.
 	filenameToID := make(map[string]string)
 	if attachments, ok := export.Attachments[confPage.ID]; ok {
 		for _, att := range attachments {
+			if att.FilePath == "" {
+				continue
+			}
 			filenameToID[att.FileName] = att.ID
 		}
 	}
@@ -277,9 +283,15 @@ func (t *Transformer) transformPage(confPage *ConfluencePage, export *Confluence
 		Props:                props,
 	}
 
-	// Handle attachments
+	// Handle attachments. Only emit attachments that were successfully extracted
+	// (non-empty FilePath); emitting an entry with an empty path would ship a
+	// broken reference in an otherwise "successful" bundle.
 	if attachments, ok := export.Attachments[confPage.ID]; ok && !t.Config.SkipAttachments {
 		for _, att := range attachments {
+			if att.FilePath == "" {
+				t.Logger.Warnf("Skipping attachment %q (id %s) on page %s: file was not extracted", att.FileName, att.ID, confPage.ID)
+				continue
+			}
 			page.Attachments = append(page.Attachments, IntermediateAttachment{
 				Path:     att.FilePath,
 				SourceID: att.ID,

--- a/services/confluence/links.go
+++ b/services/confluence/links.go
@@ -1,0 +1,363 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Link placeholder formats
+const (
+	// PlaceholderPageByID links to page by Confluence page ID
+	PlaceholderPageByID = "{{CONF_PAGE_ID:%s}}"
+	// PlaceholderPageByTitle links to page by title (for resolution by title lookup)
+	PlaceholderPageByTitle = "{{CONF_PAGE_TITLE:%s}}"
+	// PlaceholderFile links to attachment by Confluence attachment ID
+	PlaceholderFile = "{{CONF_FILE:%s}}"
+	// PlaceholderUser links to a user mention
+	PlaceholderUser = "{{CONF_USER:%s}}"
+)
+
+// LinkConverter handles conversion of Confluence links to placeholders
+// and resolution of placeholders to Mattermost URLs.
+type LinkConverter struct {
+	// PageIDToTitle maps Confluence page IDs to titles
+	PageIDToTitle map[string]string
+	// PageTitleToID maps page titles to Confluence IDs
+	PageTitleToID map[string]string
+	// AttachmentPaths maps attachment identifiers to file paths
+	AttachmentPaths map[string]string
+}
+
+// NewLinkConverter creates a new link converter.
+func NewLinkConverter() *LinkConverter {
+	return &LinkConverter{
+		PageIDToTitle:   make(map[string]string),
+		PageTitleToID:   make(map[string]string),
+		AttachmentPaths: make(map[string]string),
+	}
+}
+
+// BuildMappings builds the link mappings from a Confluence export.
+func (lc *LinkConverter) BuildMappings(export *ConfluenceExport) {
+	for _, page := range export.Pages {
+		lc.PageIDToTitle[page.ID] = page.Title
+		lc.PageTitleToID[strings.ToLower(page.Title)] = page.ID
+	}
+
+	for pageID, attachments := range export.Attachments {
+		for _, att := range attachments {
+			key := pageID + ":" + att.FileName
+			lc.AttachmentPaths[key] = att.FilePath
+			// Also map just by filename for simpler lookups
+			lc.AttachmentPaths[att.FileName] = att.FilePath
+		}
+	}
+}
+
+// ConvertConfluenceLinks converts Confluence link elements to placeholders.
+// This is called during HTML preprocessing before TipTap conversion.
+func ConvertConfluenceLinks(content string) string {
+	// Handle ac:link with ri:page by content-title
+	// <ac:link><ri:page ri:content-title="Page Title"/></ac:link>
+	acLinkTitleRegex := regexp.MustCompile(`(?s)<ac:link[^>]*>.*?<ri:page[^>]*ri:content-title="([^"]+)"[^>]*/?>.*?</ac:link>`)
+	content = acLinkTitleRegex.ReplaceAllStringFunc(content, func(match string) string {
+		titleMatch := regexp.MustCompile(`ri:content-title="([^"]+)"`).FindStringSubmatch(match)
+		if len(titleMatch) < 2 {
+			return match
+		}
+		title := titleMatch[1]
+
+		// Check for custom link body
+		linkBody := extractLinkBody(match)
+		if linkBody == "" {
+			linkBody = title
+		}
+
+		return `<a href="{{CONF_PAGE_TITLE:` + escapeForPlaceholder(title) + `}}">` + linkBody + `</a>`
+	})
+
+	// Handle ac:link with ri:page by content-id
+	// <ac:link><ri:page ri:content-id="123456"/></ac:link>
+	acLinkIDRegex := regexp.MustCompile(`(?s)<ac:link[^>]*>.*?<ri:page[^>]*ri:content-id="([^"]+)"[^>]*/?>.*?</ac:link>`)
+	content = acLinkIDRegex.ReplaceAllStringFunc(content, func(match string) string {
+		idMatch := regexp.MustCompile(`ri:content-id="([^"]+)"`).FindStringSubmatch(match)
+		if len(idMatch) < 2 {
+			return match
+		}
+		pageID := idMatch[1]
+
+		// Check for custom link body
+		linkBody := extractLinkBody(match)
+		if linkBody == "" {
+			linkBody = "Page " + pageID
+		}
+
+		return `<a href="{{CONF_PAGE_ID:` + pageID + `}}">` + linkBody + `</a>`
+	})
+
+	// Handle ac:link with ri:attachment
+	// <ac:link><ri:attachment ri:filename="doc.pdf"/></ac:link>
+	acAttachmentRegex := regexp.MustCompile(`(?s)<ac:link[^>]*>.*?<ri:attachment[^>]*ri:filename="([^"]+)"[^>]*/?>.*?</ac:link>`)
+	content = acAttachmentRegex.ReplaceAllStringFunc(content, func(match string) string {
+		fileMatch := regexp.MustCompile(`ri:filename="([^"]+)"`).FindStringSubmatch(match)
+		if len(fileMatch) < 2 {
+			return match
+		}
+		filename := fileMatch[1]
+
+		linkBody := extractLinkBody(match)
+		if linkBody == "" {
+			linkBody = filename
+		}
+
+		return `<a href="{{CONF_ATTACHMENT:` + escapeForPlaceholder(filename) + `}}">` + linkBody + `</a>`
+	})
+
+	// Handle ac:link with ri:url (external links)
+	// <ac:link><ri:url ri:value="https://example.com"/></ac:link>
+	acURLRegex := regexp.MustCompile(`(?s)<ac:link[^>]*>.*?<ri:url[^>]*ri:value="([^"]+)"[^>]*/?>.*?</ac:link>`)
+	content = acURLRegex.ReplaceAllStringFunc(content, func(match string) string {
+		urlMatch := regexp.MustCompile(`ri:value="([^"]+)"`).FindStringSubmatch(match)
+		if len(urlMatch) < 2 {
+			return match
+		}
+		url := urlMatch[1]
+
+		linkBody := extractLinkBody(match)
+		if linkBody == "" {
+			linkBody = url
+		}
+
+		return `<a href="` + url + `">` + linkBody + `</a>`
+	})
+
+	// Handle standalone ri:url (simpler form)
+	riURLRegex := regexp.MustCompile(`<ri:url ri:value="([^"]+)"\s*/>`)
+	content = riURLRegex.ReplaceAllString(content, `<a href="$1">$1</a>`)
+
+	// Handle user mentions
+	// <ac:link><ri:user ri:account-id="user123"/></ac:link>
+	// We use the placeholder directly as the display text so it can be resolved later
+	userMentionRegex := regexp.MustCompile(`(?s)<ac:link[^>]*>.*?<ri:user[^>]*ri:(?:account-id|userkey)="([^"]+)"[^>]*/?>.*?</ac:link>`)
+	content = userMentionRegex.ReplaceAllString(content, `{{CONF_USER:$1}}`)
+
+	// Handle ac:image elements
+	// <ac:image><ri:attachment ri:filename="image.png"/></ac:image>
+	acImageRegex := regexp.MustCompile(`(?s)<ac:image[^>]*>.*?<ri:attachment[^>]*ri:filename="([^"]+)"[^>]*/?>.*?</ac:image>`)
+	content = acImageRegex.ReplaceAllString(content, `<img src="{{CONF_ATTACHMENT:$1}}" alt="$1"/>`)
+
+	// Handle ac:image with ri:url (external images)
+	acImageURLRegex := regexp.MustCompile(`(?s)<ac:image[^>]*>.*?<ri:url[^>]*ri:value="([^"]+)"[^>]*/?>.*?</ac:image>`)
+	content = acImageURLRegex.ReplaceAllString(content, `<img src="$1" alt=""/>`)
+
+	// Handle emoticons
+	// <ac:emoticon ac:name="smile"/>
+	emoticonRegex := regexp.MustCompile(`<ac:emoticon[^>]*ac:name="([^"]+)"[^>]*/>`)
+	content = emoticonRegex.ReplaceAllStringFunc(content, func(match string) string {
+		nameMatch := regexp.MustCompile(`ac:name="([^"]+)"`).FindStringSubmatch(match)
+		if len(nameMatch) < 2 {
+			return match
+		}
+		return emoticonToEmoji(nameMatch[1])
+	})
+
+	return content
+}
+
+// extractLinkBody extracts custom link text from ac:link elements.
+func extractLinkBody(acLink string) string {
+	// Try ac:plain-text-link-body first
+	plainTextRegex := regexp.MustCompile(`(?s)<ac:plain-text-link-body><!\[CDATA\[(.*?)\]\]></ac:plain-text-link-body>`)
+	if match := plainTextRegex.FindStringSubmatch(acLink); len(match) > 1 {
+		return strings.TrimSpace(match[1])
+	}
+
+	// Try ac:link-body
+	linkBodyRegex := regexp.MustCompile(`(?s)<ac:link-body>(.*?)</ac:link-body>`)
+	if match := linkBodyRegex.FindStringSubmatch(acLink); len(match) > 1 {
+		// Strip any nested HTML tags
+		text := regexp.MustCompile(`<[^>]+>`).ReplaceAllString(match[1], "")
+		return strings.TrimSpace(text)
+	}
+
+	return ""
+}
+
+// escapeForPlaceholder escapes special characters in placeholder values.
+func escapeForPlaceholder(s string) string {
+	s = strings.ReplaceAll(s, "}", "\\}")
+	s = strings.ReplaceAll(s, "{", "\\{")
+	return s
+}
+
+// unescapeFromPlaceholder reverses placeholder escaping.
+func unescapeFromPlaceholder(s string) string {
+	s = strings.ReplaceAll(s, "\\}", "}")
+	s = strings.ReplaceAll(s, "\\{", "{")
+	return s
+}
+
+// emoticonToEmoji converts Confluence emoticon names to Unicode emoji.
+func emoticonToEmoji(name string) string {
+	emoticons := map[string]string{
+		"smile":        "😊",
+		"sad":          "😢",
+		"cheeky":       "😜",
+		"laugh":        "😂",
+		"wink":         "😉",
+		"thumbs-up":    "👍",
+		"thumbs-down":  "👎",
+		"information":  "ℹ️",
+		"tick":         "✅",
+		"cross":        "❌",
+		"warning":      "⚠️",
+		"plus":         "➕",
+		"minus":        "➖",
+		"question":     "❓",
+		"light-on":     "💡",
+		"light-off":    "💡",
+		"yellow-star":  "⭐",
+		"red-star":     "⭐",
+		"green-star":   "⭐",
+		"blue-star":    "⭐",
+		"heart":        "❤️",
+		"broken-heart": "💔",
+	}
+
+	if emoji, ok := emoticons[name]; ok {
+		return emoji
+	}
+	return ":" + name + ":"
+}
+
+// ResolvePlaceholders resolves link placeholders in content using provided mappings.
+// This is used for post-import link resolution.
+func ResolvePlaceholders(content string, pageIDToMMID map[string]string, pageTitleToMMID map[string]string, baseURL string) string {
+	// Resolve page ID placeholders
+	pageIDRegex := regexp.MustCompile(`\{\{CONF_PAGE_ID:([^}]+)\}\}`)
+	content = pageIDRegex.ReplaceAllStringFunc(content, func(match string) string {
+		submatch := pageIDRegex.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		confID := submatch[1]
+		if mmID, ok := pageIDToMMID[confID]; ok {
+			return baseURL + "/pages/" + mmID
+		}
+		return match // Leave unresolved
+	})
+
+	// Resolve page title placeholders
+	pageTitleRegex := regexp.MustCompile(`\{\{CONF_PAGE_TITLE:([^}]+)\}\}`)
+	content = pageTitleRegex.ReplaceAllStringFunc(content, func(match string) string {
+		submatch := pageTitleRegex.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		title := unescapeFromPlaceholder(submatch[1])
+		if mmID, ok := pageTitleToMMID[strings.ToLower(title)]; ok {
+			return baseURL + "/pages/" + mmID
+		}
+		return match // Leave unresolved
+	})
+
+	return content
+}
+
+// ResolveUserMentions resolves {{CONF_USER:userkey}} placeholders to actual usernames.
+// It uses the Users map from the Confluence export and the resolveUsername logic.
+func ResolveUserMentions(content string, users map[string]*ConfluenceUser) string {
+	userPlaceholderRegex := regexp.MustCompile(`\{\{CONF_USER:([^}]+)\}\}`)
+
+	return userPlaceholderRegex.ReplaceAllStringFunc(content, func(match string) string {
+		submatch := userPlaceholderRegex.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		userKey := submatch[1]
+
+		// Look up the user by their key/account ID
+		username := resolveUserMention(userKey, users)
+		return username
+	})
+}
+
+// resolveUserMention resolves a Confluence user key to a Mattermost username.
+func resolveUserMention(userKey string, users map[string]*ConfluenceUser) string {
+	// Try to find user by account ID (the key in the map)
+	if user, ok := users[userKey]; ok {
+		// If user has email, extract username from it
+		if user.Email != "" {
+			return "@" + emailToUsername(user.Email)
+		}
+		// If username looks like an email, extract the local part
+		if user.Username != "" && strings.Contains(user.Username, "@") {
+			return "@" + emailToUsername(user.Username)
+		}
+		// If username doesn't look like an account ID, use it
+		if user.Username != "" && !looksLikeAccountID(user.Username) {
+			return "@" + user.Username
+		}
+	}
+
+	// Search through all users to find one with matching username that looks like an account ID
+	// (some mentions reference the atlassianAccountId stored in the username field)
+	for _, user := range users {
+		if user.Username == userKey || user.AccountID == userKey {
+			if user.Email != "" {
+				return "@" + emailToUsername(user.Email)
+			}
+			if user.Username != "" && strings.Contains(user.Username, "@") {
+				return "@" + emailToUsername(user.Username)
+			}
+			if user.Username != "" && !looksLikeAccountID(user.Username) {
+				return "@" + user.Username
+			}
+		}
+	}
+
+	// Fallback: use truncated key with prefix
+	if len(userKey) >= 8 {
+		return "@confluence_user_" + userKey[:8]
+	}
+	return "@confluence_user_" + userKey
+}
+
+// CountUnresolvedPlaceholders counts unresolved placeholders in content.
+func CountUnresolvedPlaceholders(content string) int {
+	placeholderRegex := regexp.MustCompile(`\{\{CONF_[A-Z_]+:[^}]+\}\}`)
+	return len(placeholderRegex.FindAllString(content, -1))
+}
+
+// ExtractUnresolvedPlaceholders returns all unresolved placeholders in content.
+func ExtractUnresolvedPlaceholders(content string) []string {
+	placeholderRegex := regexp.MustCompile(`\{\{CONF_[A-Z_]+:[^}]+\}\}`)
+	return placeholderRegex.FindAllString(content, -1)
+}
+
+// ConvertAttachmentPlaceholdersToFileIDs converts filename-based attachment placeholders
+// to ID-based placeholders using the provided mapping.
+// Input: content with {{CONF_ATTACHMENT:filename}} placeholders
+// Output: content with {{CONF_FILE:attachment_id}} placeholders
+func ConvertAttachmentPlaceholdersToFileIDs(content string, filenameToID map[string]string) string {
+	if len(filenameToID) == 0 {
+		return content
+	}
+
+	attachmentRegex := regexp.MustCompile(`\{\{CONF_ATTACHMENT:([^}]+)\}\}`)
+	return attachmentRegex.ReplaceAllStringFunc(content, func(match string) string {
+		submatch := attachmentRegex.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		filename := unescapeFromPlaceholder(submatch[1])
+		if attachmentID, ok := filenameToID[filename]; ok {
+			return "{{CONF_FILE:" + attachmentID + "}}"
+		}
+		// Leave unresolved if no mapping found
+		return match
+	})
+}

--- a/services/confluence/manifest.go
+++ b/services/confluence/manifest.go
@@ -58,10 +58,12 @@ type ManifestSource struct {
 	ExportFile     string `json:"export_file"`
 }
 
-// ManifestTarget describes the target of the migration.
+// ManifestTarget describes the target of the migration. Team is advisory
+// destination metadata recorded for audit; the Docs import request selects the
+// actual target team. There is no backing-channel field — the Docs plugin
+// creates and owns the Space's backing channel at import time.
 type ManifestTarget struct {
-	Team    string `json:"team"`
-	Channel string `json:"channel"`
+	Team string `json:"team"`
 }
 
 // ManifestCounts contains entity counts from the migration.
@@ -92,8 +94,10 @@ type MigrationStats struct {
 	AttachmentsSkipped   int
 }
 
-// NewManifest creates a new manifest with basic information.
-func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath string) *Manifest {
+// NewManifest creates a new manifest with basic information. teamName is
+// advisory destination metadata recorded for audit; the Docs import request
+// selects the actual target team.
+func NewManifest(export *ConfluenceExport, teamName, exportFilePath string) *Manifest {
 	manifest := &Manifest{
 		Version:          "2",
 		Generator:        "mmetl-confluence",
@@ -105,8 +109,7 @@ func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath
 			ExportFile:     filepath.Base(exportFilePath),
 		},
 		Target: ManifestTarget{
-			Team:    teamName,
-			Channel: channelName,
+			Team: teamName,
 		},
 	}
 

--- a/services/confluence/manifest.go
+++ b/services/confluence/manifest.go
@@ -10,22 +10,32 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 )
 
 // Manifest contains metadata about the migration for audit and verification.
 type Manifest struct {
-	Version          string            `json:"version"`
-	Generator        string            `json:"generator"`
-	GeneratorVersion string            `json:"generator_version"`
-	CreatedAt        time.Time         `json:"created_at"`
-	Source           ManifestSource    `json:"source"`
-	Target           ManifestTarget    `json:"target"`
-	Counts           ManifestCounts    `json:"counts"`
-	Checksums        ManifestChecksums `json:"checksums,omitempty"`
-	Users            []ManifestUser    `json:"users,omitempty"`
-	Warnings         []string          `json:"warnings,omitempty"`
-	Errors           []string          `json:"errors,omitempty"`
+	Version          string                   `json:"version"`
+	Generator        string                   `json:"generator"`
+	GeneratorVersion string                   `json:"generator_version"`
+	CreatedAt        time.Time                `json:"created_at"`
+	Source           ManifestSource           `json:"source"`
+	Target           ManifestTarget           `json:"target"`
+	Counts           ManifestCounts           `json:"counts"`
+	Checksums        ManifestChecksums        `json:"checksums,omitempty"`
+	Users            []ManifestUser           `json:"users,omitempty"`
+	RestrictedPages  []ManifestRestrictedPage `json:"restricted_pages,omitempty"`
+	Warnings         []string                 `json:"warnings,omitempty"`
+	Errors           []string                 `json:"errors,omitempty"`
+}
+
+// ManifestRestrictedPage records a page that carried a View restriction in
+// Confluence. Restrictions are detected but not imported, so this list flags
+// pages whose access will change on import.
+type ManifestRestrictedPage struct {
+	ID    string `json:"id"`
+	Title string `json:"title,omitempty"`
 }
 
 // ManifestUser records a source Confluence user and the Mattermost username it
@@ -38,19 +48,14 @@ type ManifestUser struct {
 	MattermostUsername string `json:"mattermost_username,omitempty"`
 }
 
-// ManifestSource describes the source of the migration.
+// ManifestSource describes the source of the migration. OrganizationID and
+// SpaceKey together form the source namespace that scopes all bundle source IDs.
 type ManifestSource struct {
-	Type       string              `json:"type"`
-	SpaceKey   string              `json:"space_key,omitempty"`
-	SpaceName  string              `json:"space_name,omitempty"`
-	Spaces     []ManifestSpaceInfo `json:"spaces,omitempty"`
-	ExportFile string              `json:"export_file"`
-}
-
-// ManifestSpaceInfo describes a single space in a multi-space export.
-type ManifestSpaceInfo struct {
-	Key  string `json:"key"`
-	Name string `json:"name"`
+	Type           string `json:"type"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	SpaceKey       string `json:"space_key,omitempty"`
+	SpaceName      string `json:"space_name,omitempty"`
+	ExportFile     string `json:"export_file"`
 }
 
 // ManifestTarget describes the target of the migration.
@@ -62,7 +67,6 @@ type ManifestTarget struct {
 // ManifestCounts contains entity counts from the migration.
 type ManifestCounts struct {
 	Spaces         int `json:"spaces,omitempty"`
-	Wikis          int `json:"wikis,omitempty"`
 	Pages          int `json:"pages"`
 	Comments       int `json:"comments"`
 	Attachments    int `json:"attachments"`
@@ -91,13 +95,14 @@ type MigrationStats struct {
 // NewManifest creates a new manifest with basic information.
 func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath string) *Manifest {
 	manifest := &Manifest{
-		Version:          "1",
+		Version:          "2",
 		Generator:        "mmetl-confluence",
-		GeneratorVersion: "1.0.0",
+		GeneratorVersion: "2.0.0",
 		CreatedAt:        time.Now().UTC(),
 		Source: ManifestSource{
-			Type:       "confluence",
-			ExportFile: filepath.Base(exportFilePath),
+			Type:           "confluence",
+			OrganizationID: export.OrganizationID,
+			ExportFile:     filepath.Base(exportFilePath),
 		},
 		Target: ManifestTarget{
 			Team:    teamName,
@@ -105,16 +110,14 @@ func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath
 		},
 	}
 
-	// Handle multi-space exports
-	if len(export.Spaces) > 0 {
-		for key, space := range export.Spaces {
-			manifest.Source.Spaces = append(manifest.Source.Spaces, ManifestSpaceInfo{
-				Key:  key,
-				Name: space.Name,
-			})
-		}
-	} else if export.SpaceKey != "" {
-		// Legacy single-space export
+	// A CSV export covers a single space. Prefer the parsed record; fall back to
+	// the descriptor-level key/name.
+	for _, space := range export.Spaces {
+		manifest.Source.SpaceKey = space.Key
+		manifest.Source.SpaceName = space.Name
+		break
+	}
+	if manifest.Source.SpaceKey == "" && export.SpaceKey != "" {
 		manifest.Source.SpaceKey = export.SpaceKey
 		manifest.Source.SpaceName = export.SpaceName
 	}
@@ -123,15 +126,37 @@ func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath
 }
 
 // SetCounts sets the entity counts in the manifest.
-func (m *Manifest) SetCounts(pages, comments, wikis int, stats *MigrationStats) {
+func (m *Manifest) SetCounts(pages, comments, spaces int, stats *MigrationStats) {
 	m.Counts = ManifestCounts{
-		Spaces:         len(m.Source.Spaces),
-		Wikis:          wikis,
+		Spaces:         spaces,
 		Pages:          pages,
 		Comments:       comments,
 		Attachments:    stats.AttachmentCount,
 		UsersUnmapped:  stats.UsersUnmapped,
 		PagesFlattened: stats.PagesFlattened,
+	}
+}
+
+// SetRestrictedPages records pages that carried a View restriction, resolving
+// content IDs to titles where possible.
+func (m *Manifest) SetRestrictedPages(export *ConfluenceExport) {
+	if len(export.RestrictedPageIDs) == 0 {
+		return
+	}
+	titleByID := make(map[string]string, len(export.Pages))
+	for _, p := range export.Pages {
+		titleByID[p.ID] = p.Title
+	}
+	ids := make([]string, 0, len(export.RestrictedPageIDs))
+	for id := range export.RestrictedPageIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		m.RestrictedPages = append(m.RestrictedPages, ManifestRestrictedPage{
+			ID:    id,
+			Title: titleByID[id],
+		})
 	}
 }
 

--- a/services/confluence/manifest.go
+++ b/services/confluence/manifest.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Manifest contains metadata about the migration for audit and verification.
+type Manifest struct {
+	Version          string            `json:"version"`
+	Generator        string            `json:"generator"`
+	GeneratorVersion string            `json:"generator_version"`
+	CreatedAt        time.Time         `json:"created_at"`
+	Source           ManifestSource    `json:"source"`
+	Target           ManifestTarget    `json:"target"`
+	Counts           ManifestCounts    `json:"counts"`
+	Checksums        ManifestChecksums `json:"checksums,omitempty"`
+	Users            []ManifestUser    `json:"users,omitempty"`
+	Warnings         []string          `json:"warnings,omitempty"`
+	Errors           []string          `json:"errors,omitempty"`
+}
+
+// ManifestUser records a source Confluence user and the Mattermost username it
+// resolved to, so a later step can audit or re-match users (e.g. by email via the
+// Atlassian API) after import. The Confluence CSV export itself carries no email
+// or human-readable username, only these opaque identifiers.
+type ManifestUser struct {
+	AccountID          string `json:"account_id"`
+	ConfluenceUsername string `json:"confluence_username,omitempty"`
+	MattermostUsername string `json:"mattermost_username,omitempty"`
+}
+
+// ManifestSource describes the source of the migration.
+type ManifestSource struct {
+	Type       string              `json:"type"`
+	SpaceKey   string              `json:"space_key,omitempty"`
+	SpaceName  string              `json:"space_name,omitempty"`
+	Spaces     []ManifestSpaceInfo `json:"spaces,omitempty"`
+	ExportFile string              `json:"export_file"`
+}
+
+// ManifestSpaceInfo describes a single space in a multi-space export.
+type ManifestSpaceInfo struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+// ManifestTarget describes the target of the migration.
+type ManifestTarget struct {
+	Team    string `json:"team"`
+	Channel string `json:"channel"`
+}
+
+// ManifestCounts contains entity counts from the migration.
+type ManifestCounts struct {
+	Spaces         int `json:"spaces,omitempty"`
+	Wikis          int `json:"wikis,omitempty"`
+	Pages          int `json:"pages"`
+	Comments       int `json:"comments"`
+	Attachments    int `json:"attachments"`
+	UsersMapped    int `json:"users_mapped"`
+	UsersUnmapped  int `json:"users_unmapped"`
+	PagesFlattened int `json:"pages_flattened,omitempty"`
+}
+
+// ManifestChecksums contains checksums for verification.
+type ManifestChecksums struct {
+	JSONLSha256       string `json:"jsonl_sha256,omitempty"`
+	AttachmentsSha256 string `json:"attachments_sha256,omitempty"`
+}
+
+// MigrationStats tracks statistics during migration for manifest generation.
+type MigrationStats struct {
+	Warnings             []string
+	Errors               []string
+	UsersUnmapped        int
+	PagesFlattened       int
+	AttachmentCount      int
+	AttachmentsExtracted int
+	AttachmentsSkipped   int
+}
+
+// NewManifest creates a new manifest with basic information.
+func NewManifest(export *ConfluenceExport, teamName, channelName, exportFilePath string) *Manifest {
+	manifest := &Manifest{
+		Version:          "1",
+		Generator:        "mmetl-confluence",
+		GeneratorVersion: "1.0.0",
+		CreatedAt:        time.Now().UTC(),
+		Source: ManifestSource{
+			Type:       "confluence",
+			ExportFile: filepath.Base(exportFilePath),
+		},
+		Target: ManifestTarget{
+			Team:    teamName,
+			Channel: channelName,
+		},
+	}
+
+	// Handle multi-space exports
+	if len(export.Spaces) > 0 {
+		for key, space := range export.Spaces {
+			manifest.Source.Spaces = append(manifest.Source.Spaces, ManifestSpaceInfo{
+				Key:  key,
+				Name: space.Name,
+			})
+		}
+	} else if export.SpaceKey != "" {
+		// Legacy single-space export
+		manifest.Source.SpaceKey = export.SpaceKey
+		manifest.Source.SpaceName = export.SpaceName
+	}
+
+	return manifest
+}
+
+// SetCounts sets the entity counts in the manifest.
+func (m *Manifest) SetCounts(pages, comments, wikis int, stats *MigrationStats) {
+	m.Counts = ManifestCounts{
+		Spaces:         len(m.Source.Spaces),
+		Wikis:          wikis,
+		Pages:          pages,
+		Comments:       comments,
+		Attachments:    stats.AttachmentCount,
+		UsersUnmapped:  stats.UsersUnmapped,
+		PagesFlattened: stats.PagesFlattened,
+	}
+}
+
+// SetUserMappingCount sets the user mapping count.
+func (m *Manifest) SetUserMappingCount(mapped int) {
+	m.Counts.UsersMapped = mapped
+}
+
+// AddWarning adds a warning to the manifest.
+func (m *Manifest) AddWarning(warning string) {
+	m.Warnings = append(m.Warnings, warning)
+}
+
+// AddError adds an error to the manifest.
+func (m *Manifest) AddError(err string) {
+	m.Errors = append(m.Errors, err)
+}
+
+// ComputeJSONLChecksum computes and sets the SHA256 checksum of the JSONL file.
+func (m *Manifest) ComputeJSONLChecksum(jsonlPath string) error {
+	hash, err := computeFileHash(jsonlPath)
+	if err != nil {
+		return err
+	}
+	m.Checksums.JSONLSha256 = hash
+	return nil
+}
+
+// ComputeAttachmentsChecksum computes a combined checksum of all attachments.
+func (m *Manifest) ComputeAttachmentsChecksum(attachmentsDir string) error {
+	if _, err := os.Stat(attachmentsDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	hasher := sha256.New()
+	err := filepath.Walk(attachmentsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(hasher, file); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	m.Checksums.AttachmentsSha256 = hex.EncodeToString(hasher.Sum(nil))
+	return nil
+}
+
+// Write writes the manifest to a JSON file.
+func (m *Manifest) Write(outputPath string) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(outputPath, data, 0644)
+}
+
+// LoadManifest loads a manifest from a JSON file.
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// computeFileHash computes the SHA256 hash of a file.
+func computeFileHash(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/services/confluence/parser.go
+++ b/services/confluence/parser.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"archive/zip"
+	"html"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// ParseConfluenceExport parses a Confluence Cloud CSV space export ZIP file into
+// a ConfluenceExport. Only the CSV export format is supported; legacy
+// entities.xml / HTML exports are intentionally not handled.
+func (t *Transformer) ParseConfluenceExport(zipReader *zip.Reader) (*ConfluenceExport, error) {
+	t.Logger.Info("Parsing Confluence export")
+
+	export := &ConfluenceExport{
+		Spaces:               make(map[string]*SpaceInfo),
+		Pages:                []*ConfluencePage{},
+		Comments:             []*ConfluenceComment{},
+		Attachments:          make(map[string][]*ConfluenceAttachment),
+		Users:                make(map[string]*ConfluenceUser),
+		AttachmentFiles:      make(map[string]string),
+		BodyContents:         make(map[string]string),
+		HistoricalCommentIDs: make(map[string]bool),
+		HistoricalPageIDs:    make(map[string]bool),
+		InlineCommentAnchors: make(map[string]string),
+		ContentProperties:    make(map[string]*ContentProperty),
+	}
+
+	// Index files in the ZIP by name.
+	fileIndex := make(map[string]*zip.File)
+	for _, f := range zipReader.File {
+		fileIndex[f.Name] = f
+	}
+
+	if !isCSVExport(fileIndex) {
+		return nil, ErrUnsupportedExportFormat
+	}
+
+	if err := t.parseCSVExport(fileIndex, export); err != nil {
+		return nil, err
+	}
+
+	// Index attachment files by base name for later extraction/lookup.
+	for _, f := range zipReader.File {
+		if strings.HasPrefix(f.Name, "attachments/") && !f.FileInfo().IsDir() {
+			export.AttachmentFiles[path.Base(f.Name)] = f.Name
+		}
+	}
+
+	t.Logger.Infof("Parsed %d pages, %d comments, %d users",
+		len(export.Pages), len(export.Comments), len(export.Users))
+
+	return export, nil
+}
+
+// extractInlineCommentAnchors extracts inline comment markers from page content.
+// Confluence inline comments are marked with: <ac:inline-comment-marker ac:ref="COMMENT_ID">anchor text</ac:inline-comment-marker>
+// This function finds all such markers and returns a map of comment ID → anchor text.
+// It operates on the storage-format body string and is independent of the export
+// container format (XML or CSV).
+func extractInlineCommentAnchors(content string) map[string]string {
+	anchors := make(map[string]string)
+
+	// Pattern: <ac:inline-comment-marker ac:ref="COMMENT_ID">anchor text</ac:inline-comment-marker>
+	const markerStart = "<ac:inline-comment-marker"
+	const markerEnd = "</ac:inline-comment-marker>"
+
+	pos := 0
+	for {
+		startIdx := strings.Index(content[pos:], markerStart)
+		if startIdx == -1 {
+			break
+		}
+		startIdx += pos
+
+		endIdx := strings.Index(content[startIdx:], markerEnd)
+		if endIdx == -1 {
+			break
+		}
+		endIdx += startIdx + len(markerEnd)
+
+		marker := content[startIdx:endIdx]
+
+		// Extract ac:ref attribute value
+		refIdx := strings.Index(marker, "ac:ref=\"")
+		if refIdx != -1 {
+			refStart := refIdx + len("ac:ref=\"")
+			refEnd := strings.Index(marker[refStart:], "\"")
+			if refEnd != -1 {
+				commentID := marker[refStart : refStart+refEnd]
+
+				// Extract anchor text (content between > and </ac:inline-comment-marker>)
+				contentStart := strings.Index(marker, ">")
+				if contentStart != -1 {
+					contentStart++
+					contentEnd := strings.Index(marker[contentStart:], "</ac:inline-comment-marker>")
+					if contentEnd != -1 {
+						anchorText := marker[contentStart : contentStart+contentEnd]
+						// Strip any nested HTML tags from the anchor text
+						anchorText = stripHTMLTags(anchorText)
+						anchorText = strings.TrimSpace(anchorText)
+						if anchorText != "" {
+							anchors[commentID] = anchorText
+						}
+					}
+				}
+			}
+		}
+
+		pos = endIdx
+	}
+
+	return anchors
+}
+
+// stripHTMLTags removes HTML tags from a string and decodes HTML entities, keeping only text content.
+func stripHTMLTags(s string) string {
+	var result strings.Builder
+	inTag := false
+	for _, c := range s {
+		if c == '<' {
+			inTag = true
+			continue
+		}
+		if c == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(c)
+		}
+	}
+	// Decode HTML entities like &apos; &quot; &amp; etc.
+	return html.UnescapeString(result.String())
+}
+
+// parsePositionValue parses a Confluence position/ordering value into an int,
+// returning 0 for empty or malformed input.
+func parsePositionValue(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	pos, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return pos
+}

--- a/services/confluence/parser.go
+++ b/services/confluence/parser.go
@@ -29,6 +29,7 @@ func (t *Transformer) ParseConfluenceExport(zipReader *zip.Reader) (*ConfluenceE
 		HistoricalPageIDs:    make(map[string]bool),
 		InlineCommentAnchors: make(map[string]string),
 		ContentProperties:    make(map[string]*ContentProperty),
+		RestrictedPageIDs:    make(map[string]bool),
 	}
 
 	// Index files in the ZIP by name.

--- a/services/confluence/tiptap_converter.go
+++ b/services/confluence/tiptap_converter.go
@@ -1,0 +1,1178 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// TipTap node types
+const (
+	NodeTypeDoc            = "doc"
+	NodeTypeParagraph      = "paragraph"
+	NodeTypeText           = "text"
+	NodeTypeHeading        = "heading"
+	NodeTypeBulletList     = "bulletList"
+	NodeTypeOrderedList    = "orderedList"
+	NodeTypeListItem       = "listItem"
+	NodeTypeCodeBlock      = "codeBlock"
+	NodeTypeBlockquote     = "blockquote"
+	NodeTypeHardBreak      = "hardBreak"
+	NodeTypeHorizontalRule = "horizontalRule"
+	NodeTypeImage          = "image"
+	NodeTypeTable          = "table"
+	NodeTypeTableRow       = "tableRow"
+	NodeTypeTableCell      = "tableCell"
+	NodeTypeTableHeader    = "tableHeader"
+)
+
+// TipTap mark types
+const (
+	MarkTypeBold          = "bold"
+	MarkTypeItalic        = "italic"
+	MarkTypeStrike        = "strike"
+	MarkTypeCode          = "code"
+	MarkTypeLink          = "link"
+	MarkTypeUnderline     = "underline"
+	MarkTypeCommentAnchor = "commentAnchor"
+)
+
+// TipTapNode represents a node in the TipTap document structure.
+type TipTapNode struct {
+	Type    string         `json:"type"`
+	Attrs   map[string]any `json:"attrs,omitempty"`
+	Content []TipTapNode   `json:"content,omitempty"`
+	Marks   []TipTapMark   `json:"marks,omitempty"`
+	Text    string         `json:"text,omitempty"`
+}
+
+// TipTapMark represents a mark (formatting) in TipTap.
+type TipTapMark struct {
+	Type  string         `json:"type"`
+	Attrs map[string]any `json:"attrs,omitempty"`
+}
+
+// ChildPageInfo contains information about a child page for generating navigation links.
+type ChildPageInfo struct {
+	ID    string // Confluence page ID
+	Title string // Page title
+}
+
+// ConvertHTMLToTipTap converts Confluence HTML content to TipTap JSON.
+func ConvertHTMLToTipTap(htmlContent string) (string, error) {
+	return ConvertHTMLToTipTapWithChildren(htmlContent, nil)
+}
+
+// ConvertHTMLToTipTapWithChildren converts Confluence HTML content to TipTap JSON,
+// with optional children info for generating child page links in children/pagetree macros.
+func ConvertHTMLToTipTapWithChildren(htmlContent string, children []ChildPageInfo) (string, error) {
+	// Pre-process Confluence-specific macros
+	htmlContent = preprocessConfluenceMacros(htmlContent)
+
+	// Parse HTML
+	doc, err := html.Parse(strings.NewReader(htmlContent))
+	if err != nil {
+		return "", err
+	}
+
+	// Pre-scan for headings (needed for ToC generation)
+	headings := scanHeadings(doc)
+
+	// Convert to TipTap
+	converter := &tiptapConverter{
+		children: children,
+		headings: headings,
+	}
+	content := converter.convertNode(doc)
+
+	// Wrap in doc node
+	tipTapDoc := TipTapNode{
+		Type:    NodeTypeDoc,
+		Content: flattenContent(content),
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(tipTapDoc)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonBytes), nil
+}
+
+// HeadingInfo stores information about a heading for ToC generation.
+type HeadingInfo struct {
+	Level int
+	Text  string
+	ID    string // Anchor ID for linking
+}
+
+type tiptapConverter struct {
+	currentMarks []TipTapMark
+	children     []ChildPageInfo // Child pages for generating navigation links
+	headings     []HeadingInfo   // Headings for ToC generation
+	headingIndex int             // Current heading index for ID assignment
+}
+
+func (c *tiptapConverter) convertNode(n *html.Node) []TipTapNode {
+	var result []TipTapNode
+
+	switch n.Type {
+	case html.TextNode:
+		text := n.Data
+
+		// For preformatted elements, preserve all whitespace exactly
+		if n.Parent != nil && isPreformattedElement(n.Parent) {
+			if text != "" {
+				node := TipTapNode{
+					Type: NodeTypeText,
+					Text: text,
+				}
+				if len(c.currentMarks) > 0 {
+					node.Marks = make([]TipTapMark, len(c.currentMarks))
+					copy(node.Marks, c.currentMarks)
+				}
+				result = append(result, node)
+			}
+		} else {
+			// For normal text, collapse whitespace but preserve word boundaries
+			// Skip nodes that are purely structural whitespace (only newlines/tabs between block elements)
+			if strings.TrimSpace(text) == "" {
+				// Pure whitespace - skip if it's just structural (newlines between elements)
+				// But preserve a single space if we're inside inline content
+				if n.Parent != nil && isInlineElement(n.Parent) && strings.Contains(text, " ") {
+					// Keep a single space for inline contexts
+					text = " "
+				} else {
+					break
+				}
+			} else {
+				// Has actual content - normalize internal whitespace but preserve leading/trailing spaces
+				// This maintains word boundaries when text is adjacent to formatted elements
+				text = normalizeWhitespace(text)
+			}
+
+			if text != "" {
+				node := TipTapNode{
+					Type: NodeTypeText,
+					Text: text,
+				}
+				if len(c.currentMarks) > 0 {
+					node.Marks = make([]TipTapMark, len(c.currentMarks))
+					copy(node.Marks, c.currentMarks)
+				}
+				result = append(result, node)
+			}
+		}
+
+	case html.ElementNode:
+		result = c.convertElement(n)
+
+	case html.DocumentNode:
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			result = append(result, c.convertNode(child)...)
+		}
+	}
+
+	return result
+}
+
+func (c *tiptapConverter) convertElement(n *html.Node) []TipTapNode {
+	var result []TipTapNode
+
+	switch strings.ToLower(n.Data) {
+	// Block elements
+	case "p", "div":
+		content := c.convertChildren(n)
+		if len(content) > 0 {
+			result = append(result, TipTapNode{
+				Type:    NodeTypeParagraph,
+				Content: content,
+			})
+		}
+
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		level := int(n.Data[1] - '0')
+		content := c.convertChildren(n)
+		attrs := map[string]any{"level": level}
+		// Add anchor ID from pre-scanned headings for ToC linking
+		if c.headingIndex < len(c.headings) {
+			attrs["id"] = c.headings[c.headingIndex].ID
+			c.headingIndex++
+		}
+		result = append(result, TipTapNode{
+			Type:    NodeTypeHeading,
+			Attrs:   attrs,
+			Content: content,
+		})
+
+	case "ul":
+		items := c.convertListItems(n)
+		result = append(result, TipTapNode{
+			Type:    NodeTypeBulletList,
+			Content: items,
+		})
+
+	case "ol":
+		items := c.convertListItems(n)
+		attrs := map[string]any{"start": 1}
+		if start := getAttr(n, "start"); start != "" {
+			attrs["start"] = start
+		}
+		result = append(result, TipTapNode{
+			Type:    NodeTypeOrderedList,
+			Attrs:   attrs,
+			Content: items,
+		})
+
+	case "li":
+		content := c.convertChildren(n)
+		// Wrap inline content in paragraph
+		if len(content) > 0 && content[0].Type == NodeTypeText {
+			content = []TipTapNode{{
+				Type:    NodeTypeParagraph,
+				Content: content,
+			}}
+		}
+		result = append(result, TipTapNode{
+			Type:    NodeTypeListItem,
+			Content: content,
+		})
+
+	case "pre":
+		// <pre> always creates a code block
+		text := extractText(n)
+		language := getAttr(n, "data-language")
+		if language == "" {
+			language = getAttr(n, "class") // Often contains language hint
+		}
+		attrs := map[string]any{}
+		if language != "" {
+			attrs["language"] = extractLanguageFromClass(language)
+		}
+		// Only create text node if content is not empty.
+		// Empty text nodes with omitempty create invalid {"type": "text"} without text property.
+		var preContent []TipTapNode
+		if text != "" {
+			preContent = []TipTapNode{{
+				Type: NodeTypeText,
+				Text: text,
+			}}
+		}
+		result = append(result, TipTapNode{
+			Type:    NodeTypeCodeBlock,
+			Attrs:   attrs,
+			Content: preContent,
+		})
+
+	case "code":
+		// <code> inside <pre> is already handled by the <pre> case via extractText
+		// <code> standalone is inline code (like <tt>, <samp>, <kbd>)
+		if n.Parent != nil && strings.ToLower(n.Parent.Data) == "pre" {
+			// Skip - parent <pre> handles this
+		} else {
+			// Inline code - use code mark
+			c.pushMark(TipTapMark{Type: MarkTypeCode})
+			result = append(result, c.convertChildren(n)...)
+			c.popMark()
+		}
+
+	case "blockquote":
+		content := c.convertChildren(n)
+		result = append(result, TipTapNode{
+			Type:    NodeTypeBlockquote,
+			Content: wrapInParagraphIfNeeded(content),
+		})
+
+	case "hr":
+		result = append(result, TipTapNode{Type: NodeTypeHorizontalRule})
+
+	case "br":
+		result = append(result, TipTapNode{Type: NodeTypeHardBreak})
+
+	case "img":
+		src := getAttr(n, "src")
+		alt := getAttr(n, "alt")
+		if src != "" {
+			result = append(result, TipTapNode{
+				Type: NodeTypeImage,
+				Attrs: map[string]any{
+					"src": src,
+					"alt": alt,
+				},
+			})
+		}
+
+	case "table":
+		rows := c.convertTableRows(n)
+		result = append(result, TipTapNode{
+			Type:    NodeTypeTable,
+			Content: rows,
+		})
+
+	case "a":
+		href := getAttr(n, "href")
+		c.pushMark(TipTapMark{
+			Type:  MarkTypeLink,
+			Attrs: map[string]any{"href": href},
+		})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	// Inline formatting
+	case "strong", "b":
+		c.pushMark(TipTapMark{Type: MarkTypeBold})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	case "em", "i":
+		c.pushMark(TipTapMark{Type: MarkTypeItalic})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	case "u":
+		c.pushMark(TipTapMark{Type: MarkTypeUnderline})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	case "s", "strike", "del":
+		c.pushMark(TipTapMark{Type: MarkTypeStrike})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	case "tt", "samp", "kbd":
+		c.pushMark(TipTapMark{Type: MarkTypeCode})
+		result = append(result, c.convertChildren(n)...)
+		c.popMark()
+
+	// Confluence-specific elements (handled after preprocessing)
+	case "ac:structured-macro":
+		result = append(result, c.convertConfluenceMacro(n)...)
+
+	case "ac:inline-comment-marker":
+		// Inline comment marker - convert to commentAnchor mark
+		// The ac:ref attribute contains the UUID that links this highlight to the comment
+		anchorID := getAttr(n, "ac:ref")
+		if anchorID != "" {
+			c.pushMark(TipTapMark{
+				Type:  MarkTypeCommentAnchor,
+				Attrs: map[string]any{"anchorId": anchorID},
+			})
+			result = append(result, c.convertChildren(n)...)
+			c.popMark()
+		} else {
+			// No anchor ID - just process children without mark
+			result = append(result, c.convertChildren(n)...)
+		}
+
+	// Containers to pass through
+	case "html", "body", "head", "span", "font":
+		result = append(result, c.convertChildren(n)...)
+
+	// Confluence parameter elements - skip (they contain macro configuration, not content)
+	// Without this, unknown macros like "children" or "contentbylabel" would have their
+	// parameter values (like "true", "1") extracted as text content
+	case "ac:parameter":
+		// Skip - don't extract text from parameter elements
+
+	default:
+		// Unknown element - just process children
+		result = append(result, c.convertChildren(n)...)
+	}
+
+	return result
+}
+
+func (c *tiptapConverter) convertChildren(n *html.Node) []TipTapNode {
+	var result []TipTapNode
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		result = append(result, c.convertNode(child)...)
+	}
+	return result
+}
+
+func (c *tiptapConverter) convertListItems(n *html.Node) []TipTapNode {
+	var items []TipTapNode
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode && strings.ToLower(child.Data) == "li" {
+			items = append(items, c.convertElement(child)...)
+		}
+	}
+	return items
+}
+
+func (c *tiptapConverter) convertTableRows(n *html.Node) []TipTapNode {
+	var rows []TipTapNode
+
+	var processNode func(*html.Node)
+	processNode = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			switch strings.ToLower(node.Data) {
+			case "tr":
+				cells := c.convertTableCells(node)
+				rows = append(rows, TipTapNode{
+					Type:    NodeTypeTableRow,
+					Content: cells,
+				})
+			case "thead", "tbody", "tfoot":
+				for child := node.FirstChild; child != nil; child = child.NextSibling {
+					processNode(child)
+				}
+			}
+		}
+	}
+
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		processNode(child)
+	}
+
+	return rows
+}
+
+func (c *tiptapConverter) convertTableCells(tr *html.Node) []TipTapNode {
+	var cells []TipTapNode
+	for child := tr.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode {
+			tag := strings.ToLower(child.Data)
+			if tag == "td" || tag == "th" {
+				nodeType := NodeTypeTableCell
+				if tag == "th" {
+					nodeType = NodeTypeTableHeader
+				}
+
+				content := c.convertChildren(child)
+				attrs := map[string]any{}
+
+				if colspan := getAttr(child, "colspan"); colspan != "" {
+					attrs["colspan"] = colspan
+				}
+				if rowspan := getAttr(child, "rowspan"); rowspan != "" {
+					attrs["rowspan"] = rowspan
+				}
+
+				cells = append(cells, TipTapNode{
+					Type:    nodeType,
+					Attrs:   attrs,
+					Content: wrapInParagraphIfNeeded(content),
+				})
+			}
+		}
+	}
+	return cells
+}
+
+func (c *tiptapConverter) convertConfluenceMacro(n *html.Node) []TipTapNode {
+	macroName := getAttr(n, "ac:name")
+
+	switch macroName {
+	case "code":
+		// Code macro - extract language and content
+		language := ""
+		content := ""
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type == html.ElementNode {
+				if strings.ToLower(child.Data) == "ac:parameter" && getAttr(child, "ac:name") == "language" {
+					language = extractText(child)
+				}
+				if strings.ToLower(child.Data) == "ac:plain-text-body" {
+					content = extractText(child)
+				}
+			}
+		}
+		attrs := map[string]any{}
+		if language != "" {
+			attrs["language"] = language
+		}
+		// Only create text node if content is not empty.
+		// Empty text nodes with omitempty create invalid {"type": "text"} without text property.
+		var codeContent []TipTapNode
+		if content != "" {
+			codeContent = []TipTapNode{{
+				Type: NodeTypeText,
+				Text: content,
+			}}
+		}
+		return []TipTapNode{{
+			Type:    NodeTypeCodeBlock,
+			Attrs:   attrs,
+			Content: codeContent,
+		}}
+
+	case "info", "note", "warning", "tip":
+		// Panel macros - convert to blockquote with marker
+		content := c.convertChildren(n)
+		return []TipTapNode{{
+			Type:    NodeTypeBlockquote,
+			Content: wrapInParagraphIfNeeded(content),
+		}}
+
+	case "expand":
+		// Expand macro - just include the content
+		return c.convertChildren(n)
+
+	case "toc":
+		// Table of contents - generate static list from collected headings
+		if len(c.headings) > 0 {
+			return c.generateToCList()
+		}
+		return nil
+
+	case "jira":
+		// JIRA macro - extract the issue key only
+		// Structure: <ac:structured-macro ac:name="jira">
+		//   <ac:parameter ac:name="key">MM-50469</ac:parameter>
+		//   <ac:parameter ac:name="server">System JIRA</ac:parameter>
+		//   <ac:parameter ac:name="serverId">UUID</ac:parameter>
+		// </ac:structured-macro>
+		jiraKey := ""
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type == html.ElementNode && strings.ToLower(child.Data) == "ac:parameter" {
+				paramName := getAttr(child, "ac:name")
+				if paramName == "key" {
+					jiraKey = extractText(child)
+					break
+				}
+			}
+		}
+		if jiraKey != "" {
+			return []TipTapNode{{
+				Type: NodeTypeText,
+				Text: jiraKey,
+			}}
+		}
+		return nil
+
+	case "children", "pagetree", "pagetreesearch":
+		// Dynamic navigation macros - these display child pages at runtime
+		// If we have children info, generate a bullet list with links
+		if len(c.children) > 0 {
+			return c.generateChildPageList()
+		}
+		// No children info available - generate placeholder
+		return []TipTapNode{{
+			Type: NodeTypeParagraph,
+			Content: []TipTapNode{{
+				Type:  NodeTypeText,
+				Text:  "[This section displayed a list of child pages in Confluence]",
+				Marks: []TipTapMark{{Type: MarkTypeItalic}},
+			}},
+		}}
+
+	case "contentbylabel":
+		// Content by label macro - dynamically lists pages with specific labels
+		return []TipTapNode{{
+			Type: NodeTypeParagraph,
+			Content: []TipTapNode{{
+				Type:  NodeTypeText,
+				Text:  "[This section displayed pages by label in Confluence]",
+				Marks: []TipTapMark{{Type: MarkTypeItalic}},
+			}},
+		}}
+
+	case "recently-updated":
+		// Recently updated macro - dynamically shows recent changes
+		return []TipTapNode{{
+			Type: NodeTypeParagraph,
+			Content: []TipTapNode{{
+				Type:  NodeTypeText,
+				Text:  "[This section displayed recently updated content in Confluence]",
+				Marks: []TipTapMark{{Type: MarkTypeItalic}},
+			}},
+		}}
+
+	default:
+		// Unknown macro - try to extract content
+		return c.convertChildren(n)
+	}
+}
+
+func (c *tiptapConverter) pushMark(mark TipTapMark) {
+	c.currentMarks = append(c.currentMarks, mark)
+}
+
+func (c *tiptapConverter) popMark() {
+	if len(c.currentMarks) > 0 {
+		c.currentMarks = c.currentMarks[:len(c.currentMarks)-1]
+	}
+}
+
+// scanHeadings extracts all headings from the parsed HTML document.
+// Used for generating static Table of Contents.
+func scanHeadings(doc *html.Node) []HeadingInfo {
+	var headings []HeadingInfo
+	usedIDs := make(map[string]int) // Track used IDs for uniqueness
+
+	var scan func(*html.Node)
+	scan = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			tag := strings.ToLower(n.Data)
+			if len(tag) == 2 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6' {
+				level := int(tag[1] - '0')
+				text := extractText(n)
+				text = strings.TrimSpace(text)
+				if text != "" {
+					// Generate unique anchor ID
+					id := slugify(text)
+					if count, exists := usedIDs[id]; exists {
+						usedIDs[id] = count + 1
+						id = fmt.Sprintf("%s-%d", id, count+1)
+					} else {
+						usedIDs[id] = 1
+					}
+					headings = append(headings, HeadingInfo{
+						Level: level,
+						Text:  text,
+						ID:    id,
+					})
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			scan(child)
+		}
+	}
+	scan(doc)
+
+	return headings
+}
+
+// slugify converts text to a URL-friendly anchor ID.
+func slugify(text string) string {
+	// Convert to lowercase
+	result := strings.ToLower(text)
+	// Replace spaces with hyphens
+	result = strings.ReplaceAll(result, " ", "-")
+	// Remove non-alphanumeric characters except hyphens
+	var cleaned strings.Builder
+	for _, r := range result {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			cleaned.WriteRune(r)
+		}
+	}
+	result = cleaned.String()
+	// Collapse multiple hyphens
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+	// Trim leading/trailing hyphens
+	result = strings.Trim(result, "-")
+	if result == "" {
+		result = "heading"
+	}
+	return result
+}
+
+// generateToCList creates a bullet list from collected headings for Table of Contents.
+// Each item is a link that navigates to the corresponding heading anchor.
+func (c *tiptapConverter) generateToCList() []TipTapNode {
+	if len(c.headings) == 0 {
+		return nil
+	}
+
+	// Create list items for each heading as anchor links
+	var listItems []TipTapNode
+	for _, heading := range c.headings {
+		listItem := TipTapNode{
+			Type: NodeTypeListItem,
+			Content: []TipTapNode{{
+				Type: NodeTypeParagraph,
+				Content: []TipTapNode{{
+					Type: NodeTypeText,
+					Text: heading.Text,
+					Marks: []TipTapMark{{
+						Type: MarkTypeLink,
+						Attrs: map[string]any{
+							"href": "#" + heading.ID,
+						},
+					}},
+				}},
+			}},
+		}
+		listItems = append(listItems, listItem)
+	}
+
+	// Wrap in a bullet list
+	return []TipTapNode{{
+		Type:    NodeTypeBulletList,
+		Content: listItems,
+	}}
+}
+
+// generateChildPageList creates a bullet list of links to child pages.
+// Uses CONF_PAGE_ID placeholders that get resolved to actual wiki page URLs during import.
+func (c *tiptapConverter) generateChildPageList() []TipTapNode {
+	if len(c.children) == 0 {
+		return nil
+	}
+
+	// Create list items for each child page
+	var listItems []TipTapNode
+	for _, child := range c.children {
+		// Create a link with CONF_PAGE_ID placeholder that gets resolved during import
+		linkURL := fmt.Sprintf("{{CONF_PAGE_ID:%s}}", child.ID)
+		listItem := TipTapNode{
+			Type: NodeTypeListItem,
+			Content: []TipTapNode{{
+				Type: NodeTypeParagraph,
+				Content: []TipTapNode{{
+					Type: NodeTypeText,
+					Text: child.Title,
+					Marks: []TipTapMark{{
+						Type: MarkTypeLink,
+						Attrs: map[string]any{
+							"href": linkURL,
+						},
+					}},
+				}},
+			}},
+		}
+		listItems = append(listItems, listItem)
+	}
+
+	// Wrap in a bullet list
+	return []TipTapNode{{
+		Type:    NodeTypeBulletList,
+		Content: listItems,
+	}}
+}
+
+// Helper functions
+
+func getAttr(n *html.Node, key string) string {
+	for _, attr := range n.Attr {
+		if strings.EqualFold(attr.Key, key) {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func extractText(n *html.Node) string {
+	var text strings.Builder
+	var extract func(*html.Node)
+	extract = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			text.WriteString(node.Data)
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			extract(child)
+		}
+	}
+	extract(n)
+	return text.String()
+}
+
+func isPreformattedElement(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	tag := strings.ToLower(n.Data)
+	return tag == "pre" || tag == "code" || tag == "ac:plain-text-body"
+}
+
+// isInlineElement returns true if the element is an inline/phrasing element
+// where whitespace between children should be preserved.
+func isInlineElement(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	tag := strings.ToLower(n.Data)
+	// Common inline elements where whitespace matters for word separation
+	switch tag {
+	case "p", "span", "a", "strong", "b", "em", "i", "u", "s", "strike", "del",
+		"code", "tt", "samp", "kbd", "sub", "sup", "small", "mark", "q",
+		"abbr", "cite", "dfn", "time", "var", "li", "td", "th", "h1", "h2",
+		"h3", "h4", "h5", "h6", "label", "legend", "caption", "figcaption":
+		return true
+	}
+	return false
+}
+
+// normalizeWhitespace collapses multiple whitespace characters into single spaces
+// while preserving leading and trailing spaces for word boundary preservation.
+func normalizeWhitespace(s string) string {
+	// Check for leading/trailing whitespace before normalization
+	hasLeadingSpace := len(s) > 0 && (s[0] == ' ' || s[0] == '\t' || s[0] == '\n' || s[0] == '\r')
+	hasTrailingSpace := len(s) > 0 && (s[len(s)-1] == ' ' || s[len(s)-1] == '\t' || s[len(s)-1] == '\n' || s[len(s)-1] == '\r')
+
+	// Collapse all whitespace sequences to single space
+	result := strings.Join(strings.Fields(s), " ")
+
+	// Restore leading/trailing space if they existed (for word boundaries)
+	if hasLeadingSpace && len(result) > 0 {
+		result = " " + result
+	}
+	if hasTrailingSpace && len(result) > 0 {
+		result = result + " "
+	}
+
+	return result
+}
+
+func extractLanguageFromClass(class string) string {
+	// Extract language from class like "language-go" or "brush: java"
+	if strings.HasPrefix(class, "language-") {
+		return strings.TrimPrefix(class, "language-")
+	}
+	if strings.Contains(class, "brush:") {
+		parts := strings.Split(class, ":")
+		if len(parts) > 1 {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
+}
+
+func flattenContent(nodes []TipTapNode) []TipTapNode {
+	var result []TipTapNode
+	for _, node := range nodes {
+		if node.Type == "" {
+			continue
+		}
+		result = append(result, node)
+	}
+	if len(result) == 0 {
+		// Empty doc needs at least one paragraph
+		return []TipTapNode{{Type: NodeTypeParagraph, Content: []TipTapNode{}}}
+	}
+	return result
+}
+
+func wrapInParagraphIfNeeded(content []TipTapNode) []TipTapNode {
+	if len(content) == 0 {
+		return []TipTapNode{{Type: NodeTypeParagraph, Content: []TipTapNode{}}}
+	}
+	// If first node is inline (text), wrap in paragraph
+	if content[0].Type == NodeTypeText {
+		return []TipTapNode{{
+			Type:    NodeTypeParagraph,
+			Content: content,
+		}}
+	}
+	return content
+}
+
+// ConvertHTMLToMarkdown converts Confluence HTML content to Markdown.
+// This is used for page comments which should be plain text/markdown, not TipTap JSON.
+func ConvertHTMLToMarkdown(htmlContent string) string {
+	// Pre-process Confluence-specific macros
+	htmlContent = preprocessConfluenceMacros(htmlContent)
+
+	// Parse HTML
+	doc, err := html.Parse(strings.NewReader(htmlContent))
+	if err != nil {
+		// Fallback to stripped HTML
+		return stripHTMLForMarkdown(htmlContent)
+	}
+
+	// Convert to Markdown
+	converter := &markdownConverter{}
+	return strings.TrimSpace(converter.convertNode(doc))
+}
+
+type markdownConverter struct{}
+
+func (m *markdownConverter) convertNode(n *html.Node) string {
+	var result strings.Builder
+
+	switch n.Type {
+	case html.TextNode:
+		text := n.Data
+		// Normalize whitespace for non-preformatted text
+		if n.Parent == nil || !isPreformattedElement(n.Parent) {
+			if strings.TrimSpace(text) == "" {
+				// Preserve single space for word boundaries in inline contexts
+				if n.Parent != nil && isInlineElement(n.Parent) && strings.Contains(text, " ") {
+					result.WriteString(" ")
+				}
+			} else {
+				result.WriteString(normalizeWhitespace(text))
+			}
+		} else {
+			result.WriteString(text)
+		}
+
+	case html.ElementNode:
+		result.WriteString(m.convertElement(n))
+
+	case html.DocumentNode:
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			result.WriteString(m.convertNode(child))
+		}
+	}
+
+	return result.String()
+}
+
+func (m *markdownConverter) convertElement(n *html.Node) string {
+	var result strings.Builder
+
+	switch strings.ToLower(n.Data) {
+	// Block elements
+	case "p", "div":
+		content := m.convertChildren(n)
+		if strings.TrimSpace(content) != "" {
+			result.WriteString(content)
+			result.WriteString("\n\n")
+		}
+
+	case "br":
+		result.WriteString("\n")
+
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		level := int(n.Data[1] - '0')
+		result.WriteString(strings.Repeat("#", level))
+		result.WriteString(" ")
+		result.WriteString(m.convertChildren(n))
+		result.WriteString("\n\n")
+
+	case "ul", "ol":
+		result.WriteString(m.convertList(n, strings.ToLower(n.Data) == "ol"))
+		result.WriteString("\n")
+
+	case "li":
+		result.WriteString(m.convertChildren(n))
+
+	case "pre", "code":
+		text := extractText(n)
+		if n.Parent != nil && strings.ToLower(n.Parent.Data) == "pre" {
+			// Inside pre, just return text (parent handles formatting)
+			result.WriteString(text)
+		} else if strings.ToLower(n.Data) == "pre" {
+			// Code block
+			result.WriteString("```\n")
+			result.WriteString(text)
+			result.WriteString("\n```\n\n")
+		} else {
+			// Inline code
+			result.WriteString("`")
+			result.WriteString(strings.TrimSpace(m.convertChildren(n)))
+			result.WriteString("`")
+		}
+
+	case "blockquote":
+		content := m.convertChildren(n)
+		lines := strings.Split(strings.TrimSpace(content), "\n")
+		for _, line := range lines {
+			result.WriteString("> ")
+			result.WriteString(line)
+			result.WriteString("\n")
+		}
+		result.WriteString("\n")
+
+	case "hr":
+		result.WriteString("---\n\n")
+
+	case "a":
+		href := getAttr(n, "href")
+		text := strings.TrimSpace(m.convertChildren(n))
+		if href != "" && text != "" {
+			// If text equals href, just output the URL
+			if text == href {
+				result.WriteString(href)
+			} else {
+				result.WriteString("[")
+				result.WriteString(text)
+				result.WriteString("](")
+				result.WriteString(href)
+				result.WriteString(")")
+			}
+		} else if text != "" {
+			result.WriteString(text)
+		} else if href != "" {
+			result.WriteString(href)
+		}
+
+	case "strong", "b":
+		content := m.convertChildren(n)
+		if strings.TrimSpace(content) != "" {
+			result.WriteString("**")
+			result.WriteString(content)
+			result.WriteString("**")
+		}
+
+	case "em", "i":
+		content := m.convertChildren(n)
+		if strings.TrimSpace(content) != "" {
+			result.WriteString("*")
+			result.WriteString(content)
+			result.WriteString("*")
+		}
+
+	case "s", "strike", "del":
+		content := m.convertChildren(n)
+		if strings.TrimSpace(content) != "" {
+			result.WriteString("~~")
+			result.WriteString(content)
+			result.WriteString("~~")
+		}
+
+	case "tt", "samp", "kbd":
+		content := m.convertChildren(n)
+		if strings.TrimSpace(content) != "" {
+			result.WriteString("`")
+			result.WriteString(content)
+			result.WriteString("`")
+		}
+
+	case "img":
+		src := getAttr(n, "src")
+		alt := getAttr(n, "alt")
+		if src != "" {
+			result.WriteString("![")
+			result.WriteString(alt)
+			result.WriteString("](")
+			result.WriteString(src)
+			result.WriteString(")")
+		}
+
+	// Confluence-specific - inline comment marker (just pass through content)
+	case "ac:inline-comment-marker":
+		result.WriteString(m.convertChildren(n))
+
+	// Confluence structured macros
+	case "ac:structured-macro":
+		macroName := getAttr(n, "ac:name")
+		switch macroName {
+		case "jira":
+			// JIRA macro - extract only the issue key
+			// Structure: <ac:structured-macro ac:name="jira">
+			//   <ac:parameter ac:name="key">MM-50469</ac:parameter>
+			//   <ac:parameter ac:name="server">System JIRA</ac:parameter>
+			//   <ac:parameter ac:name="serverId">UUID</ac:parameter>
+			// </ac:structured-macro>
+			jiraKey := ""
+			for child := n.FirstChild; child != nil; child = child.NextSibling {
+				if child.Type == html.ElementNode && strings.ToLower(child.Data) == "ac:parameter" {
+					paramName := getAttr(child, "ac:name")
+					if paramName == "key" {
+						jiraKey = extractText(child)
+						break
+					}
+				}
+			}
+			if jiraKey != "" {
+				result.WriteString(jiraKey)
+			}
+		case "code":
+			// Code block macro
+			text := ""
+			for child := n.FirstChild; child != nil; child = child.NextSibling {
+				if child.Type == html.ElementNode && strings.ToLower(child.Data) == "ac:plain-text-body" {
+					text = extractText(child)
+					break
+				}
+			}
+			if text != "" {
+				result.WriteString("```\n")
+				result.WriteString(text)
+				result.WriteString("\n```\n\n")
+			}
+		case "info", "note", "warning", "tip":
+			// Panel macros - convert to blockquote
+			content := m.convertChildren(n)
+			lines := strings.Split(strings.TrimSpace(content), "\n")
+			for _, line := range lines {
+				result.WriteString("> ")
+				result.WriteString(line)
+				result.WriteString("\n")
+			}
+			result.WriteString("\n")
+		case "expand", "toc":
+			// Skip table of contents, expand macro content inline
+			result.WriteString(m.convertChildren(n))
+		default:
+			// Unknown macro - try to extract content
+			result.WriteString(m.convertChildren(n))
+		}
+
+	// Pass-through containers
+	case "html", "body", "head", "span", "font", "u":
+		result.WriteString(m.convertChildren(n))
+
+	// Confluence parameter elements - skip (they contain macro configuration, not content)
+	case "ac:parameter":
+		// Skip - don't extract text from parameter elements
+
+	default:
+		// Unknown element - just process children
+		result.WriteString(m.convertChildren(n))
+	}
+
+	return result.String()
+}
+
+func (m *markdownConverter) convertChildren(n *html.Node) string {
+	var result strings.Builder
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		result.WriteString(m.convertNode(child))
+	}
+	return result.String()
+}
+
+func (m *markdownConverter) convertList(n *html.Node, ordered bool) string {
+	var result strings.Builder
+	index := 1
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode && strings.ToLower(child.Data) == "li" {
+			if ordered {
+				result.WriteString(strconv.Itoa(index))
+				result.WriteString(". ")
+				index++
+			} else {
+				result.WriteString("- ")
+			}
+			result.WriteString(strings.TrimSpace(m.convertChildren(child)))
+			result.WriteString("\n")
+		}
+	}
+	return result.String()
+}
+
+// stripHTMLForMarkdown is a simple fallback that removes HTML tags.
+func stripHTMLForMarkdown(html string) string {
+	var result []rune
+	inTag := false
+	for _, c := range html {
+		if c == '<' {
+			inTag = true
+			continue
+		}
+		if c == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result = append(result, c)
+		}
+	}
+	return strings.TrimSpace(string(result))
+}
+
+// preprocessConfluenceMacros converts Confluence-specific XML elements to standard HTML.
+func preprocessConfluenceMacros(content string) string {
+	// Replace CDATA sections - use (?s) flag to make . match newlines
+	// This is critical for multiline content like code blocks
+	// Note: Some Confluence exports have malformed CDATA with space: "]] >" instead of "]]>"
+	cdataRegex := regexp.MustCompile(`(?s)<!\[CDATA\[(.*?)\]\]\s*>`)
+	content = cdataRegex.ReplaceAllString(content, "$1")
+
+	// Convert self-closing XML tags to properly closed tags.
+	// HTML5 parser doesn't recognize self-closing syntax for non-void elements,
+	// so <ac:structured-macro /> becomes an unclosed element that swallows subsequent content.
+	// Convert: <ac:structured-macro ... /> → <ac:structured-macro ...></ac:structured-macro>
+	selfClosingTagRegex := regexp.MustCompile(`<(ac:[a-zA-Z-]+)([^>]*)\s*/>`)
+	content = selfClosingTagRegex.ReplaceAllString(content, "<$1$2></$1>")
+
+	// Use comprehensive link converter
+	content = ConvertConfluenceLinks(content)
+
+	return content
+}

--- a/services/confluence/transformer.go
+++ b/services/confluence/transformer.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import log "github.com/sirupsen/logrus"
+
+// Transformer handles the transformation of Confluence exports to Mattermost import format.
+type Transformer struct {
+	TeamName     string
+	ChannelName  string
+	Intermediate *Intermediate
+	UserMapper   *UserMapper
+	Logger       log.FieldLogger
+	Config       *TransformConfig
+	Stats        *MigrationStats
+	ExportFile   string // Original export file path for manifest
+}
+
+// TransformConfig holds configuration options for the transformation.
+type TransformConfig struct {
+	// SkipAttachments skips copying attachments from the export
+	SkipAttachments bool
+	// AttachmentsDir is the directory to store attachments
+	AttachmentsDir string
+	// MaxDepth is the maximum hierarchy depth (default 10)
+	MaxDepth int
+	// DryRun validates without writing output
+	DryRun bool
+	// AutoCreateChannel generates a channel entry in the JSONL output
+	AutoCreateChannel bool
+}
+
+// NewTransformer creates a new Confluence transformer.
+func NewTransformer(teamName, channelName string, logger log.FieldLogger, config *TransformConfig) *Transformer {
+	if config == nil {
+		config = &TransformConfig{
+			MaxDepth: 10,
+		}
+	}
+	if config.MaxDepth == 0 {
+		config.MaxDepth = 10
+	}
+
+	return &Transformer{
+		TeamName:     teamName,
+		ChannelName:  channelName,
+		Intermediate: &Intermediate{},
+		Logger:       logger,
+		Config:       config,
+		Stats:        &MigrationStats{},
+	}
+}
+
+// Transform performs the full transformation from Confluence export to intermediate format.
+func (t *Transformer) Transform(export *ConfluenceExport) error {
+	t.Logger.Info("Starting Confluence transformation")
+
+	// Transform pages (in topological order for hierarchy)
+	if err := t.TransformPages(export); err != nil {
+		return err
+	}
+
+	// Transform comments
+	if err := t.TransformComments(export); err != nil {
+		return err
+	}
+
+	t.Logger.Infof("Transformation complete: %d pages, %d comments",
+		len(t.Intermediate.Pages), len(t.Intermediate.Comments))
+
+	return nil
+}

--- a/services/confluence/transformer.go
+++ b/services/confluence/transformer.go
@@ -7,8 +7,9 @@ import log "github.com/sirupsen/logrus"
 
 // Transformer handles the transformation of Confluence exports to Mattermost import format.
 type Transformer struct {
+	// TeamName is advisory destination metadata recorded in the bundle; the Docs
+	// import request selects the actual target team.
 	TeamName     string
-	ChannelName  string
 	Intermediate *Intermediate
 	UserMapper   *UserMapper
 	Logger       log.FieldLogger
@@ -29,8 +30,10 @@ type TransformConfig struct {
 	DryRun bool
 }
 
-// NewTransformer creates a new Confluence transformer.
-func NewTransformer(teamName, channelName string, logger log.FieldLogger, config *TransformConfig) *Transformer {
+// NewTransformer creates a new Confluence transformer. teamName is advisory
+// destination metadata recorded in the bundle; the Docs import request selects
+// the actual target team.
+func NewTransformer(teamName string, logger log.FieldLogger, config *TransformConfig) *Transformer {
 	if config == nil {
 		config = &TransformConfig{
 			MaxDepth: 10,
@@ -42,7 +45,6 @@ func NewTransformer(teamName, channelName string, logger log.FieldLogger, config
 
 	return &Transformer{
 		TeamName:     teamName,
-		ChannelName:  channelName,
 		Intermediate: &Intermediate{},
 		Logger:       logger,
 		Config:       config,

--- a/services/confluence/transformer.go
+++ b/services/confluence/transformer.go
@@ -27,8 +27,6 @@ type TransformConfig struct {
 	MaxDepth int
 	// DryRun validates without writing output
 	DryRun bool
-	// AutoCreateChannel generates a channel entry in the JSONL output
-	AutoCreateChannel bool
 }
 
 // NewTransformer creates a new Confluence transformer.

--- a/services/confluence/types.go
+++ b/services/confluence/types.go
@@ -6,14 +6,27 @@ package confluence
 import "time"
 
 // ConfluenceExport represents a parsed Confluence space export.
-// Supports both single-space and multi-space exports.
+//
+// A Confluence Cloud CSV export always covers a single space; the Spaces map is
+// the parse-side shape (the natural seam should site/multi-space exports ever
+// appear), but the transform/export side commits to one space per bundle.
 type ConfluenceExport struct {
-	// Legacy single-space fields (for backward compatibility)
+	// SpaceKey/SpaceName describe the single space this export covers.
 	SpaceKey  string
 	SpaceName string
 
-	// Multi-space support
+	// OrganizationID namespaces source IDs (page IDs, space keys) across
+	// Confluence instances. Derived from exportDescriptor.properties.
+	OrganizationID string
+
+	// Spaces holds the parsed space records keyed by space key. A CSV export
+	// yields exactly one; more than one is rejected at transform time.
 	Spaces map[string]*SpaceInfo // spaceKey -> space info
+
+	// RestrictedPageIDs holds content IDs carrying a View restriction. These are
+	// detected and surfaced (not resolved into an ACL) so a view-restricted page
+	// is not silently widened on import.
+	RestrictedPageIDs map[string]bool
 
 	Pages           []*ConfluencePage
 	Comments        []*ConfluenceComment
@@ -93,6 +106,8 @@ type ConfluenceComment struct {
 	BodyContentID      string // Reference to BodyContent object
 	CreatedBy          string // Account ID
 	CreatedAt          time.Time
+	UpdatedBy          string // Account ID
+	UpdatedAt          time.Time
 	InlineAnchor       *InlineAnchor // For inline comments
 	HistoricalIDs      []string      // IDs of historical versions (old edits) of this comment
 	ContentPropertyIDs []string      // IDs of ContentProperty objects for this comment

--- a/services/confluence/types.go
+++ b/services/confluence/types.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import "time"
+
+// ConfluenceExport represents a parsed Confluence space export.
+// Supports both single-space and multi-space exports.
+type ConfluenceExport struct {
+	// Legacy single-space fields (for backward compatibility)
+	SpaceKey  string
+	SpaceName string
+
+	// Multi-space support
+	Spaces map[string]*SpaceInfo // spaceKey -> space info
+
+	Pages           []*ConfluencePage
+	Comments        []*ConfluenceComment
+	Attachments     map[string][]*ConfluenceAttachment // pageID -> attachments
+	Users           map[string]*ConfluenceUser         // accountID -> user
+	AttachmentFiles map[string]string                  // attachmentID -> file path in export
+	BodyContents    map[string]string                  // bodyContentID -> HTML content
+
+	// HistoricalCommentIDs contains comment IDs that are historical versions (old edits)
+	// These should be skipped during transformation as they're not current comments
+	HistoricalCommentIDs map[string]bool
+
+	// HistoricalPageIDs contains page IDs that are historical versions (old edits)
+	// These should be skipped during transformation as they're not current pages
+	HistoricalPageIDs map[string]bool
+
+	// InlineCommentAnchors maps inline-marker-ref UUID to anchor text extracted from page content.
+	// Populated by extracting <ac:inline-comment-marker> tags from page bodies.
+	InlineCommentAnchors map[string]string
+
+	// ContentProperties maps ContentProperty ID to property name and value.
+	// Used to look up inline-marker-ref for comments.
+	ContentProperties map[string]*ContentProperty
+}
+
+// ContentProperty represents a key-value property attached to content.
+type ContentProperty struct {
+	ID          string
+	Name        string
+	StringValue string
+}
+
+// SpaceInfo holds space metadata.
+type SpaceInfo struct {
+	Key         string
+	Name        string
+	Description string
+	HomePageID  string // Root page ID for the space
+}
+
+// ConfluencePage represents a page from the Confluence export.
+type ConfluencePage struct {
+	ID                string
+	Title             string
+	ParentID          string // Empty for root pages
+	SpaceKey          string // Space this page belongs to
+	Content           string // HTML content (Confluence Storage Format)
+	BodyContentID     string // Reference to BodyContent object
+	CreatedBy         string // Account ID
+	CreatedAt         time.Time
+	UpdatedBy         string // Account ID
+	UpdatedAt         time.Time
+	Version           int
+	Labels            []string
+	Children          []*ConfluencePage // For building hierarchy
+	Restrictions      *PageRestrictions
+	HistoricalIDs     []string // IDs of historical versions (old edits) of this page
+	OriginalVersionID string   // If non-empty, this page is a historical version pointing to the current page
+	ContentStatus     string   // "current", "draft", "deleted", "archived"
+	Position          int      // Ordering position within parent (from Confluence's position property)
+}
+
+// PageRestrictions represents view/edit restrictions on a page.
+type PageRestrictions struct {
+	ViewUsers  []string // Account IDs
+	ViewGroups []string
+	EditUsers  []string // Account IDs
+	EditGroups []string
+}
+
+// ConfluenceComment represents a comment from the Confluence export.
+type ConfluenceComment struct {
+	ID                 string
+	PageID             string
+	ParentID           string // For threaded comments
+	Content            string // HTML content
+	BodyContentID      string // Reference to BodyContent object
+	CreatedBy          string // Account ID
+	CreatedAt          time.Time
+	InlineAnchor       *InlineAnchor // For inline comments
+	HistoricalIDs      []string      // IDs of historical versions (old edits) of this comment
+	ContentPropertyIDs []string      // IDs of ContentProperty objects for this comment
+	IsResolved         bool          // True if comment was resolved in Confluence
+}
+
+// InlineAnchor represents the position of an inline comment in page content.
+type InlineAnchor struct {
+	AnchorID          string // The UUID from ac:ref attribute (used to link TipTap mark to comment)
+	OriginalSelection string // The selected text
+	TextContext       string // Surrounding text for fuzzy matching
+	Offset            int    // Character offset in content
+}
+
+// ConfluenceAttachment represents an attachment from the Confluence export.
+type ConfluenceAttachment struct {
+	ID        string
+	PageID    string
+	FileName  string
+	MediaType string
+	FileSize  int64
+	CreatedBy string
+	CreatedAt time.Time
+	Comment   string
+	FilePath  string // Path within the export ZIP
+}
+
+// ConfluenceUser represents a user from the Confluence export.
+type ConfluenceUser struct {
+	AccountID   string
+	Username    string
+	DisplayName string
+	Email       string
+}
+
+// ExportFormat represents the type of Confluence export.
+type ExportFormat string
+
+const (
+	// ExportFormatXML is the standard Confluence XML export format.
+	ExportFormatXML ExportFormat = "xml"
+	// ExportFormatHTML is the HTML export format (used by some Confluence versions).
+	ExportFormatHTML ExportFormat = "html"
+)

--- a/services/confluence/user_mapper.go
+++ b/services/confluence/user_mapper.go
@@ -211,6 +211,29 @@ func (um *UserMapper) ResolveUser(accountID, email, username string) string {
 	return ""
 }
 
+// ResolvesExplicitly reports whether the mapping file maps this user by any key
+// (account ID, email, or Confluence username), independent of any fallback. It
+// mirrors the mapper lookups used during transformation so strict validation
+// does not reject a mapping that transformation would successfully use.
+func (um *UserMapper) ResolvesExplicitly(accountID, email, username string) bool {
+	if accountID != "" {
+		if _, err := um.GetUsername(accountID); err == nil {
+			return true
+		}
+	}
+	if email != "" {
+		if _, err := um.GetUsernameByEmail(email); err == nil {
+			return true
+		}
+	}
+	if username != "" {
+		if _, err := um.GetUsernameByConfluenceUsername(username); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // GetMappingCount returns the number of user mappings loaded.
 func (um *UserMapper) GetMappingCount() int {
 	return len(um.byAccountID)

--- a/services/confluence/user_mapper.go
+++ b/services/confluence/user_mapper.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var (
+	ErrUserNotFound = errors.New("user not found in mapping")
+	ErrInvalidCSV   = errors.New("invalid CSV format")
+	ErrEmptyCSV     = errors.New("CSV contains no valid mappings")
+)
+
+// UserMapping represents a mapping from Confluence user to Mattermost user.
+type UserMapping struct {
+	ConfluenceAccountID string
+	ConfluenceUsername  string
+	ConfluenceEmail     string
+	MattermostUsername  string
+	MattermostUserID    string
+}
+
+// UserMapper handles mapping Confluence users to Mattermost users.
+type UserMapper struct {
+	// Mappings by various keys for flexible lookup
+	byAccountID map[string]*UserMapping
+	byUsername  map[string]*UserMapping
+	byEmail     map[string]*UserMapping
+
+	// Fallback username for unmapped users
+	fallbackUsername string
+}
+
+// NewUserMapper creates a new user mapper from a CSV file.
+// CSV format: confluence_account_id,confluence_username,confluence_email,mattermost_username,mattermost_user_id
+// Header row is optional but recommended.
+func NewUserMapper(csvPath string, fallbackUsername string) (*UserMapper, error) {
+	um := &UserMapper{
+		byAccountID:      make(map[string]*UserMapping),
+		byUsername:       make(map[string]*UserMapping),
+		byEmail:          make(map[string]*UserMapping),
+		fallbackUsername: fallbackUsername,
+	}
+
+	if csvPath == "" {
+		return um, nil
+	}
+
+	file, err := os.Open(csvPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open user mapping CSV: %w", err)
+	}
+	defer file.Close()
+
+	if err := um.loadFromCSV(file); err != nil {
+		return nil, err
+	}
+
+	return um, nil
+}
+
+// loadFromCSV loads mappings from a CSV reader.
+func (um *UserMapper) loadFromCSV(r io.Reader) error {
+	reader := csv.NewReader(r)
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1 // Allow variable fields
+
+	lineNum := 0
+	hasValidMappings := false
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("%w: line %d: %v", ErrInvalidCSV, lineNum+1, err)
+		}
+		lineNum++
+
+		// Skip header row
+		if lineNum == 1 && isHeaderRow(record) {
+			continue
+		}
+
+		// Parse record
+		mapping, err := parseCSVRecord(record)
+		if err != nil {
+			// Log warning but continue
+			continue
+		}
+
+		// Index by available keys
+		if mapping.ConfluenceAccountID != "" {
+			um.byAccountID[mapping.ConfluenceAccountID] = mapping
+		}
+		if mapping.ConfluenceUsername != "" {
+			um.byUsername[strings.ToLower(mapping.ConfluenceUsername)] = mapping
+		}
+		if mapping.ConfluenceEmail != "" {
+			um.byEmail[strings.ToLower(mapping.ConfluenceEmail)] = mapping
+		}
+
+		hasValidMappings = true
+	}
+
+	if !hasValidMappings {
+		return ErrEmptyCSV
+	}
+
+	return nil
+}
+
+// isHeaderRow checks if a CSV row is a header.
+func isHeaderRow(record []string) bool {
+	if len(record) == 0 {
+		return false
+	}
+	first := strings.ToLower(record[0])
+	return strings.Contains(first, "account") ||
+		strings.Contains(first, "confluence") ||
+		strings.Contains(first, "user") ||
+		strings.Contains(first, "id")
+}
+
+// parseCSVRecord parses a CSV record into a UserMapping.
+func parseCSVRecord(record []string) (*UserMapping, error) {
+	if len(record) < 4 {
+		return nil, fmt.Errorf("record has too few fields: %d", len(record))
+	}
+
+	mapping := &UserMapping{
+		ConfluenceAccountID: strings.TrimSpace(record[0]),
+		ConfluenceUsername:  strings.TrimSpace(record[1]),
+		ConfluenceEmail:     strings.TrimSpace(record[2]),
+		MattermostUsername:  strings.TrimSpace(record[3]),
+	}
+
+	if len(record) > 4 {
+		mapping.MattermostUserID = strings.TrimSpace(record[4])
+	}
+
+	// At minimum need a Mattermost username
+	if mapping.MattermostUsername == "" {
+		return nil, errors.New("missing mattermost username")
+	}
+
+	return mapping, nil
+}
+
+// GetUsername returns the Mattermost username for a Confluence account ID.
+func (um *UserMapper) GetUsername(confluenceAccountID string) (string, error) {
+	if mapping, ok := um.byAccountID[confluenceAccountID]; ok {
+		return mapping.MattermostUsername, nil
+	}
+	return "", ErrUserNotFound
+}
+
+// GetUsernameByEmail returns the Mattermost username for a Confluence email.
+func (um *UserMapper) GetUsernameByEmail(email string) (string, error) {
+	if mapping, ok := um.byEmail[strings.ToLower(email)]; ok {
+		return mapping.MattermostUsername, nil
+	}
+	return "", ErrUserNotFound
+}
+
+// GetUsernameByConfluenceUsername returns the Mattermost username for a Confluence username.
+func (um *UserMapper) GetUsernameByConfluenceUsername(username string) (string, error) {
+	if mapping, ok := um.byUsername[strings.ToLower(username)]; ok {
+		return mapping.MattermostUsername, nil
+	}
+	return "", ErrUserNotFound
+}
+
+// ResolveUser attempts to resolve a Confluence user to a Mattermost username.
+// It tries account ID, email, and username in order.
+func (um *UserMapper) ResolveUser(accountID, email, username string) string {
+	// Try account ID first
+	if accountID != "" {
+		if mmUser, err := um.GetUsername(accountID); err == nil {
+			return mmUser
+		}
+	}
+
+	// Try email
+	if email != "" {
+		if mmUser, err := um.GetUsernameByEmail(email); err == nil {
+			return mmUser
+		}
+	}
+
+	// Try username
+	if username != "" {
+		if mmUser, err := um.GetUsernameByConfluenceUsername(username); err == nil {
+			return mmUser
+		}
+	}
+
+	// Return fallback
+	if um.fallbackUsername != "" {
+		return um.fallbackUsername
+	}
+
+	return ""
+}
+
+// GetMappingCount returns the number of user mappings loaded.
+func (um *UserMapper) GetMappingCount() int {
+	return len(um.byAccountID)
+}
+
+// GetEmailMappingCount returns the number of email mappings loaded.
+func (um *UserMapper) GetEmailMappingCount() int {
+	return len(um.byEmail)
+}
+
+// GetFallbackUsername returns the fallback username.
+func (um *UserMapper) GetFallbackUsername() string {
+	return um.fallbackUsername
+}
+
+// ValidateMappings checks that all mappings have valid Mattermost usernames.
+// Returns a list of warnings for any issues found.
+func (um *UserMapper) ValidateMappings() []string {
+	var warnings []string
+
+	for accountID, mapping := range um.byAccountID {
+		if mapping.MattermostUsername == "" {
+			warnings = append(warnings, fmt.Sprintf("Account %s has no Mattermost username", accountID))
+		}
+	}
+
+	return warnings
+}

--- a/services/confluence/validation.go
+++ b/services/confluence/validation.go
@@ -97,7 +97,8 @@ func (v *Validator) ValidateExportContent(export *ConfluenceExport) *ValidationR
 	}
 
 	if export.SpaceKey == "" {
-		result.Warnings = append(result.Warnings, "export has no space key")
+		result.Valid = false
+		result.Errors = append(result.Errors, "export has no space key; a single, non-empty space key is required")
 	}
 
 	// Check for pages with empty content
@@ -189,10 +190,25 @@ func (v *Validator) ValidateUserMapping(export *ConfluenceExport, userMapper *Us
 		}
 	}
 
-	// Check which users are unmapped
+	// Check which users are unmapped. Mirror the transform's mapper lookups
+	// (account ID, email, and Confluence username, including email derived from
+	// the username or account ID) so strict mode agrees with what transformation
+	// would actually resolve.
 	unmappedUsers := []string{}
 	for userID := range userIDs {
-		if _, err := userMapper.GetUsername(userID); err != nil {
+		accountID := userID
+		var email, username string
+		if u, ok := export.Users[accountID]; ok {
+			username = u.Username
+			email = u.Email
+			if email == "" && strings.Contains(username, "@") {
+				email = username
+			}
+		}
+		if strings.Contains(accountID, "@") {
+			email = accountID
+		}
+		if !userMapper.ResolvesExplicitly(accountID, email, username) {
 			unmappedUsers = append(unmappedUsers, userID)
 		}
 	}

--- a/services/confluence/validation.go
+++ b/services/confluence/validation.go
@@ -35,22 +35,21 @@ type Validator struct {
 	MattermostURL string
 	// MattermostToken is the authentication token (optional for server validation)
 	MattermostToken string
-	// TeamName is the target team name
+	// TeamName is the advisory destination team recorded in the bundle. Optional
+	// server validation may check that it exists, but it is not a routing
+	// authority — the Docs import request selects the actual target team.
 	TeamName string
-	// ChannelName is the target channel name (deprecated in v2; the backing
-	// channel is resolved at import time). Only used for optional server checks.
-	ChannelName string
 	// RequireUserMapping fails validation when any author is unmapped.
 	RequireUserMapping bool
 	// FailOnRestricted fails validation when any page carries a View restriction.
 	FailOnRestricted bool
 }
 
-// NewValidator creates a new validator.
-func NewValidator(teamName, channelName string) *Validator {
+// NewValidator creates a new validator. teamName is advisory destination
+// metadata; the Docs import request selects the actual target team.
+func NewValidator(teamName string) *Validator {
 	return &Validator{
-		TeamName:    teamName,
-		ChannelName: channelName,
+		TeamName: teamName,
 	}
 }
 
@@ -240,8 +239,10 @@ func (v *Validator) ValidateServer(ctx context.Context) *ValidationResult {
 	client := model.NewAPIv4Client(v.MattermostURL)
 	client.SetToken(v.MattermostToken)
 
-	// Validate team exists
-	team, resp, err := client.GetTeamByName(ctx, v.TeamName, "")
+	// Validate the advisory team exists. This is a courtesy check only: the team
+	// is advisory metadata and the Docs import request selects the actual target.
+	// We never inspect any regular or Space backing channel here.
+	_, resp, err := client.GetTeamByName(ctx, v.TeamName, "")
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			result.Valid = false
@@ -251,33 +252,6 @@ func (v *Validator) ValidateServer(ctx context.Context) *ValidationResult {
 			result.Errors = append(result.Errors, fmt.Sprintf("failed to check team: %v", err))
 		}
 		return result
-	}
-
-	// The backing channel is resolved at import time in v2, so a channel is only
-	// checked when one was explicitly supplied.
-	if v.ChannelName == "" {
-		return result
-	}
-
-	// Validate channel exists
-	channel, resp, err := client.GetChannelByName(ctx, v.ChannelName, team.Id, "")
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			result.Valid = false
-			result.Errors = append(result.Errors, fmt.Sprintf("channel %q not found in team %q", v.ChannelName, v.TeamName))
-		} else {
-			result.Valid = false
-			result.Errors = append(result.Errors, fmt.Sprintf("failed to check channel: %v", err))
-		}
-		return result
-	}
-
-	// Validate permissions (check if we can get channel membership)
-	_, resp, err = client.GetChannelMember(ctx, channel.Id, "me", "")
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusForbidden {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("may not have access to channel %q", v.ChannelName))
-		}
 	}
 
 	return result

--- a/services/confluence/validation.go
+++ b/services/confluence/validation.go
@@ -8,9 +8,18 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// Docs storage caps the emitted bundle must respect. Body and SearchText are
+// each capped at 2 MiB; page Props at 64 KiB.
+const (
+	PageBodyMaxBytes       = 2 * 1024 * 1024
+	PageSearchTextMaxBytes = 2 * 1024 * 1024
+	PagePropsMaxBytes      = 64 * 1024
 )
 
 // ValidationResult holds the results of pre-flight validation.
@@ -28,8 +37,13 @@ type Validator struct {
 	MattermostToken string
 	// TeamName is the target team name
 	TeamName string
-	// ChannelName is the target channel name
+	// ChannelName is the target channel name (deprecated in v2; the backing
+	// channel is resolved at import time). Only used for optional server checks.
 	ChannelName string
+	// RequireUserMapping fails validation when any author is unmapped.
+	RequireUserMapping bool
+	// FailOnRestricted fails validation when any page carries a View restriction.
+	FailOnRestricted bool
 }
 
 // NewValidator creates a new validator.
@@ -97,21 +111,55 @@ func (v *Validator) ValidateExportContent(export *ConfluenceExport) *ValidationR
 		result.Warnings = append(result.Warnings, fmt.Sprintf("%d pages have empty content", emptyContentCount))
 	}
 
-	// Check content sizes
-	const maxContentSize = 10 * 1024 * 1024 // 10MB
+	// Check content sizes against the Docs Body cap (2 MiB). This is a pre-flight
+	// heads-up on the raw storage-format body; the authoritative check runs on the
+	// emitted TipTap body at export time.
 	oversizedPages := []string{}
 	for _, page := range export.Pages {
-		if len(page.Content) > maxContentSize {
+		if len(page.Content) > PageBodyMaxBytes {
 			oversizedPages = append(oversizedPages, page.Title)
 		}
 	}
 	if len(oversizedPages) > 0 {
 		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("%d pages exceed max content size (10MB): %s",
+			fmt.Sprintf("%d pages exceed the Docs body limit (2 MiB): %s",
 				len(oversizedPages), strings.Join(oversizedPages[:min(3, len(oversizedPages))], ", ")))
 	}
 
+	// Surface view-restricted pages. Restrictions are detected, not resolved into
+	// an ACL, so importing them widens access unless the operator intervenes.
+	if len(export.RestrictedPageIDs) > 0 {
+		titles := restrictedPageTitles(export)
+		msg := fmt.Sprintf("%d pages have a View restriction that will NOT be preserved on import: %s",
+			len(export.RestrictedPageIDs), strings.Join(titles[:min(5, len(titles))], ", "))
+		if v.FailOnRestricted {
+			result.Valid = false
+			result.Errors = append(result.Errors, msg)
+		} else {
+			result.Warnings = append(result.Warnings, msg)
+		}
+	}
+
 	return result
+}
+
+// restrictedPageTitles resolves restricted content IDs to page titles for
+// human-readable reporting, falling back to the bare ID when unknown.
+func restrictedPageTitles(export *ConfluenceExport) []string {
+	titleByID := make(map[string]string, len(export.Pages))
+	for _, p := range export.Pages {
+		titleByID[p.ID] = p.Title
+	}
+	titles := make([]string, 0, len(export.RestrictedPageIDs))
+	for id := range export.RestrictedPageIDs {
+		if title := titleByID[id]; title != "" {
+			titles = append(titles, title)
+		} else {
+			titles = append(titles, id)
+		}
+	}
+	sort.Strings(titles)
+	return titles
 }
 
 // ValidateUserMapping validates user mappings and returns warnings for unmapped users.
@@ -119,7 +167,12 @@ func (v *Validator) ValidateUserMapping(export *ConfluenceExport, userMapper *Us
 	result := &ValidationResult{Valid: true}
 
 	if userMapper == nil {
-		result.Warnings = append(result.Warnings, "no user mapping provided - users will be auto-generated")
+		if v.RequireUserMapping {
+			result.Valid = false
+			result.Errors = append(result.Errors, "no user mapping provided but --require-user-mapping is set")
+		} else {
+			result.Warnings = append(result.Warnings, "no user mapping provided - users will be auto-generated")
+		}
 		return result
 	}
 
@@ -145,8 +198,13 @@ func (v *Validator) ValidateUserMapping(export *ConfluenceExport, userMapper *Us
 	}
 
 	if len(unmappedUsers) > 0 {
-		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("%d Confluence users not in mapping file (will use fallback)", len(unmappedUsers)))
+		msg := fmt.Sprintf("%d Confluence users not in mapping file (will use fallback)", len(unmappedUsers))
+		if v.RequireUserMapping {
+			result.Valid = false
+			result.Errors = append(result.Errors, strings.Replace(msg, "will use fallback", "--require-user-mapping is set", 1))
+		} else {
+			result.Warnings = append(result.Warnings, msg)
+		}
 	}
 
 	return result
@@ -176,6 +234,12 @@ func (v *Validator) ValidateServer(ctx context.Context) *ValidationResult {
 			result.Valid = false
 			result.Errors = append(result.Errors, fmt.Sprintf("failed to check team: %v", err))
 		}
+		return result
+	}
+
+	// The backing channel is resolved at import time in v2, so a channel is only
+	// checked when one was explicitly supplied.
+	if v.ChannelName == "" {
 		return result
 	}
 
@@ -226,7 +290,11 @@ func (v *Validator) ValidateAll(ctx context.Context, zipReader *zip.Reader, expo
 
 		// User mapping validation
 		userResult := v.ValidateUserMapping(export, userMapper)
+		combined.Errors = append(combined.Errors, userResult.Errors...)
 		combined.Warnings = append(combined.Warnings, userResult.Warnings...)
+		if !userResult.Valid {
+			combined.Valid = false
+		}
 	}
 
 	// Server validation (optional)

--- a/services/confluence/validation.go
+++ b/services/confluence/validation.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package confluence
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// ValidationResult holds the results of pre-flight validation.
+type ValidationResult struct {
+	Valid    bool
+	Errors   []string
+	Warnings []string
+}
+
+// Validator handles pre-flight validation for Confluence migrations.
+type Validator struct {
+	// MattermostURL is the Mattermost server URL (optional for server validation)
+	MattermostURL string
+	// MattermostToken is the authentication token (optional for server validation)
+	MattermostToken string
+	// TeamName is the target team name
+	TeamName string
+	// ChannelName is the target channel name
+	ChannelName string
+}
+
+// NewValidator creates a new validator.
+func NewValidator(teamName, channelName string) *Validator {
+	return &Validator{
+		TeamName:    teamName,
+		ChannelName: channelName,
+	}
+}
+
+// SetServerConfig sets the Mattermost server configuration for server-side validation.
+func (v *Validator) SetServerConfig(url, token string) {
+	v.MattermostURL = url
+	v.MattermostToken = token
+}
+
+// ValidateExportFormat validates that the Confluence export file has the expected
+// Confluence Cloud CSV format.
+func (v *Validator) ValidateExportFormat(zipReader *zip.Reader) *ValidationResult {
+	result := &ValidationResult{Valid: true}
+
+	hasAttachments := false
+
+	fileIndex := make(map[string]*zip.File, len(zipReader.File))
+	for _, file := range zipReader.File {
+		fileIndex[file.Name] = file
+		if strings.HasPrefix(file.Name, "attachments/") {
+			hasAttachments = true
+		}
+	}
+
+	if !isCSVExport(fileIndex) {
+		result.Valid = false
+		result.Errors = append(result.Errors, "invalid export: expected a Confluence Cloud CSV export (content.csv or exportDescriptor.properties with exportFormat=csv)")
+	}
+
+	if !hasAttachments {
+		result.Warnings = append(result.Warnings, "export contains no attachments directory")
+	}
+
+	return result
+}
+
+// ValidateExportContent validates the content of the parsed export.
+func (v *Validator) ValidateExportContent(export *ConfluenceExport) *ValidationResult {
+	result := &ValidationResult{Valid: true}
+
+	if len(export.Pages) == 0 {
+		result.Valid = false
+		result.Errors = append(result.Errors, "export contains no pages")
+	}
+
+	if export.SpaceKey == "" {
+		result.Warnings = append(result.Warnings, "export has no space key")
+	}
+
+	// Check for pages with empty content
+	emptyContentCount := 0
+	for _, page := range export.Pages {
+		if page.Content == "" {
+			emptyContentCount++
+		}
+	}
+	if emptyContentCount > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("%d pages have empty content", emptyContentCount))
+	}
+
+	// Check content sizes
+	const maxContentSize = 10 * 1024 * 1024 // 10MB
+	oversizedPages := []string{}
+	for _, page := range export.Pages {
+		if len(page.Content) > maxContentSize {
+			oversizedPages = append(oversizedPages, page.Title)
+		}
+	}
+	if len(oversizedPages) > 0 {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("%d pages exceed max content size (10MB): %s",
+				len(oversizedPages), strings.Join(oversizedPages[:min(3, len(oversizedPages))], ", ")))
+	}
+
+	return result
+}
+
+// ValidateUserMapping validates user mappings and returns warnings for unmapped users.
+func (v *Validator) ValidateUserMapping(export *ConfluenceExport, userMapper *UserMapper) *ValidationResult {
+	result := &ValidationResult{Valid: true}
+
+	if userMapper == nil {
+		result.Warnings = append(result.Warnings, "no user mapping provided - users will be auto-generated")
+		return result
+	}
+
+	// Collect all unique user account IDs from pages and comments
+	userIDs := make(map[string]bool)
+	for _, page := range export.Pages {
+		if page.CreatedBy != "" {
+			userIDs[page.CreatedBy] = true
+		}
+	}
+	for _, comment := range export.Comments {
+		if comment.CreatedBy != "" {
+			userIDs[comment.CreatedBy] = true
+		}
+	}
+
+	// Check which users are unmapped
+	unmappedUsers := []string{}
+	for userID := range userIDs {
+		if _, err := userMapper.GetUsername(userID); err != nil {
+			unmappedUsers = append(unmappedUsers, userID)
+		}
+	}
+
+	if len(unmappedUsers) > 0 {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("%d Confluence users not in mapping file (will use fallback)", len(unmappedUsers)))
+	}
+
+	return result
+}
+
+// ValidateServer validates the target Mattermost server configuration.
+// This requires MattermostURL and MattermostToken to be set.
+func (v *Validator) ValidateServer(ctx context.Context) *ValidationResult {
+	result := &ValidationResult{Valid: true}
+
+	if v.MattermostURL == "" || v.MattermostToken == "" {
+		result.Warnings = append(result.Warnings, "server validation skipped - no URL/token provided")
+		return result
+	}
+
+	// Create Mattermost client
+	client := model.NewAPIv4Client(v.MattermostURL)
+	client.SetToken(v.MattermostToken)
+
+	// Validate team exists
+	team, resp, err := client.GetTeamByName(ctx, v.TeamName, "")
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("team %q not found", v.TeamName))
+		} else {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("failed to check team: %v", err))
+		}
+		return result
+	}
+
+	// Validate channel exists
+	channel, resp, err := client.GetChannelByName(ctx, v.ChannelName, team.Id, "")
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("channel %q not found in team %q", v.ChannelName, v.TeamName))
+		} else {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("failed to check channel: %v", err))
+		}
+		return result
+	}
+
+	// Validate permissions (check if we can get channel membership)
+	_, resp, err = client.GetChannelMember(ctx, channel.Id, "me", "")
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusForbidden {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("may not have access to channel %q", v.ChannelName))
+		}
+	}
+
+	return result
+}
+
+// ValidateAll runs all validation checks and combines results.
+func (v *Validator) ValidateAll(ctx context.Context, zipReader *zip.Reader, export *ConfluenceExport, userMapper *UserMapper) *ValidationResult {
+	combined := &ValidationResult{Valid: true}
+
+	// Export format validation
+	formatResult := v.ValidateExportFormat(zipReader)
+	combined.Errors = append(combined.Errors, formatResult.Errors...)
+	combined.Warnings = append(combined.Warnings, formatResult.Warnings...)
+	if !formatResult.Valid {
+		combined.Valid = false
+	}
+
+	// Export content validation
+	if export != nil {
+		contentResult := v.ValidateExportContent(export)
+		combined.Errors = append(combined.Errors, contentResult.Errors...)
+		combined.Warnings = append(combined.Warnings, contentResult.Warnings...)
+		if !contentResult.Valid {
+			combined.Valid = false
+		}
+
+		// User mapping validation
+		userResult := v.ValidateUserMapping(export, userMapper)
+		combined.Warnings = append(combined.Warnings, userResult.Warnings...)
+	}
+
+	// Server validation (optional)
+	if v.MattermostURL != "" && v.MattermostToken != "" {
+		serverResult := v.ValidateServer(ctx)
+		combined.Errors = append(combined.Errors, serverResult.Errors...)
+		combined.Warnings = append(combined.Warnings, serverResult.Warnings...)
+		if !serverResult.Valid {
+			combined.Valid = false
+		}
+	}
+
+	return combined
+}
+
+// min returns the minimum of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Implements `implementation-plans/confluence-docs-contract-alignment.md` — the mmetl-side changes that bring the emitted Confluence bundle in line with the Mattermost Docs (Spaces/Pages) domain. No changes to `mattermost-plugin-docs` or `mattermost` core.

## What changed

- **§1 Single-space**: replaced the dead multi-space scaffolding with one `IntermediateSpace`; a multi-space export is now rejected with a clear error.
- **§2 v2 contract**: renamed the wiki vocabulary to Docs terms (`space`, `space_import_source_id`, `resolve_space_placeholders`), bumped to `version: 2`, and added a bundle-level **source namespace** (`organization_id` + `space_key`) carried once on the version line and mirrored in the manifest.
- **§3 Backing channel**: dropped the `channel` line, `--create-channel`, and `AutoCreateChannel`; `--channel` is now deprecated and ignored.
- **§4 Attachments**: parse `ATTACHMENT` content rows so `export.Attachments` is populated, `CONF_ATTACHMENT` tokens resolve to `CONF_FILE`, and pages carry their `attachments` array. *(On-disk file layout still needs a real attachment-bearing CSV export to confirm — see risk #1 in the plan.)*
- **§5 Bundle**: `--bundle <out.zip>` produces one self-contained archive (`import.jsonl` + `import-manifest.json` + `data/`); fixed the loose-file "Next steps" recipe so it never omits the JSONL.
- **§6 Validation**: 2 MiB body / 64 KiB props caps, TipTap `json.Valid` check with code-block fallback, emitted `update_at`, and an opt-in `--require-user-mapping`.
- **§7 Restrictions**: detect view-restricted pages and surface them (warning + `manifest.restricted_pages` + opt-in `--fail-on-restricted`). Not resolved into an ACL.
- **§8 Tests/docs**: new `export_test.go` (v2 schema, single-space guardrail, attachments, restrictions, `update_at` omission); regenerated CLI docs; added `docs/confluence-jsonl-contract.md`.

## Verification

- `go test ./...` passes; `go vet ./...` and `gofmt` clean.
- End-to-end CLI run on a crafted CSV export with `--bundle`: emits `version:2` + source namespace, one `space` line (no channel), pages with `space_import_source_id` + `update_at`, `resolve_space_placeholders`; `CONF_ATTACHMENT:diagram.png` → `CONF_FILE:300`; manifest carries the source namespace and `restricted_pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)