### PR TITLE
ci: auto-generate release notes on tagged releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
           path: build
       - name: publish-release
         run: |
-          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" *.tar.gz
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes *.tar.gz
         working-directory: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `--generate-notes` to the `gh release create` step in `cd.yml` so the release body — the "What's Changed" PR list and the "Full Changelog" link — is populated automatically on every tagged release.

Previously the workflow created releases with an empty body, and the changelog was filled in manually via the GitHub UI after each release. This makes the process reproduce the format of past releases (e.g. v0.4.1) without the manual step.

## Test plan

Verified the generated body via the read-only GitHub API for the upcoming `v0.5.0`:

```
gh api repos/mattermost/mmetl/releases/generate-notes \
  -f tag_name=v0.5.0 -f target_commitish=master -f previous_tag_name=v0.4.1 --jq .body
```

Output matches the existing release-notes format (What's Changed list + Full Changelog link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)