### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -27,7 +27,7 @@ jobs:
         run: make package
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build
           path: build
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: download-artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build
           path: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -80,7 +80,7 @@ jobs:
         run: make package
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build
           path: build


### PR DESCRIPTION
## Summary

The `v0.5.0` release run surfaced GitHub annotations warning that several actions still target the **deprecated Node 20 runtime** and are being force-migrated to Node 24 at runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

This bumps each flagged action to its latest release, which runs natively on Node 24. SHA-pinning + version-comment convention is preserved.

| Action | Before | After |
| --- | --- | --- |
| `actions/setup-go` | v6.0.0 | v7.0.0 |
| `actions/upload-artifact` | v5.0.0 | v7.0.1 |
| `actions/download-artifact` | v6.0.0 | v8.0.1 |

`actions/checkout` (v5.0.1) and `golangci/golangci-lint-action` (v9.0.0) were **not** flagged and are left unchanged.

Applied across both `ci.yml` and `cd.yml`.

## Test plan

- CI on this PR exercises the updated `setup-go` / `upload-artifact` in the `test`, `e2e`, and `build` jobs.
- The `download-artifact` bump (cd-only) will be exercised on the next tagged release; the release flow is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)